### PR TITLE
REALMC-7632: Add import and export methods to Realm client

### DIFF
--- a/internal/cli/app_data.go
+++ b/internal/cli/app_data.go
@@ -6,10 +6,8 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-)
 
-const (
-	appConfigJSON = "config.json"
+	"github.com/10gen/realm-cli/internal/cloud/realm"
 )
 
 var (
@@ -33,7 +31,7 @@ func resolveAppData(wd string) (AppData, error) {
 		return AppData{}, nil
 	}
 
-	path := filepath.Join(appDir, appConfigJSON)
+	path := filepath.Join(appDir, realm.FileAppConfig)
 
 	data, readErr := ioutil.ReadFile(path)
 	if readErr != nil {
@@ -60,7 +58,7 @@ func resolveAppDirectory(wd string) (string, bool, error) {
 	}
 
 	for i := 0; i < maxDirectoryContainSearchDepth; i++ {
-		path := filepath.Join(wd, appConfigJSON)
+		path := filepath.Join(wd, realm.FileAppConfig)
 		if _, err := os.Stat(path); err == nil {
 			return filepath.Dir(path), true, nil
 		}

--- a/internal/cli/app_data_test.go
+++ b/internal/cli/app_data_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/10gen/realm-cli/internal/cloud/realm"
 	"github.com/10gen/realm-cli/internal/utils/test/assert"
 )
 
@@ -78,7 +79,7 @@ func TestResolveAppData(t *testing.T) {
 
 		expectedErr := fmt.Errorf(
 			"failed to read app data at %s",
-			filepath.Join(emptyProjectRoot, appConfigJSON),
+			filepath.Join(emptyProjectRoot, realm.FileAppConfig),
 		)
 
 		_, err := resolveAppData(filepath.Join(emptyProjectRoot, "l1", "l2", "l3"))

--- a/internal/cloud/realm/auth_provider.go
+++ b/internal/cloud/realm/auth_provider.go
@@ -1,0 +1,21 @@
+package realm
+
+// AuthProvider is a Realm application auth provider
+type AuthProvider struct {
+	ID                 string                 `json:"id,omitempty"`
+	Name               string                 `json:"name"`
+	Type               string                 `json:"type"`
+	Config             map[string]interface{} `json:"config,omitempty"`
+	SecretConfig       map[string]interface{} `json:"secret_config,omitempty"`
+	Disabled           bool                   `json:"disabled"`
+	MetadataFields     []AuthMetdataField     `json:"metadata_fields,omitempty"`
+	DomainRestrictions []string               `json:"domain_restrictions,omitempty"`
+	RedirectURIs       []string               `json:"redirect_uris,omitempty"`
+}
+
+// AuthMetdataField is a metadata field used with Realm auth
+type AuthMetdataField struct {
+	Required  bool   `json:"required"`
+	Name      string `json:"name"`
+	FieldName string `json:"field_name,omitempty"`
+}

--- a/internal/cloud/realm/auth_test.go
+++ b/internal/cloud/realm/auth_test.go
@@ -50,8 +50,12 @@ func TestRealmAuthProfile(t *testing.T) {
 }
 
 func newAuthClient(t *testing.T) realm.Client {
+	t.Helper()
+
 	client := realm.NewClient(u.RealmServerURL())
+
 	session, err := client.Authenticate(u.CloudUsername(), u.CloudAPIKey())
 	assert.Nil(t, err)
+
 	return realm.NewAuthClient(u.RealmServerURL(), session)
 }

--- a/internal/cloud/realm/client.go
+++ b/internal/cloud/realm/client.go
@@ -1,6 +1,7 @@
 package realm
 
 import (
+	"archive/zip"
 	"bytes"
 	"encoding/json"
 	"net/http"
@@ -20,6 +21,9 @@ const (
 type Client interface {
 	AuthProfile() (AuthProfile, error)
 	Authenticate(publicAPIKey, privateAPIKey string) (Session, error)
+
+	Export(groupID, appID string, req ExportRequest) (string, *zip.Reader, error)
+	Import(groupID, appID string, req ImportRequest) error
 
 	CreateApp(groupID, name string, meta AppMeta) (App, error)
 	DeleteApp(groupID, appID string) error
@@ -56,7 +60,7 @@ func (c *client) doJSON(method, path string, payload interface{}, options api.Re
 		return nil, err
 	}
 	options.Body = bytes.NewReader(body)
-	options.ContentType = api.MediaTypeApplicationJSON
+	options.ContentType = api.MediaTypeJSON
 
 	return c.do(method, path, options)
 }

--- a/internal/cloud/realm/error.go
+++ b/internal/cloud/realm/error.go
@@ -16,8 +16,9 @@ func (se ServerError) Error() string {
 	return se.Message
 }
 
-// UnmarshalServerError attempts to unmarshal a server error from the *http.Response
-func UnmarshalServerError(res *http.Response) error {
+// unmarshalServerError attempts to read and unmarshal a server error
+// from the provided *http.Response
+func unmarshalServerError(res *http.Response) error {
 	buf := new(bytes.Buffer)
 	if _, err := buf.ReadFrom(res.Body); err != nil {
 		return err

--- a/internal/cloud/realm/error_test.go
+++ b/internal/cloud/realm/error_test.go
@@ -1,4 +1,4 @@
-package realm_test
+package realm
 
 import (
 	"io/ioutil"
@@ -6,37 +6,36 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/10gen/realm-cli/internal/cloud/realm"
 	"github.com/10gen/realm-cli/internal/utils/test/assert"
 )
 
 func TestServerError(t *testing.T) {
 	t.Run("Should unmarshal a non-json response successfully", func(t *testing.T) {
-		err := realm.UnmarshalServerError(&http.Response{
+		err := unmarshalServerError(&http.Response{
 			Body: ioutil.NopCloser(strings.NewReader("something bad happened")),
 		})
-		assert.Equal(t, realm.ServerError{Message: "something bad happened"}, err)
+		assert.Equal(t, ServerError{Message: "something bad happened"}, err)
 	})
 
 	t.Run("Should unmarshal an empty response with its status", func(t *testing.T) {
-		err := realm.UnmarshalServerError(&http.Response{
+		err := unmarshalServerError(&http.Response{
 			Status: "something bad happened",
 			Body:   ioutil.NopCloser(strings.NewReader("")),
 		})
-		assert.Equal(t, realm.ServerError{Message: "something bad happened"}, err)
+		assert.Equal(t, ServerError{Message: "something bad happened"}, err)
 	})
 
 	t.Run("Should unmarshal a server error payload without an error code successfully", func(t *testing.T) {
-		err := realm.UnmarshalServerError(&http.Response{
+		err := unmarshalServerError(&http.Response{
 			Body: ioutil.NopCloser(strings.NewReader(`{"error": "something bad happened"}`)),
 		})
-		assert.Equal(t, realm.ServerError{Message: "something bad happened"}, err)
+		assert.Equal(t, ServerError{Message: "something bad happened"}, err)
 	})
 
 	t.Run("Should unmarshal a server error payload with an error code successfully", func(t *testing.T) {
-		err := realm.UnmarshalServerError(&http.Response{
+		err := unmarshalServerError(&http.Response{
 			Body: ioutil.NopCloser(strings.NewReader(`{"error": "something bad happened","error_code": "AnErrorCode"}`)),
 		})
-		assert.Equal(t, realm.ServerError{Code: "AnErrorCode", Message: "something bad happened"}, err)
+		assert.Equal(t, ServerError{Code: "AnErrorCode", Message: "something bad happened"}, err)
 	})
 }

--- a/internal/cloud/realm/export.go
+++ b/internal/cloud/realm/export.go
@@ -1,0 +1,80 @@
+package realm
+
+import (
+	"archive/zip"
+	"bytes"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"mime"
+	"net/http"
+
+	"github.com/10gen/realm-cli/internal/utils/api"
+)
+
+const (
+	exportPathPattern = appPathPattern + "/export"
+
+	exportQueryForSourceControl = "source_control"
+	exportQueryIsTemplated      = "template"
+	exportQueryVersion          = "version"
+
+	mediaParamFilename = "filename"
+
+	trueVal = "true"
+)
+
+// ExportRequest is a Realm application export request
+type ExportRequest struct {
+	ConfigVersion AppConfigVersion
+	IsTemplated   bool
+}
+
+func (c *client) Export(groupID, appID string, req ExportRequest) (string, *zip.Reader, error) {
+	options := api.RequestOptions{
+		UseAuth: true,
+		Query: map[string]string{
+			exportQueryVersion:          DefaultAppConfigVersion.String(),
+			exportQueryForSourceControl: trueVal,
+		},
+	}
+
+	if req.ConfigVersion != AppConfigVersionNil {
+		options.Query[exportQueryVersion] = req.ConfigVersion.String()
+	}
+	if req.IsTemplated {
+		options.Query[exportQueryIsTemplated] = trueVal
+	}
+
+	res, resErr := c.do(http.MethodGet, fmt.Sprintf(exportPathPattern, groupID, appID), options)
+	if resErr != nil {
+		return "", nil, resErr
+	}
+	if res.StatusCode != http.StatusOK {
+		defer res.Body.Close()
+		return "", nil, unmarshalServerError(res)
+	}
+
+	_, mediaParams, mediaErr := mime.ParseMediaType(res.Header.Get(api.HeaderContentDisposition))
+	if mediaErr != nil {
+		return "", nil, mediaErr
+	}
+
+	filename := mediaParams[mediaParamFilename]
+	if filename == "" {
+		return "", nil, errors.New("export response is missing filename")
+	}
+
+	defer res.Body.Close()
+	body, bodyErr := ioutil.ReadAll(res.Body)
+	if bodyErr != nil {
+		return "", nil, bodyErr
+	}
+
+	zipPkg, zipErr := zip.NewReader(bytes.NewReader(body), int64(len(body)))
+	if zipErr != nil {
+		return "", nil, zipErr
+	}
+
+	return filename, zipPkg, nil
+}

--- a/internal/cloud/realm/import.go
+++ b/internal/cloud/realm/import.go
@@ -1,0 +1,48 @@
+package realm
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/10gen/realm-cli/internal/utils/api"
+)
+
+const (
+	importPathPattern = appPathPattern + "/import"
+
+	importQueryStrategy = "strategy"
+
+	importStrategyReplaceByName = "replace-by-name"
+)
+
+// ImportRequest is a Realm application import request
+type ImportRequest struct {
+	ConfigVersion AppConfigVersion `json:"config_version"`
+	AuthProviders []AuthProvider   `json:"auth_providers"`
+}
+
+func (c *client) Import(groupID, appID string, req ImportRequest) error {
+	if req.ConfigVersion == AppConfigVersionNil {
+		req.ConfigVersion = DefaultAppConfigVersion
+	}
+
+	res, resErr := c.doJSON(
+		http.MethodPost,
+		fmt.Sprintf(importPathPattern, groupID, appID),
+		req,
+		api.RequestOptions{
+			UseAuth: true,
+			Query: map[string]string{
+				importQueryStrategy: importStrategyReplaceByName,
+			},
+		},
+	)
+	if resErr != nil {
+		return resErr
+	}
+	if res.StatusCode != http.StatusNoContent {
+		defer res.Body.Close()
+		return unmarshalServerError(res)
+	}
+	return nil
+}

--- a/internal/cloud/realm/import_export_test.go
+++ b/internal/cloud/realm/import_export_test.go
@@ -1,0 +1,143 @@
+package realm_test
+
+import (
+	"archive/zip"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"regexp"
+	"testing"
+
+	"github.com/10gen/realm-cli/internal/cloud/realm"
+	u "github.com/10gen/realm-cli/internal/utils/test"
+	"github.com/10gen/realm-cli/internal/utils/test/assert"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func TestRealmImportExport(t *testing.T) {
+	u.SkipUnlessRealmServerRunning(t)
+
+	groupID := u.CloudGroupID()
+
+	t.Run("Should fail without an auth client", func(t *testing.T) {
+		client := realm.NewClient(u.RealmServerURL())
+
+		err := client.Import(groupID, primitive.NewObjectID().Hex(), realm.ImportRequest{})
+		assert.Equal(t, realm.ErrInvalidSession, err)
+	})
+
+	t.Run("With an active session", func(t *testing.T) {
+		client := newAuthClient(t)
+
+		app, appErr := client.CreateApp(groupID, "importexport-test", realm.AppMeta{})
+		assert.Nil(t, appErr)
+
+		resetPasswordURL := "http://localhost:8080/reset_password"
+		emailConfirmationURL := "http://localhost:8080/confirm_email"
+
+		t.Run("Should import an app with auth providers", func(t *testing.T) {
+			err := client.Import(groupID, app.ID, realm.ImportRequest{
+				AuthProviders: []realm.AuthProvider{
+					{Name: "api-key", Type: "api-key"},
+					{Name: "local-userpass", Type: "local-userpass", Config: map[string]interface{}{
+						"resetPasswordUrl":     resetPasswordURL,
+						"emailConfirmationUrl": emailConfirmationURL,
+					}},
+				},
+			})
+			assert.Nil(t, err)
+		})
+
+		t.Run("Should export the same app with the imported changes included", func(t *testing.T) {
+			filename, zipPkg, err := client.Export(groupID, app.ID, realm.ExportRequest{})
+			assert.Nil(t, err)
+
+			filenameMatch, matchErr := regexp.MatchString(fmt.Sprintf("%s_.*\\.zip", app.Name), filename)
+			assert.Nil(t, matchErr)
+			assert.True(t, filenameMatch, "expected exported filename to match '$appName_yyyymmddHHMMSS'")
+
+			exported := parseZipPkg(t, zipPkg)
+
+			t.Run("And the app config contents should be as expected", func(t *testing.T) {
+				appConfig, appConfigOK := exported[realm.FileAppConfig]
+				assert.True(t, appConfigOK, "expected exported app to have file: %s", realm.FileAppConfig)
+				assert.Equal(t, fmt.Sprintf(`{
+    "app_id": %q,
+    "config_version": %s,
+    "name": "importexport-test",
+    "location": "US-VA",
+    "deployment_model": "GLOBAL",
+    "security": {},
+    "custom_user_data_config": {
+        "enabled": false
+    },
+    "sync": {
+        "development_mode_enabled": false
+    }
+}
+`, app.ClientAppID, realm.DefaultAppConfigVersion), appConfig)
+			})
+
+			t.Run("And the auth provider contents should be as expected", func(t *testing.T) {
+				apiKeyConfigFilepath := realm.FileAuthProvider("api-key")
+				apiKeyConfigPayload, apiKeyConfigOK := exported[apiKeyConfigFilepath]
+				assert.True(t, apiKeyConfigOK, "expected exported app to have file: %s", apiKeyConfigFilepath)
+
+				var apiKeyConfig map[string]interface{}
+				assert.Nil(t, json.Unmarshal([]byte(apiKeyConfigPayload), &apiKeyConfig))
+				assert.Nilf(t, apiKeyConfig["id"], "expected api-key.json to not have an 'id' field")
+				assert.Equal(t, "api-key", apiKeyConfig["name"])
+				assert.Equal(t, "api-key", apiKeyConfig["type"])
+				assert.False(t, apiKeyConfig["disabled"], "expected api-key.json to have 'disabled' field set to false")
+
+				localUserpassConfigFilepath := realm.FileAuthProvider("local-userpass")
+				localUserpassConfigPayload, localUserpassOK := exported[localUserpassConfigFilepath]
+				assert.True(t, localUserpassOK, "expected exported app to have file: %s", localUserpassConfigFilepath)
+
+				var localUserpassConfig map[string]interface{}
+				assert.Nil(t, json.Unmarshal([]byte(localUserpassConfigPayload), &localUserpassConfig))
+				assert.Nilf(t, localUserpassConfig["id"], "expected local-userpass.json to not have an 'id' field")
+				assert.Equal(t, "local-userpass", localUserpassConfig["name"])
+				assert.Equal(t, "local-userpass", localUserpassConfig["type"])
+				assert.False(t, apiKeyConfig["disabled"], "expected local-userpass.json to have 'disabled' field set to false")
+
+				localUserpassConfigConfig, localUserpassConfigConfigOK := localUserpassConfig["config"].(map[string]interface{})
+				assert.True(t, localUserpassConfigConfigOK, "expected local-userpass.json to have 'config' field set to a nested map")
+				assert.Equal(t, resetPasswordURL, localUserpassConfigConfig["resetPasswordUrl"])
+				assert.Equal(t, emailConfirmationURL, localUserpassConfigConfig["emailConfirmationUrl"])
+			})
+
+			t.Run("And the graphql contents should be as expected", func(t *testing.T) {
+				graphQLConfig, graphQLConfigOK := exported[realm.FileGraphQLConfig]
+				assert.True(t, graphQLConfigOK, "expected exported app to have file: %s", realm.FileGraphQLConfig)
+				assert.Equal(t, `{
+    "use_natural_pluralization": true
+}
+`, graphQLConfig)
+			})
+		})
+	})
+}
+
+func parseZipPkg(t *testing.T, zipPkg *zip.Reader) map[string]string {
+	t.Helper()
+
+	out := make(map[string]string)
+	for _, file := range zipPkg.File {
+		out[file.Name] = parseZipFile(t, file)
+	}
+	return out
+}
+
+func parseZipFile(t *testing.T, file *zip.File) string {
+	t.Helper()
+
+	r, openErr := file.Open()
+	assert.Nil(t, openErr)
+
+	data, readErr := ioutil.ReadAll(r)
+	assert.Nil(t, readErr)
+
+	return string(data)
+}

--- a/internal/cloud/realm/realm.go
+++ b/internal/cloud/realm/realm.go
@@ -1,0 +1,41 @@
+package realm
+
+import (
+	"fmt"
+	"strconv"
+)
+
+var (
+	// DefaultAppConfigVersion is the default app config version
+	// TODO(REALMC-7653): switch this default version to AppConfigVersion20210101
+	DefaultAppConfigVersion = AppConfigVersion20200603
+)
+
+// AppConfigVersion is the Realm application config version for import/export
+type AppConfigVersion int
+
+func (v AppConfigVersion) String() string { return strconv.Itoa(int(v)) }
+
+// set of supported app config versions
+const (
+	AppConfigVersionNil      AppConfigVersion = 0
+	AppConfigVersion20210101 AppConfigVersion = 20210101
+	AppConfigVersion20200603 AppConfigVersion = 20200603
+	AppConfigVersion20180301 AppConfigVersion = 20180301
+)
+
+// set of app structure filepath parts
+const (
+	FileAppConfig = "config.json"
+
+	DirAuthProviders = "auth_providers"
+
+	DirGraphQL                = "graphql"
+	DirGraphQLCustomResolvers = DirGraphQL + "/custom_resolvers"
+	FileGraphQLConfig         = DirGraphQL + "/config.json"
+)
+
+// FileAuthProvider creates the auth provider config filepath
+func FileAuthProvider(name string) string {
+	return fmt.Sprintf("%s/%s.json", DirAuthProviders, name)
+}

--- a/internal/cloud/realm/user.go
+++ b/internal/cloud/realm/user.go
@@ -23,6 +23,47 @@ const (
 	usersQueryProviderTypes = "provider_types"
 )
 
+// UserState is a Realm application user state
+type UserState string
+
+// set of supported user state values
+const (
+	UserStateNil      UserState = ""
+	UserStateEnabled  UserState = "enabled"
+	UserStateDisabled UserState = "disabled"
+)
+
+// APIKey is a Realm application api key
+type APIKey struct {
+	ID       string `json:"_id"`
+	Name     string `json:"name"`
+	Disabled bool   `json:"disabled"`
+	Key      string `json:"key"`
+}
+
+// User is a Realm application user
+type User struct {
+	ID                     string                 `json:"_id"`
+	Identities             []UserIdentity         `json:"identities,omitempty"`
+	Type                   string                 `json:"type"`
+	Disabled               bool                   `json:"disabled"`
+	Data                   map[string]interface{} `json:"data,omitempty"`
+	CreationDate           int64                  `json:"creation_date"`
+	LastAuthenticationDate int64                  `json:"last_authentication_date"`
+}
+
+// UserIdentity is a Realm application user identity
+type UserIdentity struct {
+	UID          string                 `json:"id"`
+	ProviderType string                 `json:"provider_type"`
+	ProviderID   primitive.ObjectID     `json:"provider_id"`
+	ProviderData map[string]interface{} `json:"provider_data,omitempty"`
+}
+
+type createAPIKeyRequest struct {
+	Name string `json:"name"`
+}
+
 func (c *client) CreateAPIKey(groupID, appID, apiKeyName string) (APIKey, error) {
 	res, resErr := c.doJSON(
 		http.MethodPost,
@@ -33,18 +74,21 @@ func (c *client) CreateAPIKey(groupID, appID, apiKeyName string) (APIKey, error)
 	if resErr != nil {
 		return APIKey{}, resErr
 	}
+	defer res.Body.Close()
 	if res.StatusCode != http.StatusCreated {
-		return APIKey{}, UnmarshalServerError(res)
+		return APIKey{}, unmarshalServerError(res)
 	}
 
-	dec := json.NewDecoder(res.Body)
-	defer res.Body.Close()
-
 	var apiKey APIKey
-	if err := dec.Decode(&apiKey); err != nil {
+	if err := json.NewDecoder(res.Body).Decode(&apiKey); err != nil {
 		return APIKey{}, err
 	}
 	return apiKey, nil
+}
+
+type createUserRequest struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
 }
 
 func (c *client) CreateUser(groupID, appID, email, password string) (User, error) {
@@ -57,15 +101,13 @@ func (c *client) CreateUser(groupID, appID, email, password string) (User, error
 	if resErr != nil {
 		return User{}, resErr
 	}
+	defer res.Body.Close()
 	if res.StatusCode != http.StatusCreated {
-		return User{}, UnmarshalServerError(res)
+		return User{}, unmarshalServerError(res)
 	}
 
-	dec := json.NewDecoder(res.Body)
-	defer res.Body.Close()
-
 	var user User
-	if err := dec.Decode(&user); err != nil {
+	if err := json.NewDecoder(res.Body).Decode(&user); err != nil {
 		return User{}, err
 	}
 	return user, nil
@@ -81,7 +123,8 @@ func (c *client) DeleteUser(groupID, appID, userID string) error {
 		return resErr
 	}
 	if res.StatusCode != http.StatusNoContent {
-		return UnmarshalServerError(res)
+		defer res.Body.Close()
+		return unmarshalServerError(res)
 	}
 	return nil
 }
@@ -96,59 +139,28 @@ func (c *client) DisableUser(groupID, appID, userID string) error {
 		return resErr
 	}
 	if res.StatusCode != http.StatusNoContent {
-		return UnmarshalServerError(res)
+		defer res.Body.Close()
+		return unmarshalServerError(res)
 	}
 	return nil
+}
+
+// UserFilter represents the optional filter parameters available for lists of users
+type UserFilter struct {
+	IDs       []string
+	Pending   bool
+	Providers []string
+	State     UserState
 }
 
 func (c *client) FindUsers(groupID, appID string, filter UserFilter) ([]User, error) {
 	if filter.Pending {
 		return c.getPendingUsers(groupID, appID, filter.IDs)
 	}
-
 	if len(filter.IDs) == 0 {
 		return c.getUsers(groupID, appID, filter.State, filter.Providers)
 	}
-
-	users := make([]User, 0, len(filter.IDs))
-	for _, userID := range filter.IDs {
-		user, err := c.getUser(groupID, appID, userID)
-		if err != nil {
-			return nil, err
-		}
-
-		var include bool
-		switch filter.State {
-		case UserStateEnabled:
-			include = !user.Disabled
-		case UserStateDisabled:
-			include = user.Disabled
-		default:
-			include = true
-		}
-
-		if include {
-			users = append(users, user)
-		}
-	}
-
-	if len(filter.Providers) == 0 {
-		return users, nil
-	}
-
-	providers := make(map[string]struct{}, len(filter.Providers))
-	for _, provider := range filter.Providers {
-		providers[provider] = struct{}{}
-	}
-
-	filtered := make([]User, 0, len(users))
-	for _, user := range users {
-		if _, ok := providers[user.Type]; !ok {
-			continue
-		}
-		filtered = append(filtered, user)
-	}
-	return filtered, nil
+	return c.getUsersByIDs(groupID, appID, filter.IDs, filter.State, filter.Providers)
 }
 
 func (c *client) RevokeUserSessions(groupID, appID, userID string) error {
@@ -161,7 +173,8 @@ func (c *client) RevokeUserSessions(groupID, appID, userID string) error {
 		return resErr
 	}
 	if res.StatusCode != http.StatusNoContent {
-		return UnmarshalServerError(res)
+		defer res.Body.Close()
+		return unmarshalServerError(res)
 	}
 	return nil
 }
@@ -175,15 +188,13 @@ func (c *client) getPendingUsers(groupID, appID string, userIDs []string) ([]Use
 	if resErr != nil {
 		return nil, resErr
 	}
+	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return nil, UnmarshalServerError(res)
+		return nil, unmarshalServerError(res)
 	}
 
-	dec := json.NewDecoder(res.Body)
-	defer res.Body.Close()
-
 	var users []User
-	if err := dec.Decode(&users); err != nil {
+	if err := json.NewDecoder(res.Body).Decode(&users); err != nil {
 		return nil, err
 	}
 
@@ -215,15 +226,13 @@ func (c *client) getUser(groupID, appID, userID string) (User, error) {
 	if resErr != nil {
 		return User{}, resErr
 	}
+	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return User{}, UnmarshalServerError(res)
+		return User{}, unmarshalServerError(res)
 	}
 
-	dec := json.NewDecoder(res.Body)
-	defer res.Body.Close()
-
 	var user User
-	if err := dec.Decode(&user); err != nil {
+	if err := json.NewDecoder(res.Body).Decode(&user); err != nil {
 		return User{}, err
 	}
 	return user, nil
@@ -245,70 +254,63 @@ func (c *client) getUsers(groupID, appID string, userState UserState, providerTy
 	if resErr != nil {
 		return nil, resErr
 	}
+	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return nil, UnmarshalServerError(res)
+		return nil, unmarshalServerError(res)
 	}
 
-	dec := json.NewDecoder(res.Body)
-	defer res.Body.Close()
-
 	var users []User
-	if err := dec.Decode(&users); err != nil {
+	if err := json.NewDecoder(res.Body).Decode(&users); err != nil {
 		return nil, err
 	}
 	return users, nil
 }
 
-// APIKey is a Realm application api key
-type APIKey struct {
-	ID       string `json:"_id"`
-	Name     string `json:"name"`
-	Disabled bool   `json:"disabled"`
-	Key      string `json:"key"`
+func (c *client) getUsersByIDs(groupID, appID string, userIDs []string, userState UserState, providerTypes []string) ([]User, error) {
+	users := make([]User, 0, len(userIDs))
+	for _, userID := range userIDs {
+		user, err := c.getUser(groupID, appID, userID)
+		if err != nil {
+			return nil, err
+		}
+
+		if userMatchesState(user, userState) {
+			users = append(users, user)
+		}
+	}
+
+	if len(providerTypes) == 0 {
+		return users, nil
+	}
+
+	providers := make(map[string]struct{}, len(providerTypes))
+	for _, provider := range providerTypes {
+		providers[provider] = struct{}{}
+	}
+
+	filtered := make([]User, 0, len(users))
+	for _, user := range users {
+		var matchedProvider bool
+		for _, identity := range user.Identities {
+			if _, ok := providers[identity.ProviderType]; !ok {
+				continue
+			}
+			matchedProvider = true
+			break
+		}
+		if matchedProvider {
+			filtered = append(filtered, user)
+		}
+	}
+	return filtered, nil
 }
 
-// UserFilter represents the optional filter parameters available for lists of users
-type UserFilter struct {
-	IDs       []string
-	Pending   bool
-	Providers []string
-	State     UserState
-}
-
-// UserState is a Realm application user state
-type UserState string
-
-// set of supported user state values
-const (
-	UserStateNil      UserState = ""
-	UserStateEnabled  UserState = "enabled"
-	UserStateDisabled UserState = "disabled"
-)
-
-// User is a Realm application user
-type User struct {
-	ID                     string                 `json:"_id"`
-	Identities             []UserIdentity         `json:"identities,omitempty"`
-	Type                   string                 `json:"type"`
-	Disabled               bool                   `json:"disabled"`
-	Data                   map[string]interface{} `json:"data,omitempty"`
-	CreationDate           int64                  `json:"creation_date"`
-	LastAuthenticationDate int64                  `json:"last_authentication_date"`
-}
-
-// UserIdentity is a Realm application user identity
-type UserIdentity struct {
-	UID          string                 `json:"id"`
-	ProviderType string                 `json:"provider_type"`
-	ProviderID   primitive.ObjectID     `json:"provider_id"`
-	ProviderData map[string]interface{} `json:"provider_data,omitempty"`
-}
-
-type createAPIKeyRequest struct {
-	Name string `json:"name"`
-}
-
-type createUserRequest struct {
-	Email    string `json:"email"`
-	Password string `json:"password"`
+func userMatchesState(user User, userState UserState) bool {
+	if userState == UserStateEnabled {
+		return !user.Disabled
+	}
+	if userState == UserStateDisabled {
+		return user.Disabled
+	}
+	return true
 }

--- a/internal/cloud/realm/user_test.go
+++ b/internal/cloud/realm/user_test.go
@@ -6,27 +6,36 @@ import (
 	"github.com/10gen/realm-cli/internal/cloud/realm"
 	u "github.com/10gen/realm-cli/internal/utils/test"
 	"github.com/10gen/realm-cli/internal/utils/test/assert"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 func TestRealmUsers(t *testing.T) {
 	u.SkipUnlessRealmServerRunning(t)
 
-	client := newAuthClient(t)
-	groupID := u.CloudGroupID()
-
-	app, appErr := client.CreateApp(groupID, "users-test", realm.AppMeta{})
-	assert.Nil(t, appErr)
-
 	t.Run("Should fail without an auth client", func(t *testing.T) {
-		badClient := realm.NewClient(u.RealmServerURL())
+		client := realm.NewClient(u.RealmServerURL())
 
-		_, err := badClient.FindUsers(groupID, app.ID, realm.UserFilter{})
+		_, err := client.FindUsers(primitive.NewObjectID().Hex(), primitive.NewObjectID().Hex(), realm.UserFilter{})
 		assert.Equal(t, realm.ErrInvalidSession, err)
 	})
 
 	t.Run("With an active session ", func(t *testing.T) {
-		// need to enable local-userpass and api-key auth providers first
-		t.Skip("TODO(REALMC-7632): implement basic version of import to facilitate test setup")
+		client := newAuthClient(t)
+		groupID := u.CloudGroupID()
+
+		app, appErr := client.CreateApp(groupID, "users-test", realm.AppMeta{})
+		assert.Nil(t, appErr)
+
+		assert.Nil(t, client.Import(groupID, app.ID, realm.ImportRequest{
+			AuthProviders: []realm.AuthProvider{
+				{Name: "api-key", Type: "api-key"},
+				{Name: "local-userpass", Type: "local-userpass", Config: map[string]interface{}{
+					"resetPasswordUrl":     "http://localhost:8080/reset_password",
+					"emailConfirmationUrl": "http://localhost:8080/confirm_email",
+				}},
+			},
+		}))
 
 		t.Run("Should create users", func(t *testing.T) {
 			email1, createErr := client.CreateUser(groupID, app.ID, "one@domain.com", "password1")
@@ -41,9 +50,9 @@ func TestRealmUsers(t *testing.T) {
 			apiKey2, createErr := client.CreateAPIKey(groupID, app.ID, "two")
 			assert.Nil(t, createErr)
 
-			apiKeyIDs := map[string]struct{}{
-				apiKey1.ID: struct{}{},
-				apiKey2.ID: struct{}{},
+			apiKeyIDs := map[string]string{
+				apiKey1.ID: "",
+				apiKey2.ID: "",
 			}
 
 			t.Run("And find all types of users", func(t *testing.T) {
@@ -54,7 +63,8 @@ func TestRealmUsers(t *testing.T) {
 				apiKeyUsers := make([]realm.User, 0, 2)
 
 				for _, user := range users {
-					switch user.Type {
+					assert.Equalf(t, 1, len(user.Identities), "expected user to have only one identity")
+					switch user.Identities[0].ProviderType {
 					case "local-userpass":
 						emailUsers = append(emailUsers, user)
 					case "api-key":
@@ -67,11 +77,10 @@ func TestRealmUsers(t *testing.T) {
 
 				assert.Equal(t, 2, len(apiKeyUsers))
 				for _, user := range apiKeyUsers {
-					assert.Equalf(t, 1, len(user.Identities), "expected api key user to have one identity")
-
 					identity := user.Identities[0]
 					_, ok := apiKeyIDs[identity.UID]
 					assert.True(t, ok, "expected %s to match a previously created api key id", identity.UID)
+					apiKeyIDs[identity.UID] = user.ID
 				}
 			})
 
@@ -95,13 +104,16 @@ func TestRealmUsers(t *testing.T) {
 			t.Run("And find all disabled users", func(t *testing.T) {
 				users, err := client.FindUsers(groupID, app.ID, realm.UserFilter{State: realm.UserStateDisabled})
 				assert.Nil(t, err)
+
+				email1.Disabled = true
+				email3.Disabled = true
+
 				assert.Equal(t, []realm.User{email1, email3}, users)
 			})
 
 			t.Run("And find specific user using all filter options", func(t *testing.T) {
-				// target email3
 				filter := realm.UserFilter{
-					IDs:       []string{email2.ID, email3.ID, apiKey1.ID},
+					IDs:       []string{email2.ID, email3.ID, apiKeyIDs[apiKey1.ID]},
 					State:     realm.UserStateDisabled,
 					Providers: []string{"local-userpass"},
 				}
@@ -110,14 +122,14 @@ func TestRealmUsers(t *testing.T) {
 				assert.Equal(t, []realm.User{email3}, users)
 			})
 
-			t.Run("And delete users", func(t *testing.T) {
-				for _, userID := range []string{email1.ID, email2.ID, email3.ID, apiKey1.ID, apiKey2.ID} {
-					assert.Nilf(t, client.DeleteUser(groupID, app.ID, userID), "failed to successfully delete user: %s", userID)
-				}
-			})
-
 			t.Run("And revoking a user session should succeed", func(t *testing.T) {
 				assert.Nil(t, client.RevokeUserSessions(groupID, app.ID, email1.ID))
+			})
+
+			t.Run("And delete users", func(t *testing.T) {
+				for _, userID := range []string{email1.ID, email2.ID, email3.ID, apiKeyIDs[apiKey1.ID], apiKeyIDs[apiKey2.ID]} {
+					assert.Nilf(t, client.DeleteUser(groupID, app.ID, userID), "failed to successfully delete user: %s", userID)
+				}
 			})
 		})
 

--- a/internal/utils/api/api.go
+++ b/internal/utils/api/api.go
@@ -6,13 +6,15 @@ import (
 
 // set of supported api header keys
 const (
-	HeaderContentType   = "Content-Type"
-	HeaderAuthorization = "Authorization"
+	HeaderAccept             = "Accept"
+	HeaderContentDisposition = "Content-Disposition"
+	HeaderContentType        = "Content-Type"
+	HeaderAuthorization      = "Authorization"
 )
 
 // set of supported api media types
 const (
-	MediaTypeApplicationJSON = "application/json"
+	MediaTypeJSON = "application/json"
 )
 
 // RequestOptions are options to configure an *http.Request


### PR DESCRIPTION
The purpose of these import/export implementations was primarily to support testing the other Realm client actions (instead of implementing a "CreateAuthProvider" function, which the CLI's client doesn't actually need, tests should leverage importing an app with the necessary auth providers included).

Some functionality for import/export is intentionally left out here, and should/will be filled in respectively once the push and pull command tickets are picked up.

This work does however enable to use fully test the Realm client `User` methods.

**Open to ideas on naming/organization here:** Does the `realm` package make sense for all the import/export related stuff: filepath-ing, config versions, payload structs that don't necessarily line up with the API response structure, etc?