### PR TITLE
 REALMC-8182: Remove lifecycle interfaces from command implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ TODO
 
 ## Linting
 
-TODO
+To lint the project, run:
+
+```cmd
+golangci-lint run
+```
 
 ## Testing
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -4,12 +4,14 @@ import (
 	"strings"
 )
 
-// SessionManager is an auth session manager
-type SessionManager interface {
+// Service is an auth service
+type Service interface {
 	ClearSession()
 	Save() error
 	Session() Session
 	SetSession(session Session)
+	User() User
+	SetUser(user User)
 }
 
 // Session is the CLI profile session

--- a/internal/cli/command.go
+++ b/internal/cli/command.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"github.com/10gen/realm-cli/internal/cloud/atlas"
+	"github.com/10gen/realm-cli/internal/cloud/realm"
 	"github.com/10gen/realm-cli/internal/terminal"
 
 	"github.com/spf13/pflag"
@@ -15,15 +17,20 @@ import (
 //   2. CommandInputs.Resolve: use this hook to prompt for any flags not provided
 //   3. CommandPreparer.Setup: use this hook to use setup the command (e.g. create clients/services)
 //   4. Command.Handler: this is the command hook
-//   5. CommandResponder.Feedback: use this hook to print feedback to the user after the command has executed
 // At any point should an error occur, command execution will terminate
 // and the ensuing steps will not be run
 type Command interface {
-	Handler(profile *Profile, ui terminal.UI) error
+	Handler(profile *Profile, ui terminal.UI, clients Clients) error
 }
 
-// CommandFlagger is a hook for commands to register local flags to be parsed
-type CommandFlagger interface {
+// Clients are the CLI clients
+type Clients struct {
+	Realm realm.Client
+	Atlas atlas.Client
+}
+
+// CommandFlags provides access for commands to register local flags
+type CommandFlags interface {
 	Flags(fs *pflag.FlagSet)
 }
 
@@ -32,21 +39,9 @@ type CommandInputs interface {
 	Inputs() InputResolver
 }
 
-// InputResolver is an input resolver
+// InputResolver provides access for command inputs to resolve missing data
 type InputResolver interface {
 	Resolve(profile *Profile, ui terminal.UI) error
-}
-
-// CommandPreparer handles the command setup phase
-// This interface maps 1:1 to Cobra's Command.PreRunE phase
-type CommandPreparer interface {
-	Setup(profile *Profile, ui terminal.UI) error
-}
-
-// CommandResponder handles the command feedback phase
-// This interface maps 1:1 to Cobra's Command.PostRun phase
-type CommandResponder interface {
-	Feedback(profile *Profile, ui terminal.UI) error
 }
 
 // CommandDefinition is a command's definition that the CommandFactory

--- a/internal/cli/profile.go
+++ b/internal/cli/profile.go
@@ -5,8 +5,6 @@ import (
 	"os"
 
 	"github.com/10gen/realm-cli/internal/auth"
-	"github.com/10gen/realm-cli/internal/cloud/atlas"
-	"github.com/10gen/realm-cli/internal/cloud/realm"
 	"github.com/10gen/realm-cli/internal/telemetry"
 
 	"github.com/spf13/afero"
@@ -230,24 +228,4 @@ func (p Profile) AtlasBaseURL() string {
 // SetAtlasBaseURL sets the CLI profile Atlas base url
 func (p Profile) SetAtlasBaseURL(realmBaseURL string) {
 	p.SetString(keyAtlasBaseURL, realmBaseURL)
-}
-
-// RealmClient creates an unauthenticated Realm client
-func (p Profile) RealmClient() realm.Client {
-	return realm.NewClient(p.RealmBaseURL())
-}
-
-// RealmAuthClient creates an authenticated Realm client
-func (p *Profile) RealmAuthClient() realm.Client {
-	return realm.NewAuthClient(p.RealmBaseURL(), p)
-}
-
-// AtlasClient creates an unauthenticated Atlas client
-func (p Profile) AtlasClient() atlas.Client {
-	return atlas.NewClient(p.AtlasBaseURL())
-}
-
-// AtlasAuthClient creates an authenticated Atlas client
-func (p Profile) AtlasAuthClient() atlas.Client {
-	return atlas.NewAuthClient(p.AtlasBaseURL(), p.User())
 }

--- a/internal/cloud/realm/auth.go
+++ b/internal/cloud/realm/auth.go
@@ -73,8 +73,8 @@ func (c *client) AuthProfile() (AuthProfile, error) {
 	return profile, nil
 }
 
-func (c *client) getAuth(options api.RequestOptions) (string, error) {
-	session := c.sessionManager.Session()
+func (c *client) getAuthToken(options api.RequestOptions) (string, error) {
+	session := c.authService.Session()
 
 	if !options.NoAuth {
 		if session.AccessToken == "" {
@@ -112,11 +112,11 @@ func (c *client) refreshAuth() error {
 		return err
 	}
 
-	session := c.sessionManager.Session()
+	session := c.authService.Session()
 	session.AccessToken = s.AccessToken
-	c.sessionManager.SetSession(session)
+	c.authService.SetSession(session)
 
-	return c.sessionManager.Save()
+	return c.authService.Save()
 }
 
 // AllGroupIDs returns all group ids associated with the user's profile

--- a/internal/commands/app/init.go
+++ b/internal/commands/app/init.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"github.com/10gen/realm-cli/internal/cli"
-	"github.com/10gen/realm-cli/internal/cloud/atlas"
 	"github.com/10gen/realm-cli/internal/cloud/realm"
 	"github.com/10gen/realm-cli/internal/local"
 	"github.com/10gen/realm-cli/internal/terminal"
@@ -12,9 +11,7 @@ import (
 
 // CommandInit is the `app init` command
 type CommandInit struct {
-	inputs      initInputs
-	atlasClient atlas.Client
-	realmClient realm.Client
+	inputs initInputs
 }
 
 // Flags is the command flags
@@ -31,51 +28,50 @@ func (cmd *CommandInit) Inputs() cli.InputResolver {
 	return &cmd.inputs
 }
 
-// Setup is the command setup
-func (cmd *CommandInit) Setup(profile *cli.Profile, ui terminal.UI) error {
-	cmd.atlasClient = profile.AtlasAuthClient()
-	cmd.realmClient = profile.RealmAuthClient()
-	return nil
-}
-
 // Handler is the command handler
-func (cmd *CommandInit) Handler(profile *cli.Profile, ui terminal.UI) error {
-	from, fromErr := cmd.inputs.resolveFrom(ui, cmd.realmClient)
-	if fromErr != nil {
-		return fromErr
+func (cmd *CommandInit) Handler(profile *cli.Profile, ui terminal.UI, clients cli.Clients) error {
+	from, err := cmd.inputs.resolveFrom(ui, clients.Realm)
+	if err != nil {
+		return err
 	}
 
 	if from.IsZero() {
-		/*
-			TODO(REALMC-7886): initialize also the following:
-			  - auth/custom_user_data.json: { "enabled": false }
-			  - auth/providers.json: {}
-			  - data_sources/
-			  - http_endpoints/
-			  - sync/config.json: { "development_mode_enabled": false }
-
-			this logic probably wants to live in local.App, where ConfigVersion actually determines what gets written/initialized
-		*/
-		return local.NewApp(
-			profile.WorkingDirectory,
-			cmd.inputs.Name,
-			cmd.inputs.Location,
-			cmd.inputs.DeploymentModel,
-		).WriteConfig()
+		if err := cmd.writeAppFromScratch(profile.WorkingDirectory); err != nil {
+			return err
+		}
+	} else {
+		if err := cmd.writeAppFromExisting(profile.WorkingDirectory, clients.Realm, from.GroupID, from.AppID); err != nil {
+			return err
+		}
 	}
 
-	_, zipPkg, exportErr := cmd.realmClient.Export(
-		from.GroupID,
-		from.AppID,
-		realm.ExportRequest{IsTemplated: true},
-	)
-	if exportErr != nil {
-		return exportErr
-	}
-	return local.WriteZip(profile.WorkingDirectory, zipPkg)
+	ui.Print(terminal.NewTextLog("Successfully initialized app"))
+	return nil
 }
 
-// Feedback is the command feedback
-func (cmd *CommandInit) Feedback(profile *cli.Profile, ui terminal.UI) error {
-	return ui.Print(terminal.NewTextLog("Successfully initialized app"))
+func (cmd *CommandInit) writeAppFromScratch(wd string) error {
+	/*
+		TODO(REALMC-7886): initialize also the following:
+			- auth/custom_user_data.json: { "enabled": false }
+			- auth/providers.json: {}
+			- data_sources/
+			- http_endpoints/
+			- sync/config.json: { "development_mode_enabled": false }
+
+		this logic probably wants to live in local.App, where ConfigVersion actually determines what gets written/initialized
+	*/
+	return local.NewApp(wd,
+		cmd.inputs.Name,
+		cmd.inputs.Location,
+		cmd.inputs.DeploymentModel,
+	).WriteConfig()
+}
+
+func (cmd *CommandInit) writeAppFromExisting(wd string, realmClient realm.Client, groupID, appID string) error {
+	_, zipPkg, err := realmClient.Export(groupID, appID, realm.ExportRequest{IsTemplated: true})
+	if err != nil {
+		return err
+	}
+
+	return local.WriteZip(wd, zipPkg)
 }

--- a/internal/commands/app/init_test.go
+++ b/internal/commands/app/init_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/10gen/realm-cli/internal/cli"
 	"github.com/10gen/realm-cli/internal/cloud/realm"
 	"github.com/10gen/realm-cli/internal/local"
 	"github.com/10gen/realm-cli/internal/utils/test/assert"
@@ -15,37 +16,26 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
-func TestAppInitSetup(t *testing.T) {
-	t.Run("should construct a Realm client with the configured base url", func(t *testing.T) {
-		profile := mock.NewProfile(t)
-		profile.SetRealmBaseURL("http://localhost:8080")
-
-		cmd := &CommandInit{inputs: initInputs{newAppInputs{
-			Name: "test-app",
-		}}}
-		assert.Nil(t, cmd.realmClient)
-
-		assert.Nil(t, cmd.Setup(profile, nil))
-		assert.NotNil(t, cmd.realmClient)
-	})
-}
-
 func TestAppInitHandler(t *testing.T) {
 	t.Run("should initialize an empty project when no from type is specified", func(t *testing.T) {
 		profile, teardown := mock.NewProfileFromTmpDir(t, "app_init_test")
 		defer teardown()
 
-		cmd := &CommandInit{inputs: initInputs{newAppInputs{
+		out, ui := mock.NewUI()
+
+		cmd := &CommandInit{initInputs{newAppInputs{
 			Name:            "test-app",
 			Project:         "test-project",
 			DeploymentModel: realm.DeploymentModelLocal,
 			Location:        realm.LocationSydney,
 		}}}
 
-		assert.Nil(t, cmd.Handler(profile, nil))
+		assert.Nil(t, cmd.Handler(profile, ui, cli.Clients{}))
 
 		data, readErr := ioutil.ReadFile(filepath.Join(profile.WorkingDirectory, local.FileRealmConfig.String()))
 		assert.Nil(t, readErr)
+
+		assert.Equal(t, "01:23:45 UTC INFO  Successfully initialized app\n", out.String())
 
 		var config local.AppRealmConfigJSON
 		assert.Nil(t, json.Unmarshal(data, &config))
@@ -60,6 +50,8 @@ func TestAppInitHandler(t *testing.T) {
 	t.Run("should initialze a templated app when from type is specified to app", func(t *testing.T) {
 		profile, teardown := mock.NewProfileFromTmpDir(t, "app_init_test")
 		defer teardown()
+
+		out, ui := mock.NewUI()
 
 		app := realm.App{
 			ID:          primitive.NewObjectID().Hex(),
@@ -82,12 +74,11 @@ func TestAppInitHandler(t *testing.T) {
 			return "", &zipPkg.Reader, err
 		}
 
-		cmd := &CommandInit{
-			inputs:      initInputs{newAppInputs{From: "test"}},
-			realmClient: client,
-		}
+		cmd := &CommandInit{initInputs{newAppInputs{From: "test"}}}
 
-		assert.Nil(t, cmd.Handler(profile, nil))
+		assert.Nil(t, cmd.Handler(profile, ui, cli.Clients{Realm: client}))
+
+		assert.Equal(t, "01:23:45 UTC INFO  Successfully initialized app\n", out.String())
 
 		t.Run("should have the expected contents in the app config file", func(t *testing.T) {
 			data, readErr := ioutil.ReadFile(filepath.Join(profile.WorkingDirectory, local.FileRealmConfig.String()))
@@ -141,18 +132,5 @@ func TestAppInitHandler(t *testing.T) {
 		// should have an empty http_endpoints directory
 		// should have an empty data_sources directory
 		// should have an empty services directory
-	})
-}
-
-func TestAppInitFeedback(t *testing.T) {
-	t.Run("feedback should print a message that app initialization was successful", func(t *testing.T) {
-		out, ui := mock.NewUI()
-
-		cmd := &CommandInit{}
-
-		err := cmd.Feedback(nil, ui)
-		assert.Nil(t, err)
-
-		assert.Equal(t, "01:23:45 UTC INFO  Successfully initialized app\n", out.String())
 	})
 }

--- a/internal/commands/logout/command.go
+++ b/internal/commands/logout/command.go
@@ -9,17 +9,17 @@ import (
 type Command struct{}
 
 // Handler is the command handler
-func (cmd *Command) Handler(profile *cli.Profile, ui terminal.UI) error {
+func (cmd *Command) Handler(profile *cli.Profile, ui terminal.UI, clients cli.Clients) error {
 	user := profile.User()
 	user.PrivateAPIKey = "" // ensures subsequent `login` commands prompt for password
 
 	profile.SetUser(user)
 	profile.ClearSession()
 
-	return profile.Save()
-}
+	if err := profile.Save(); err != nil {
+		return err
+	}
 
-// Feedback is the command feedback
-func (cmd *Command) Feedback(profile *cli.Profile, ui terminal.UI) error {
-	return ui.Print(terminal.NewTextLog("Successfully logged out"))
+	ui.Print(terminal.NewTextLog("Successfully logged out"))
+	return nil
 }

--- a/internal/commands/logout/command_test.go
+++ b/internal/commands/logout/command_test.go
@@ -7,13 +7,14 @@ import (
 	"testing"
 
 	"github.com/10gen/realm-cli/internal/auth"
+	"github.com/10gen/realm-cli/internal/cli"
 	u "github.com/10gen/realm-cli/internal/utils/test"
 	"github.com/10gen/realm-cli/internal/utils/test/assert"
 	"github.com/10gen/realm-cli/internal/utils/test/mock"
 )
 
 func TestLogoutHandler(t *testing.T) {
-	t.Run("Handler should clear user and session and save the config", func(t *testing.T) {
+	t.Run("should clear user and session and save the config", func(t *testing.T) {
 		tmpDir, teardownTmpDir, tmpDirErr := u.NewTempDir("home")
 		assert.Nil(t, tmpDirErr)
 		defer teardownTmpDir()
@@ -45,7 +46,7 @@ func TestLogoutHandler(t *testing.T) {
 
 		cmd := &Command{}
 
-		assert.Nil(t, cmd.Handler(profile, ui))
+		assert.Nil(t, cmd.Handler(profile, ui, cli.Clients{}))
 
 		assert.Equal(t, auth.User{PublicAPIKey: "username"}, profile.User())
 		assert.Equal(t, auth.Session{}, profile.Session())
@@ -62,13 +63,14 @@ func TestLogoutHandler(t *testing.T) {
 }
 
 func TestLogoutFeedback(t *testing.T) {
-	t.Run("Feedback should print a message that logout was successful", func(t *testing.T) {
+	t.Run("should print a message that logout was successful", func(t *testing.T) {
+		profile := mock.NewProfile(t)
+
 		out, ui := mock.NewUI()
 
 		cmd := &Command{}
 
-		err := cmd.Feedback(nil, ui)
-		assert.Nil(t, err)
+		assert.Nil(t, cmd.Handler(profile, ui, cli.Clients{}))
 
 		assert.Equal(t, "01:23:45 UTC INFO  Successfully logged out\n", out.String())
 	})

--- a/internal/commands/secrets/delete_inputs_test.go
+++ b/internal/commands/secrets/delete_inputs_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/10gen/realm-cli/internal/utils/test/mock"
 )
 
-func TestResolveDeleteInputs(t *testing.T) {
+func TestSecretsDeleteInputsResolve(t *testing.T) {
 	testLen := 7
 	secrets := make([]realm.Secret, testLen)
 	for i := 0; i < testLen; i++ {

--- a/internal/commands/secrets/list_test.go
+++ b/internal/commands/secrets/list_test.go
@@ -11,19 +11,6 @@ import (
 	"github.com/10gen/realm-cli/internal/utils/test/mock"
 )
 
-func TestSecretsListSetup(t *testing.T) {
-	t.Run("Should construct a Realm client with the configured base url", func(t *testing.T) {
-		profile := mock.NewProfile(t)
-		profile.SetRealmBaseURL("http://localhost:8080")
-
-		cmd := &CommandList{inputs: listInputs{}}
-		assert.Nil(t, cmd.realmClient)
-
-		assert.Nil(t, cmd.Setup(profile, nil))
-		assert.NotNil(t, cmd.realmClient)
-	})
-}
-
 func TestSecretsListHandler(t *testing.T) {
 	projectID := "projectID"
 	appID := "appID"
@@ -36,42 +23,67 @@ func TestSecretsListHandler(t *testing.T) {
 	testSecrets := []realm.Secret{
 		{ID: "secret1", Name: "test1"},
 		{ID: "secret2", Name: "test2"},
-		{ID: "secret3", Name: "duplicate"},
-		{ID: "secret4", Name: "duplicate"},
+		{ID: "secret3", Name: "dup"},
+		{ID: "secret4", Name: "dup"},
 	}
 
-	t.Run("Should find app secrets", func(t *testing.T) {
-		realmClient := mock.RealmClient{}
-		realmClient.FindAppsFn = func(filter realm.AppFilter) ([]realm.App, error) {
-			return []realm.App{app}, nil
-		}
-
-		realmClient.SecretsFn = func(groupID, appID string) ([]realm.Secret, error) {
-			return testSecrets, nil
-		}
-
-		cmd := &CommandList{
-			inputs: listInputs{
-				ProjectInputs: cli.ProjectInputs{
-					Project: projectID,
-					App:     appID,
+	for _, tc := range []struct {
+		description    string
+		secrets        []realm.Secret
+		expectedOutput string
+	}{
+		{
+			description:    "should list no secrets with no app secrets found",
+			expectedOutput: "01:23:45 UTC INFO  No available secrets to show\n",
+		},
+		{
+			description: "should list the secrets found for the app",
+			secrets:     testSecrets,
+			expectedOutput: strings.Join(
+				[]string{
+					"01:23:45 UTC INFO  Found 4 secrets",
+					"  ID       Name ",
+					"  -------  -----",
+					"  secret1  test1",
+					"  secret2  test2",
+					"  secret3  dup  ",
+					"  secret4  dup  ",
+					"",
 				},
-			},
-			realmClient: realmClient,
-		}
+				"\n",
+			),
+		},
+	} {
+		t.Run(tc.description, func(t *testing.T) {
+			out, ui := mock.NewUI()
 
-		assert.Nil(t, cmd.Handler(nil, nil))
-		assert.Equal(t, testSecrets, cmd.secrets)
-	})
+			realmClient := mock.RealmClient{}
+			realmClient.FindAppsFn = func(filter realm.AppFilter) ([]realm.App, error) {
+				return []realm.App{app}, nil
+			}
 
-	t.Run("Should return an error", func(t *testing.T) {
+			realmClient.SecretsFn = func(groupID, appID string) ([]realm.Secret, error) {
+				return tc.secrets, nil
+			}
+
+			cmd := &CommandList{listInputs{cli.ProjectInputs{
+				Project: projectID,
+				App:     appID,
+			}}}
+
+			assert.Nil(t, cmd.Handler(nil, ui, cli.Clients{Realm: realmClient}))
+			assert.Equal(t, tc.expectedOutput, out.String())
+		})
+	}
+
+	t.Run("should return an error", func(t *testing.T) {
 		for _, tc := range []struct {
 			description string
 			setupClient func() realm.Client
 			expectedErr error
 		}{
 			{
-				description: "When resolving the app fails",
+				description: "when resolving the app fails",
 				setupClient: func() realm.Client {
 					realmClient := mock.RealmClient{}
 					realmClient.FindAppsFn = func(filter realm.AppFilter) ([]realm.App, error) {
@@ -82,7 +94,7 @@ func TestSecretsListHandler(t *testing.T) {
 				expectedErr: errors.New("something bad happened"),
 			},
 			{
-				description: "When finding the secrets fails",
+				description: "when finding the secrets fails",
 				setupClient: func() realm.Client {
 					realmClient := mock.RealmClient{}
 					realmClient.FindAppsFn = func(filter realm.AppFilter) ([]realm.App, error) {
@@ -99,60 +111,11 @@ func TestSecretsListHandler(t *testing.T) {
 			t.Run(tc.description, func(t *testing.T) {
 				realmClient := tc.setupClient()
 
-				cmd := &CommandList{
-					realmClient: realmClient,
-				}
+				cmd := &CommandList{}
 
-				err := cmd.Handler(nil, nil)
+				err := cmd.Handler(nil, nil, cli.Clients{Realm: realmClient})
 				assert.Equal(t, tc.expectedErr, err)
 			})
 		}
 	})
-}
-
-func TestSecretsListFeedback(t *testing.T) {
-	testSecrets := []realm.Secret{
-		{ID: "60066e14734d0b6c336ffc23", Name: "test1"},
-		{ID: "234566e14734d0b6c336ffc2", Name: "test2"},
-		{ID: "60066e14564d0b6c336ffc23", Name: "dup"},
-		{ID: "60066e14734d0b6c886ffc23", Name: "dup"},
-	}
-
-	for _, tc := range []struct {
-		description    string
-		secrets        []realm.Secret
-		expectedOutput string
-	}{
-		{
-			description:    "Should indicate no secrets found when none are found",
-			secrets:        []realm.Secret{},
-			expectedOutput: "01:23:45 UTC INFO  No available secrets to show\n",
-		},
-		{
-			description: "Should display all found secrets",
-			secrets:     testSecrets,
-			expectedOutput: strings.Join(
-				[]string{
-					"01:23:45 UTC INFO  Found 4 secrets",
-					"  ID                        Name ",
-					"  ------------------------  -----",
-					"  60066e14734d0b6c336ffc23  test1",
-					"  234566e14734d0b6c336ffc2  test2",
-					"  60066e14564d0b6c336ffc23  dup  ",
-					"  60066e14734d0b6c886ffc23  dup  ",
-					"",
-				},
-				"\n",
-			),
-		},
-	} {
-		t.Run(tc.description, func(t *testing.T) {
-			out, ui := mock.NewUI()
-			cmd := &CommandList{
-				secrets: tc.secrets,
-			}
-			assert.Nil(t, cmd.Feedback(nil, ui))
-			assert.Equal(t, tc.expectedOutput, out.String())
-		})
-	}
 }

--- a/internal/commands/secrets/output.go
+++ b/internal/commands/secrets/output.go
@@ -21,12 +21,6 @@ type secretOutput struct {
 
 type secretTableRowModifier func(secretOutput, map[string]interface{})
 
-func secretOutputComparerBySuccess(outputs secretOutputs) func(i, j int) bool {
-	return func(i, j int) bool {
-		return outputs[i].err != nil && outputs[j].err == nil
-	}
-}
-
 func secretHeaders(additionalHeaders ...string) []string {
 	return append([]string{headerID, headerName}, additionalHeaders...)
 }

--- a/internal/commands/secrets/update_inputs_test.go
+++ b/internal/commands/secrets/update_inputs_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/10gen/realm-cli/internal/utils/test/mock"
 )
 
-func TestResolveSecret(t *testing.T) {
+func TestSecretInputResolve(t *testing.T) {
 	testLen := 7
 	secrets := make([]realm.Secret, testLen)
 

--- a/internal/commands/user/delete_test.go
+++ b/internal/commands/user/delete_test.go
@@ -11,17 +11,29 @@ import (
 	"github.com/10gen/realm-cli/internal/utils/test/mock"
 )
 
-func TestUserDeleteSetup(t *testing.T) {
-	t.Run("should construct a realm client with the configured base url", func(t *testing.T) {
-		profile := mock.NewProfile(t)
-		profile.SetRealmBaseURL("http://localhost:8080")
-		cmd := &CommandDelete{inputs: deleteInputs{}}
-
-		assert.Nil(t, cmd.realmClient)
-		assert.Nil(t, cmd.Setup(profile, nil))
-		assert.NotNil(t, cmd.realmClient)
-	})
-}
+var (
+	testUsers = []realm.User{
+		{
+			ID:         "user-1",
+			Type:       "type-1",
+			Identities: []realm.UserIdentity{{ProviderType: realm.AuthProviderTypeAnonymous}},
+		},
+		{
+			ID:         "user-2",
+			Identities: []realm.UserIdentity{{ProviderType: realm.AuthProviderTypeUserPassword}},
+			Data:       map[string]interface{}{"email": "user-2@test.com"},
+		},
+		{
+			ID:         "user-3",
+			Identities: []realm.UserIdentity{{ProviderType: realm.AuthProviderTypeAPIKey}},
+			Data:       map[string]interface{}{"name": "name-3"},
+		},
+		{
+			ID:         "user-4",
+			Identities: []realm.UserIdentity{{ProviderType: realm.AuthProviderTypeCustomToken}},
+		},
+	}
+)
 
 func TestUserDeleteHandler(t *testing.T) {
 	projectID := "projectID"
@@ -32,29 +44,106 @@ func TestUserDeleteHandler(t *testing.T) {
 		ClientAppID: "eggcorn-abcde",
 		Name:        "eggcorn",
 	}
-	testUsers := []realm.User{
-		{
-			ID:         "user-1",
-			Identities: []realm.UserIdentity{{ProviderType: realm.AuthProviderTypeAnonymous}},
-		},
-	}
+
+	t.Run("should display empty state message no users are found to delete", func(t *testing.T) {
+		out, ui := mock.NewUI()
+
+		realmClient := mock.RealmClient{}
+		realmClient.FindAppsFn = func(filter realm.AppFilter) ([]realm.App, error) {
+			return []realm.App{app}, nil
+		}
+		realmClient.FindUsersFn = func(groupID, appID string, filter realm.UserFilter) ([]realm.User, error) {
+			return nil, nil
+		}
+		realmClient.DeleteUserFn = func(groupID, appID, userID string) error {
+			return nil
+		}
+
+		cmd := &CommandDelete{deleteInputs{ProjectInputs: cli.ProjectInputs{
+			Project: projectID,
+			App:     appID,
+		}}}
+
+		assert.Nil(t, cmd.Handler(nil, ui, cli.Clients{Realm: realmClient}))
+		assert.Equal(t, "01:23:45 UTC INFO  No users to delete\n", out.String())
+	})
+
+	t.Run("should display users deleted by auth provider type", func(t *testing.T) {
+		out, ui := mock.NewUI()
+
+		realmClient := mock.RealmClient{}
+		realmClient.FindAppsFn = func(filter realm.AppFilter) ([]realm.App, error) {
+			return []realm.App{app}, nil
+		}
+		realmClient.FindUsersFn = func(groupID, appID string, filter realm.UserFilter) ([]realm.User, error) {
+			return testUsers, nil
+		}
+		realmClient.DeleteUserFn = func(groupID, appID, userID string) error {
+			return nil
+		}
+
+		cmd := &CommandDelete{deleteInputs{
+			ProjectInputs: cli.ProjectInputs{
+				Project: projectID,
+				App:     appID,
+			},
+			multiUserInputs: multiUserInputs{
+				Users: []string{testUsers[0].ID},
+			},
+		}}
+
+		assert.Nil(t, cmd.Handler(nil, ui, cli.Clients{Realm: realmClient}))
+		assert.Equal(t, strings.Join([]string{
+			"01:23:45 UTC INFO  Provider type: User/Password",
+			"  Email            ID      Type  Deleted  Details",
+			"  ---------------  ------  ----  -------  -------",
+			"  user-2@test.com  user-2        true            ",
+			"01:23:45 UTC INFO  Provider type: ApiKey",
+			"  Name    ID      Type  Deleted  Details",
+			"  ------  ------  ----  -------  -------",
+			"  name-3  user-3        true            ",
+			"01:23:45 UTC INFO  Provider type: Anonymous",
+			"  ID      Type    Deleted  Details",
+			"  ------  ------  -------  -------",
+			"  user-1  type-1  true            ",
+			"01:23:45 UTC INFO  Provider type: Custom JWT",
+			"  ID      Type  Deleted  Details",
+			"  ------  ----  -------  -------",
+			"  user-4        true            ",
+			"",
+		}, "\n"), out.String())
+	})
 
 	for _, tc := range []struct {
-		description     string
-		userDeleteErr   error
-		expectedOutputs userOutputs
+		description    string
+		deleteErr      error
+		expectedOutput string
 	}{
 		{
-			description:     "should delete a user when a user id is provided",
-			expectedOutputs: userOutputs{{testUsers[0], nil}},
+			description: "should delete a user when a user id is provided",
+			expectedOutput: strings.Join([]string{
+				"01:23:45 UTC INFO  Provider type: Anonymous",
+				"  ID      Type    Deleted  Details",
+				"  ------  ------  -------  -------",
+				"  user-1  type-1  true            ",
+				"",
+			}, "\n"),
 		},
 		{
-			description:     "should save failed deletion errors",
-			userDeleteErr:   errors.New("client error"),
-			expectedOutputs: userOutputs{{testUsers[0], errors.New("client error")}},
+			description: "should save failed deletion errors",
+			deleteErr:   errors.New("client error"),
+			expectedOutput: strings.Join([]string{
+				"01:23:45 UTC INFO  Provider type: Anonymous",
+				"  ID      Type    Deleted  Details     ",
+				"  ------  ------  -------  ------------",
+				"  user-1  type-1  false    client error",
+				"",
+			}, "\n"),
 		},
 	} {
 		t.Run(tc.description, func(t *testing.T) {
+			out, ui := mock.NewUI()
+
 			realmClient := mock.RealmClient{}
 
 			var capturedAppFilter realm.AppFilter
@@ -67,33 +156,28 @@ func TestUserDeleteHandler(t *testing.T) {
 			realmClient.FindUsersFn = func(groupID, appID string, filter realm.UserFilter) ([]realm.User, error) {
 				capturedFindProjectID = groupID
 				capturedFindAppID = appID
-				return testUsers, nil
+				return testUsers[:1], nil
 			}
 
 			var capturedDeleteProjectID, capturedDeleteAppID string
 			realmClient.DeleteUserFn = func(groupID, appID, userID string) error {
 				capturedDeleteProjectID = groupID
 				capturedDeleteAppID = appID
-				return tc.userDeleteErr
+				return tc.deleteErr
 			}
 
-			cmd := &CommandDelete{
-				inputs: deleteInputs{
-					ProjectInputs: cli.ProjectInputs{
-						Project: projectID,
-						App:     appID,
-					},
-					multiUserInputs: multiUserInputs{
-						Users: []string{testUsers[0].ID},
-					},
+			cmd := &CommandDelete{deleteInputs{
+				ProjectInputs: cli.ProjectInputs{
+					Project: projectID,
+					App:     appID,
 				},
-				realmClient: realmClient,
-			}
+				multiUserInputs: multiUserInputs{
+					Users: []string{testUsers[0].ID},
+				},
+			}}
 
-			assert.Nil(t, cmd.Handler(nil, nil))
-
-			assert.Equal(t, cmd.outputs[0].user, tc.expectedOutputs[0].user)
-			assert.Equal(t, cmd.outputs[0].err, tc.expectedOutputs[0].err)
+			assert.Nil(t, cmd.Handler(nil, ui, cli.Clients{Realm: realmClient}))
+			assert.Equal(t, tc.expectedOutput, out.String())
 
 			assert.Equal(t, realm.AppFilter{App: appID, GroupID: projectID}, capturedAppFilter)
 			assert.Equal(t, projectID, capturedFindProjectID)
@@ -136,115 +220,13 @@ func TestUserDeleteHandler(t *testing.T) {
 			},
 		} {
 			t.Run(tc.description, func(t *testing.T) {
-				realmClient := tc.setupClient()
+				cmd := &CommandDelete{}
 
-				cmd := &CommandDelete{
-					realmClient: realmClient,
-				}
-
-				err := cmd.Handler(nil, nil)
+				err := cmd.Handler(nil, nil, cli.Clients{Realm: tc.setupClient()})
 				assert.Equal(t, tc.expectedErr, err)
 			})
 		}
 	})
-}
-
-func TestUserDeleteFeedback(t *testing.T) {
-	testUsers := []realm.User{
-		{
-			ID:         "user-1",
-			Identities: []realm.UserIdentity{{ProviderType: realm.AuthProviderTypeUserPassword}},
-			Type:       "type-1",
-			Data:       map[string]interface{}{"email": "user-1@test.com"},
-		},
-		{
-			ID:         "user-2",
-			Identities: []realm.UserIdentity{{ProviderType: realm.AuthProviderTypeUserPassword}},
-			Type:       "type-2",
-			Data:       map[string]interface{}{"email": "user-2@test.com"},
-		},
-		{
-			ID:         "user-3",
-			Identities: []realm.UserIdentity{{ProviderType: realm.AuthProviderTypeUserPassword}},
-			Type:       "type-1",
-			Data:       map[string]interface{}{"email": "user-3@test.com"},
-		},
-		{
-			ID:         "user-4",
-			Identities: []realm.UserIdentity{{ProviderType: realm.AuthProviderTypeAPIKey}},
-			Type:       "type-1",
-			Data:       map[string]interface{}{"name": "name-4"},
-		},
-		{
-			ID:         "user-5",
-			Identities: []realm.UserIdentity{{ProviderType: realm.AuthProviderTypeCustomToken}},
-			Type:       "type-3",
-		},
-	}
-	for _, tc := range []struct {
-		description    string
-		outputs        userOutputs
-		expectedOutput string
-	}{
-		{
-			description:    "should show no users to delete",
-			expectedOutput: "01:23:45 UTC INFO  No users to delete\n",
-		},
-		{
-			description: "should show 1 failed user",
-			outputs:     userOutputs{{testUsers[0], errors.New("client error")}},
-			expectedOutput: strings.Join(
-				[]string{
-					"01:23:45 UTC INFO  Provider type: User/Password",
-					"  Email            ID      Type    Deleted  Details     ",
-					"  ---------------  ------  ------  -------  ------------",
-					"  user-1@test.com  user-1  type-1  false    client error",
-					"",
-				},
-				"\n",
-			),
-		},
-		{
-			description: "should show 2 failed users",
-			outputs: userOutputs{
-				{testUsers[0], nil},
-				{testUsers[1], errors.New("client error")},
-				{testUsers[2], nil},
-				{testUsers[3], errors.New("client error")},
-				{testUsers[4], nil},
-			},
-			expectedOutput: strings.Join(
-				[]string{
-					"01:23:45 UTC INFO  Provider type: User/Password",
-					"  Email            ID      Type    Deleted  Details     ",
-					"  ---------------  ------  ------  -------  ------------",
-					"  user-2@test.com  user-2  type-2  false    client error",
-					"  user-1@test.com  user-1  type-1  true                 ",
-					"  user-3@test.com  user-3  type-1  true                 ",
-					"01:23:45 UTC INFO  Provider type: ApiKey",
-					"  Name    ID      Type    Deleted  Details     ",
-					"  ------  ------  ------  -------  ------------",
-					"  name-4  user-4  type-1  false    client error",
-					"01:23:45 UTC INFO  Provider type: Custom JWT",
-					"  ID      Type    Deleted  Details",
-					"  ------  ------  -------  -------",
-					"  user-5  type-3  true            ",
-					"",
-				},
-				"\n",
-			),
-		},
-	} {
-		t.Run(tc.description, func(t *testing.T) {
-			out, ui := mock.NewUI()
-			cmd := &CommandDelete{
-				outputs: tc.outputs,
-			}
-
-			assert.Nil(t, cmd.Feedback(nil, ui))
-			assert.Equal(t, tc.expectedOutput, out.String())
-		})
-	}
 }
 
 func TestUserDeleteRow(t *testing.T) {

--- a/internal/commands/user/disable.go
+++ b/internal/commands/user/disable.go
@@ -13,14 +13,7 @@ import (
 
 // CommandDisable is the `user disable` command
 type CommandDisable struct {
-	inputs      disableInputs
-	outputs     userOutputs
-	realmClient realm.Client
-}
-
-type disableInputs struct {
-	cli.ProjectInputs
-	multiUserInputs
+	inputs disableInputs
 }
 
 // Flags is the command flags
@@ -34,20 +27,14 @@ func (cmd *CommandDisable) Inputs() cli.InputResolver {
 	return &cmd.inputs
 }
 
-// Setup is the command setup
-func (cmd *CommandDisable) Setup(profile *cli.Profile, ui terminal.UI) error {
-	cmd.realmClient = profile.RealmAuthClient()
-	return nil
-}
-
 // Handler is the command handler
-func (cmd *CommandDisable) Handler(profile *cli.Profile, ui terminal.UI) error {
-	app, err := cli.ResolveApp(ui, cmd.realmClient, cmd.inputs.Filter())
+func (cmd *CommandDisable) Handler(profile *cli.Profile, ui terminal.UI, clients cli.Clients) error {
+	app, err := cli.ResolveApp(ui, clients.Realm, cmd.inputs.Filter())
 	if err != nil {
 		return err
 	}
 
-	found, err := cmd.inputs.findUsers(cmd.realmClient, app.GroupID, app.ID)
+	found, err := cmd.inputs.findUsers(clients.Realm, app.GroupID, app.ID)
 	if err != nil {
 		return err
 	}
@@ -57,33 +44,41 @@ func (cmd *CommandDisable) Handler(profile *cli.Profile, ui terminal.UI) error {
 		return err
 	}
 
+	outputs := make(userOutputs, 0, len(users))
 	for _, user := range users {
-		err := cmd.realmClient.DisableUser(app.GroupID, app.ID, user.ID)
-		cmd.outputs = append(cmd.outputs, userOutput{user, err})
+		err := clients.Realm.DisableUser(app.GroupID, app.ID, user.ID)
+		outputs = append(outputs, userOutput{user, err})
 	}
+
+	if len(outputs) == 0 {
+		ui.Print(terminal.NewTextLog("No users to disable"))
+		return nil
+	}
+
+	outputsByProviderType := outputs.byProviderType()
+
+	logs := make([]terminal.Log, 0, len(outputsByProviderType))
+	for _, providerType := range realm.ValidAuthProviderTypes {
+		o := outputsByProviderType[providerType]
+		if len(o) == 0 {
+			continue
+		}
+
+		sort.SliceStable(o, getUserOutputComparerBySuccess(o))
+
+		logs = append(logs, terminal.NewTableLog(
+			fmt.Sprintf("Provider type: %s", providerType.Display()),
+			append(userTableHeaders(providerType), headerEnabled, headerDetails),
+			userTableRows(providerType, o, userDisableRow)...,
+		))
+	}
+	ui.Print(logs...)
 	return nil
 }
 
-// Feedback is the command feedback
-func (cmd *CommandDisable) Feedback(profile *cli.Profile, ui terminal.UI) error {
-	if len(cmd.outputs) == 0 {
-		return ui.Print(terminal.NewTextLog("No users to disable"))
-	}
-	outputsByProviderType := cmd.outputs.mapByProviderType()
-	logs := make([]terminal.Log, 0, len(outputsByProviderType))
-	for _, apt := range realm.ValidAuthProviderTypes {
-		outputs := outputsByProviderType[apt]
-		if len(outputs) == 0 {
-			continue
-		}
-		sort.SliceStable(outputs, getUserOutputComparerBySuccess(outputs))
-		logs = append(logs, terminal.NewTableLog(
-			fmt.Sprintf("Provider type: %s", apt.Display()),
-			append(userTableHeaders(apt), headerEnabled, headerDetails),
-			userTableRows(apt, outputs, userDisableRow)...,
-		))
-	}
-	return ui.Print(logs...)
+type disableInputs struct {
+	cli.ProjectInputs
+	multiUserInputs
 }
 
 func (i *disableInputs) Resolve(profile *cli.Profile, ui terminal.UI) error {

--- a/internal/commands/user/disable_test.go
+++ b/internal/commands/user/disable_test.go
@@ -11,18 +11,6 @@ import (
 	"github.com/10gen/realm-cli/internal/utils/test/mock"
 )
 
-func TestUserDisableSetup(t *testing.T) {
-	t.Run("should construct a realm client with the configured base url", func(t *testing.T) {
-		profile := mock.NewProfile(t)
-		profile.SetRealmBaseURL("http://localhost:8080")
-		cmd := &CommandDisable{inputs: disableInputs{}}
-
-		assert.Nil(t, cmd.realmClient)
-		assert.Nil(t, cmd.Setup(profile, nil))
-		assert.NotNil(t, cmd.realmClient)
-	})
-}
-
 func TestUserDisableHandler(t *testing.T) {
 	projectID := "projectID"
 	appID := "appID"
@@ -32,26 +20,106 @@ func TestUserDisableHandler(t *testing.T) {
 		ClientAppID: "eggcorn-abcde",
 		Name:        "eggcorn",
 	}
-	testUsers := []realm.User{
-		{
-			ID:         "user-1",
-			Identities: []realm.UserIdentity{{ProviderType: realm.AuthProviderTypeAnonymous}},
-		},
-		{
-			ID:         "user-2",
-			Identities: []realm.UserIdentity{{ProviderType: realm.AuthProviderTypeAnonymous}},
-			Disabled:   true,
-		},
-	}
+
+	t.Run("should display empty state message no users are found to disable", func(t *testing.T) {
+		out, ui := mock.NewUI()
+
+		realmClient := mock.RealmClient{}
+		realmClient.FindAppsFn = func(filter realm.AppFilter) ([]realm.App, error) {
+			return []realm.App{app}, nil
+		}
+		realmClient.FindUsersFn = func(groupID, appID string, filter realm.UserFilter) ([]realm.User, error) {
+			return nil, nil
+		}
+		realmClient.DisableUserFn = func(groupID, appID, userID string) error {
+			return nil
+		}
+
+		cmd := &CommandDisable{disableInputs{ProjectInputs: cli.ProjectInputs{
+			Project: projectID,
+			App:     appID,
+		}}}
+
+		assert.Nil(t, cmd.Handler(nil, ui, cli.Clients{Realm: realmClient}))
+		assert.Equal(t, "01:23:45 UTC INFO  No users to disable\n", out.String())
+	})
+
+	t.Run("should display users disabled by auth provider type", func(t *testing.T) {
+		out, ui := mock.NewUI()
+
+		realmClient := mock.RealmClient{}
+		realmClient.FindAppsFn = func(filter realm.AppFilter) ([]realm.App, error) {
+			return []realm.App{app}, nil
+		}
+		realmClient.FindUsersFn = func(groupID, appID string, filter realm.UserFilter) ([]realm.User, error) {
+			return testUsers, nil
+		}
+		realmClient.DisableUserFn = func(groupID, appID, userID string) error {
+			return nil
+		}
+
+		cmd := &CommandDisable{disableInputs{
+			ProjectInputs: cli.ProjectInputs{
+				Project: projectID,
+				App:     appID,
+			},
+			multiUserInputs: multiUserInputs{
+				Users: []string{testUsers[0].ID},
+			},
+		}}
+
+		assert.Nil(t, cmd.Handler(nil, ui, cli.Clients{Realm: realmClient}))
+		assert.Equal(t, strings.Join([]string{
+			"01:23:45 UTC INFO  Provider type: User/Password",
+			"  Email            ID      Type  Enabled  Details",
+			"  ---------------  ------  ----  -------  -------",
+			"  user-2@test.com  user-2        false           ",
+			"01:23:45 UTC INFO  Provider type: ApiKey",
+			"  Name    ID      Type  Enabled  Details",
+			"  ------  ------  ----  -------  -------",
+			"  name-3  user-3        false           ",
+			"01:23:45 UTC INFO  Provider type: Anonymous",
+			"  ID      Type    Enabled  Details",
+			"  ------  ------  -------  -------",
+			"  user-1  type-1  false           ",
+			"01:23:45 UTC INFO  Provider type: Custom JWT",
+			"  ID      Type  Enabled  Details",
+			"  ------  ----  -------  -------",
+			"  user-4        false           ",
+			"",
+		}, "\n"), out.String())
+	})
 
 	for _, tc := range []struct {
 		description    string
-		disableUserErr error
+		expectedOutput string
+		disableErr     error
 	}{
-		{"should disable a user when a user id is provided", nil},
-		{"should save failed disable errors", errors.New("client error")},
+		{
+			description: "should disable a user when a user id is provided",
+			expectedOutput: strings.Join([]string{
+				"01:23:45 UTC INFO  Provider type: Anonymous",
+				"  ID      Type    Enabled  Details",
+				"  ------  ------  -------  -------",
+				"  user-1  type-1  false           ",
+				"",
+			}, "\n"),
+		},
+		{
+			description: "should save failed disable errors",
+			disableErr:  errors.New("client error"),
+			expectedOutput: strings.Join([]string{
+				"01:23:45 UTC INFO  Provider type: Anonymous",
+				"  ID      Type    Enabled  Details     ",
+				"  ------  ------  -------  ------------",
+				"  user-1  type-1  true     client error",
+				"",
+			}, "\n"),
+		},
 	} {
 		t.Run(tc.description, func(t *testing.T) {
+			out, ui := mock.NewUI()
+
 			realmClient := mock.RealmClient{}
 
 			var capturedAppFilter realm.AppFilter
@@ -71,27 +139,23 @@ func TestUserDisableHandler(t *testing.T) {
 			realmClient.DisableUserFn = func(groupID, appID, userID string) error {
 				capturedDisableProjectID = groupID
 				capturedDisableAppID = appID
-				return tc.disableUserErr
+				return tc.disableErr
 			}
 
-			cmd := &CommandDisable{
-				inputs: disableInputs{
-					ProjectInputs: cli.ProjectInputs{
-						Project: projectID,
-						App:     appID,
-					},
-					multiUserInputs: multiUserInputs{
-						Users: []string{testUsers[0].ID},
-					},
+			cmd := &CommandDisable{disableInputs{
+				ProjectInputs: cli.ProjectInputs{
+					Project: projectID,
+					App:     appID,
 				},
-				realmClient: realmClient,
-			}
+				multiUserInputs: multiUserInputs{
+					Users: []string{testUsers[0].ID},
+				},
+			}}
 
-			assert.Nil(t, cmd.Handler(nil, nil))
+			assert.Nil(t, cmd.Handler(nil, ui, cli.Clients{Realm: realmClient}))
 
 			assert.Equal(t, testUsers[0].ID, cmd.inputs.Users[0])
-			assert.Equal(t, testUsers[0], cmd.outputs[0].user)
-			assert.Equal(t, tc.disableUserErr, cmd.outputs[0].err)
+			assert.Equal(t, tc.expectedOutput, out.String())
 
 			assert.Equal(t, realm.AppFilter{App: appID, GroupID: projectID}, capturedAppFilter)
 			assert.Equal(t, projectID, capturedFindProjectID)
@@ -134,112 +198,13 @@ func TestUserDisableHandler(t *testing.T) {
 			},
 		} {
 			t.Run(tc.description, func(t *testing.T) {
-				realmClient := tc.setupClient()
-				cmd := &CommandDisable{
-					realmClient: realmClient,
-				}
-				err := cmd.Handler(nil, nil)
+				cmd := &CommandDisable{}
 
+				err := cmd.Handler(nil, nil, cli.Clients{Realm: tc.setupClient()})
 				assert.Equal(t, tc.expectedErr, err)
 			})
 		}
 	})
-}
-
-func TestUserDisableFeedback(t *testing.T) {
-	testUsers := []realm.User{
-		{
-			ID:         "user-1",
-			Identities: []realm.UserIdentity{{ProviderType: realm.AuthProviderTypeUserPassword}},
-			Type:       "type-1",
-			Data:       map[string]interface{}{"email": "user-1@test.com"},
-		},
-		{
-			ID:         "user-2",
-			Identities: []realm.UserIdentity{{ProviderType: realm.AuthProviderTypeUserPassword}},
-			Type:       "type-2",
-			Data:       map[string]interface{}{"email": "user-2@test.com"},
-		},
-		{
-			ID:         "user-3",
-			Identities: []realm.UserIdentity{{ProviderType: realm.AuthProviderTypeUserPassword}},
-			Type:       "type-1",
-			Data:       map[string]interface{}{"email": "user-3@test.com"},
-		},
-		{
-			ID:         "user-4",
-			Identities: []realm.UserIdentity{{ProviderType: realm.AuthProviderTypeAPIKey}},
-			Type:       "type-1",
-			Data:       map[string]interface{}{"name": "name-4"},
-		},
-		{
-			ID:         "user-5",
-			Identities: []realm.UserIdentity{{ProviderType: realm.AuthProviderTypeCustomToken}},
-			Type:       "type-3",
-		},
-	}
-	for _, tc := range []struct {
-		description     string
-		outputs         userOutputs
-		expectedContent string
-	}{
-		{
-			description:     "should show no users to disable",
-			expectedContent: "01:23:45 UTC INFO  No users to disable\n",
-		},
-		{
-			description: "should show 1 failed user",
-			outputs:     userOutputs{{testUsers[0], errors.New("client error")}},
-			expectedContent: strings.Join(
-				[]string{
-					"01:23:45 UTC INFO  Provider type: User/Password",
-					"  Email            ID      Type    Enabled  Details     ",
-					"  ---------------  ------  ------  -------  ------------",
-					"  user-1@test.com  user-1  type-1  true     client error",
-					"",
-				},
-				"\n",
-			),
-		},
-		{
-			description: "should show failures to disable 2 users amongst successful results across different auth provider types",
-			outputs: userOutputs{
-				{testUsers[0], nil},
-				{testUsers[1], errors.New("client error")},
-				{testUsers[2], nil},
-				{testUsers[3], errors.New("client error")},
-				{testUsers[4], nil},
-			},
-			expectedContent: strings.Join(
-				[]string{
-					"01:23:45 UTC INFO  Provider type: User/Password",
-					"  Email            ID      Type    Enabled  Details     ",
-					"  ---------------  ------  ------  -------  ------------",
-					"  user-2@test.com  user-2  type-2  true     client error",
-					"  user-1@test.com  user-1  type-1  false                ",
-					"  user-3@test.com  user-3  type-1  false                ",
-					"01:23:45 UTC INFO  Provider type: ApiKey",
-					"  Name    ID      Type    Enabled  Details     ",
-					"  ------  ------  ------  -------  ------------",
-					"  name-4  user-4  type-1  true     client error",
-					"01:23:45 UTC INFO  Provider type: Custom JWT",
-					"  ID      Type    Enabled  Details",
-					"  ------  ------  -------  -------",
-					"  user-5  type-3  false           ",
-					"",
-				},
-				"\n",
-			),
-		},
-	} {
-		t.Run(tc.description, func(t *testing.T) {
-			out, ui := mock.NewUI()
-			cmd := &CommandDisable{outputs: tc.outputs}
-
-			assert.Nil(t, cmd.Feedback(nil, ui))
-			assert.Equal(t, tc.expectedContent, out.String())
-		})
-	}
 }
 
 func TestUserDisableRow(t *testing.T) {

--- a/internal/commands/user/enable.go
+++ b/internal/commands/user/enable.go
@@ -13,9 +13,7 @@ import (
 
 // CommandEnable is the `user enable` command
 type CommandEnable struct {
-	inputs      enableInputs
-	outputs     userOutputs
-	realmClient realm.Client
+	inputs enableInputs
 }
 
 type enableInputs struct {
@@ -34,20 +32,14 @@ func (cmd *CommandEnable) Inputs() cli.InputResolver {
 	return &cmd.inputs
 }
 
-// Setup is the command setup
-func (cmd *CommandEnable) Setup(profile *cli.Profile, ui terminal.UI) error {
-	cmd.realmClient = profile.RealmAuthClient()
-	return nil
-}
-
 // Handler is the command handler
-func (cmd *CommandEnable) Handler(profile *cli.Profile, ui terminal.UI) error {
-	app, err := cli.ResolveApp(ui, cmd.realmClient, cmd.inputs.Filter())
+func (cmd *CommandEnable) Handler(profile *cli.Profile, ui terminal.UI, clients cli.Clients) error {
+	app, err := cli.ResolveApp(ui, clients.Realm, cmd.inputs.Filter())
 	if err != nil {
 		return err
 	}
 
-	found, err := cmd.inputs.findUsers(cmd.realmClient, app.GroupID, app.ID)
+	found, err := cmd.inputs.findUsers(clients.Realm, app.GroupID, app.ID)
 	if err != nil {
 		return err
 	}
@@ -57,33 +49,36 @@ func (cmd *CommandEnable) Handler(profile *cli.Profile, ui terminal.UI) error {
 		return err
 	}
 
+	outputs := make(userOutputs, 0, len(users))
 	for _, user := range users {
-		err := cmd.realmClient.EnableUser(app.GroupID, app.ID, user.ID)
-		cmd.outputs = append(cmd.outputs, userOutput{user, err})
+		err := clients.Realm.EnableUser(app.GroupID, app.ID, user.ID)
+		outputs = append(outputs, userOutput{user, err})
 	}
-	return nil
-}
 
-// Feedback is the command feedback
-func (cmd *CommandEnable) Feedback(profile *cli.Profile, ui terminal.UI) error {
-	if len(cmd.outputs) == 0 {
-		return ui.Print(terminal.NewTextLog("No users to enable"))
+	if len(outputs) == 0 {
+		ui.Print(terminal.NewTextLog("No users to enable"))
+		return nil
 	}
-	outputsByProviderType := cmd.outputs.mapByProviderType()
+
+	outputsByProviderType := outputs.byProviderType()
+
 	logs := make([]terminal.Log, 0, len(outputsByProviderType))
-	for _, apt := range realm.ValidAuthProviderTypes {
-		outputs := outputsByProviderType[apt]
-		if len(outputs) == 0 {
+	for _, providerType := range realm.ValidAuthProviderTypes {
+		o := outputsByProviderType[providerType]
+		if len(o) == 0 {
 			continue
 		}
-		sort.SliceStable(outputs, getUserOutputComparerBySuccess(outputs))
+
+		sort.SliceStable(o, getUserOutputComparerBySuccess(o))
+
 		logs = append(logs, terminal.NewTableLog(
-			fmt.Sprintf("Provider type: %s", apt.Display()),
-			append(userTableHeaders(apt), headerEnabled, headerDetails),
-			userTableRows(apt, outputs, userEnableRow)...,
+			fmt.Sprintf("Provider type: %s", providerType.Display()),
+			append(userTableHeaders(providerType), headerEnabled, headerDetails),
+			userTableRows(providerType, o, userEnableRow)...,
 		))
 	}
-	return ui.Print(logs...)
+	ui.Print(logs...)
+	return nil
 }
 
 func (i *enableInputs) Resolve(profile *cli.Profile, ui terminal.UI) error {

--- a/internal/commands/user/enable_test.go
+++ b/internal/commands/user/enable_test.go
@@ -11,18 +11,6 @@ import (
 	"github.com/10gen/realm-cli/internal/utils/test/mock"
 )
 
-func TestUserEnableSetup(t *testing.T) {
-	t.Run("should construct a realm client with the configured base url", func(t *testing.T) {
-		profile := mock.NewProfile(t)
-		profile.SetRealmBaseURL("http://localhost:8080")
-		cmd := &CommandEnable{inputs: enableInputs{}}
-
-		assert.Nil(t, cmd.realmClient)
-		assert.Nil(t, cmd.Setup(profile, nil))
-		assert.NotNil(t, cmd.realmClient)
-	})
-}
-
 func TestUserEnableHandler(t *testing.T) {
 	projectID := "projectID"
 	appID := "appID"
@@ -32,26 +20,106 @@ func TestUserEnableHandler(t *testing.T) {
 		ClientAppID: "eggcorn-abcde",
 		Name:        "eggcorn",
 	}
-	testUsers := []realm.User{
-		{
-			ID:         "user-1",
-			Identities: []realm.UserIdentity{{ProviderType: realm.AuthProviderTypeAnonymous}},
-			Disabled:   true,
-		},
-		{
-			ID:         "user-2",
-			Identities: []realm.UserIdentity{{ProviderType: realm.AuthProviderTypeAnonymous}},
-		},
-	}
+
+	t.Run("should display empty state message no users are found to enable", func(t *testing.T) {
+		out, ui := mock.NewUI()
+
+		realmClient := mock.RealmClient{}
+		realmClient.FindAppsFn = func(filter realm.AppFilter) ([]realm.App, error) {
+			return []realm.App{app}, nil
+		}
+		realmClient.FindUsersFn = func(groupID, appID string, filter realm.UserFilter) ([]realm.User, error) {
+			return nil, nil
+		}
+		realmClient.DeleteUserFn = func(groupID, appID, userID string) error {
+			return nil
+		}
+
+		cmd := &CommandEnable{enableInputs{ProjectInputs: cli.ProjectInputs{
+			Project: projectID,
+			App:     appID,
+		}}}
+
+		assert.Nil(t, cmd.Handler(nil, ui, cli.Clients{Realm: realmClient}))
+		assert.Equal(t, "01:23:45 UTC INFO  No users to enable\n", out.String())
+	})
+
+	t.Run("should display users enabled by auth provider type", func(t *testing.T) {
+		out, ui := mock.NewUI()
+
+		realmClient := mock.RealmClient{}
+		realmClient.FindAppsFn = func(filter realm.AppFilter) ([]realm.App, error) {
+			return []realm.App{app}, nil
+		}
+		realmClient.FindUsersFn = func(groupID, appID string, filter realm.UserFilter) ([]realm.User, error) {
+			return testUsers, nil
+		}
+		realmClient.EnableUserFn = func(groupID, appID, userID string) error {
+			return nil
+		}
+
+		cmd := &CommandEnable{enableInputs{
+			ProjectInputs: cli.ProjectInputs{
+				Project: projectID,
+				App:     appID,
+			},
+			multiUserInputs: multiUserInputs{
+				Users: []string{testUsers[0].ID},
+			},
+		}}
+
+		assert.Nil(t, cmd.Handler(nil, ui, cli.Clients{Realm: realmClient}))
+		assert.Equal(t, strings.Join([]string{
+			"01:23:45 UTC INFO  Provider type: User/Password",
+			"  Email            ID      Type  Enabled  Details",
+			"  ---------------  ------  ----  -------  -------",
+			"  user-2@test.com  user-2        true            ",
+			"01:23:45 UTC INFO  Provider type: ApiKey",
+			"  Name    ID      Type  Enabled  Details",
+			"  ------  ------  ----  -------  -------",
+			"  name-3  user-3        true            ",
+			"01:23:45 UTC INFO  Provider type: Anonymous",
+			"  ID      Type    Enabled  Details",
+			"  ------  ------  -------  -------",
+			"  user-1  type-1  true            ",
+			"01:23:45 UTC INFO  Provider type: Custom JWT",
+			"  ID      Type  Enabled  Details",
+			"  ------  ----  -------  -------",
+			"  user-4        true            ",
+			"",
+		}, "\n"), out.String())
+	})
 
 	for _, tc := range []struct {
-		description   string
-		enableUserErr error
+		description    string
+		enableErr      error
+		expectedOutput string
 	}{
-		{"should enable a user when a user id is provided", nil},
-		{"should save failed enable errors", errors.New("client error")},
+		{
+			description: "should enable a user when a user id is provided",
+			expectedOutput: strings.Join([]string{
+				"01:23:45 UTC INFO  Provider type: Anonymous",
+				"  ID      Type    Enabled  Details",
+				"  ------  ------  -------  -------",
+				"  user-1  type-1  true            ",
+				"",
+			}, "\n"),
+		},
+		{
+			description: "should save failed enable errors",
+			enableErr:   errors.New("client error"),
+			expectedOutput: strings.Join([]string{
+				"01:23:45 UTC INFO  Provider type: Anonymous",
+				"  ID      Type    Enabled  Details     ",
+				"  ------  ------  -------  ------------",
+				"  user-1  type-1  false    client error",
+				"",
+			}, "\n"),
+		},
 	} {
 		t.Run(tc.description, func(t *testing.T) {
+			out, ui := mock.NewUI()
+
 			realmClient := mock.RealmClient{}
 
 			var capturedAppFilter realm.AppFilter
@@ -64,14 +132,20 @@ func TestUserEnableHandler(t *testing.T) {
 			realmClient.FindUsersFn = func(groupID, appID string, filter realm.UserFilter) ([]realm.User, error) {
 				capturedFindProjectID = groupID
 				capturedFindAppID = appID
-				return testUsers[:1], nil
+
+				return []realm.User{{
+					ID:         "user-1",
+					Type:       "type-1",
+					Identities: []realm.UserIdentity{{ProviderType: realm.AuthProviderTypeAnonymous}},
+					Disabled:   true,
+				}}, nil
 			}
 
 			var capturedEnableProjectID, capturedEnableAppID string
 			realmClient.EnableUserFn = func(groupID, appID, userID string) error {
 				capturedEnableProjectID = groupID
 				capturedEnableAppID = appID
-				return tc.enableUserErr
+				return tc.enableErr
 			}
 
 			cmd := &CommandEnable{
@@ -84,14 +158,10 @@ func TestUserEnableHandler(t *testing.T) {
 						Users: []string{testUsers[0].ID},
 					},
 				},
-				realmClient: realmClient,
 			}
 
-			assert.Nil(t, cmd.Handler(nil, nil))
-
-			assert.Equal(t, testUsers[0].ID, cmd.inputs.Users[0])
-			assert.Equal(t, testUsers[0], cmd.outputs[0].user)
-			assert.Equal(t, tc.enableUserErr, cmd.outputs[0].err)
+			assert.Nil(t, cmd.Handler(nil, ui, cli.Clients{Realm: realmClient}))
+			assert.Equal(t, tc.expectedOutput, out.String())
 
 			assert.Equal(t, realm.AppFilter{App: appID, GroupID: projectID}, capturedAppFilter)
 			assert.Equal(t, projectID, capturedFindProjectID)
@@ -134,117 +204,13 @@ func TestUserEnableHandler(t *testing.T) {
 			},
 		} {
 			t.Run(tc.description, func(t *testing.T) {
-				realmClient := tc.setupClient()
-				cmd := &CommandEnable{
-					realmClient: realmClient,
-				}
-				err := cmd.Handler(nil, nil)
+				cmd := &CommandEnable{}
 
+				err := cmd.Handler(nil, nil, cli.Clients{Realm: tc.setupClient()})
 				assert.Equal(t, tc.expectedErr, err)
 			})
 		}
 	})
-}
-
-func TestUserEnableFeedback(t *testing.T) {
-	testUsers := []realm.User{
-		{
-			ID:         "user-1",
-			Identities: []realm.UserIdentity{{ProviderType: realm.AuthProviderTypeUserPassword}},
-			Type:       "type-1",
-			Disabled:   true,
-			Data:       map[string]interface{}{"email": "user-1@test.com"},
-		},
-		{
-			ID:         "user-2",
-			Identities: []realm.UserIdentity{{ProviderType: realm.AuthProviderTypeUserPassword}},
-			Type:       "type-2",
-			Disabled:   true,
-			Data:       map[string]interface{}{"email": "user-2@test.com"},
-		},
-		{
-			ID:         "user-3",
-			Identities: []realm.UserIdentity{{ProviderType: realm.AuthProviderTypeUserPassword}},
-			Type:       "type-1",
-			Disabled:   true,
-			Data:       map[string]interface{}{"email": "user-3@test.com"},
-		},
-		{
-			ID:         "user-4",
-			Identities: []realm.UserIdentity{{ProviderType: realm.AuthProviderTypeAPIKey}},
-			Type:       "type-1",
-			Disabled:   true,
-			Data:       map[string]interface{}{"name": "name-4"},
-		},
-		{
-			ID:         "user-5",
-			Identities: []realm.UserIdentity{{ProviderType: realm.AuthProviderTypeCustomToken}},
-			Type:       "type-3",
-			Disabled:   true,
-		},
-	}
-	for _, tc := range []struct {
-		description     string
-		outputs         userOutputs
-		expectedContent string
-	}{
-		{
-			description:     "should show no users to enable",
-			expectedContent: "01:23:45 UTC INFO  No users to enable\n",
-		},
-		{
-			description: "should show 1 failed user",
-			outputs:     userOutputs{{testUsers[0], errors.New("client error")}},
-			expectedContent: strings.Join(
-				[]string{
-					"01:23:45 UTC INFO  Provider type: User/Password",
-					"  Email            ID      Type    Enabled  Details     ",
-					"  ---------------  ------  ------  -------  ------------",
-					"  user-1@test.com  user-1  type-1  false    client error",
-					"",
-				},
-				"\n",
-			),
-		},
-		{
-			description: "should show failures to enable 2 users amongst successful results across different auth provider types",
-			outputs: userOutputs{
-				{testUsers[0], nil},
-				{testUsers[1], errors.New("client error")},
-				{testUsers[2], nil},
-				{testUsers[3], errors.New("client error")},
-				{testUsers[4], nil},
-			},
-			expectedContent: strings.Join(
-				[]string{
-					"01:23:45 UTC INFO  Provider type: User/Password",
-					"  Email            ID      Type    Enabled  Details     ",
-					"  ---------------  ------  ------  -------  ------------",
-					"  user-2@test.com  user-2  type-2  false    client error",
-					"  user-1@test.com  user-1  type-1  true                 ",
-					"  user-3@test.com  user-3  type-1  true                 ",
-					"01:23:45 UTC INFO  Provider type: ApiKey",
-					"  Name    ID      Type    Enabled  Details     ",
-					"  ------  ------  ------  -------  ------------",
-					"  name-4  user-4  type-1  false    client error",
-					"01:23:45 UTC INFO  Provider type: Custom JWT",
-					"  ID      Type    Enabled  Details",
-					"  ------  ------  -------  -------",
-					"  user-5  type-3  true            ",
-					"",
-				},
-				"\n",
-			),
-		},
-	} {
-		t.Run(tc.description, func(t *testing.T) {
-			out, ui := mock.NewUI()
-			cmd := &CommandEnable{outputs: tc.outputs}
-
-			assert.Nil(t, cmd.Feedback(nil, ui))
-			assert.Equal(t, tc.expectedContent, out.String())
-		})
-	}
 }
 
 func TestUserEnableRow(t *testing.T) {

--- a/internal/commands/user/input_test.go
+++ b/internal/commands/user/input_test.go
@@ -229,7 +229,7 @@ func TestMultiUsersInputsSelect(t *testing.T) {
 		<-doneCh              // wait for procedure to complete
 
 		assert.Nil(t, err)
-		assert.Equal(t, testUsers[0:1], users)
+		assert.Equal(t, testUsers[:1], users)
 	})
 
 	t.Run("should not prompt the user", func(t *testing.T) {

--- a/internal/commands/user/list.go
+++ b/internal/commands/user/list.go
@@ -15,9 +15,7 @@ import (
 
 // CommandList is the `user list` command
 type CommandList struct {
-	inputs      listInputs
-	realmClient realm.Client
-	outputs     userOutputs
+	inputs listInputs
 }
 
 type listInputs struct {
@@ -45,53 +43,48 @@ func (cmd *CommandList) Inputs() cli.InputResolver {
 	return &cmd.inputs
 }
 
-// Setup is the command setup
-func (cmd *CommandList) Setup(profile *cli.Profile, ui terminal.UI) error {
-	cmd.realmClient = profile.RealmAuthClient()
-	return nil
-}
-
 // Handler is the command handler
-func (cmd *CommandList) Handler(profile *cli.Profile, ui terminal.UI) error {
-	app, err := cli.ResolveApp(ui, cmd.realmClient, cmd.inputs.Filter())
+func (cmd *CommandList) Handler(profile *cli.Profile, ui terminal.UI, clients cli.Clients) error {
+	app, err := cli.ResolveApp(ui, clients.Realm, cmd.inputs.Filter())
 	if err != nil {
 		return err
 	}
 
-	users, err := cmd.inputs.findUsers(cmd.realmClient, app.GroupID, app.ID)
+	users, err := cmd.inputs.findUsers(clients.Realm, app.GroupID, app.ID)
 	if err != nil {
 		return err
 	}
 
-	cmd.outputs = make([]userOutput, 0, len(users))
+	outputs := make(userOutputs, 0, len(users))
 	for _, user := range users {
-		cmd.outputs = append(cmd.outputs, userOutput{user, nil})
+		outputs = append(outputs, userOutput{user, err})
 	}
 
-	return nil
-}
-
-// Feedback is the command feedback
-func (cmd *CommandList) Feedback(profile *cli.Profile, ui terminal.UI) error {
-	if len(cmd.outputs) == 0 {
-		return ui.Print(terminal.NewTextLog("No available users to show"))
+	if len(outputs) == 0 {
+		ui.Print(terminal.NewTextLog("No available users to show"))
+		return nil
 	}
-	outputsByProviderType := cmd.outputs.mapByProviderType()
+
+	outputsByProviderType := outputs.byProviderType()
+
 	logs := make([]terminal.Log, 0, len(outputsByProviderType))
-	for _, apt := range realm.ValidAuthProviderTypes {
-		outputs := outputsByProviderType[apt]
-		if len(outputs) == 0 {
+	for _, providerType := range realm.ValidAuthProviderTypes {
+		o := outputsByProviderType[providerType]
+		if len(o) == 0 {
 			continue
 		}
-		sort.Slice(outputs, getUserComparerByLastAuthentication(outputs))
+
+		sort.Slice(o, getUserComparerByLastAuthentication(o))
 
 		logs = append(logs, terminal.NewTableLog(
-			fmt.Sprintf("Provider type: %s", apt.Display()),
-			append(userTableHeaders(apt), headerEnabled, headerLastAuthenticationDate),
-			userTableRows(apt, outputs, userListRow)...,
+			fmt.Sprintf("Provider type: %s", providerType.Display()),
+			append(userTableHeaders(providerType), headerEnabled, headerLastAuthenticationDate),
+			userTableRows(providerType, o, userListRow)...,
 		))
 	}
-	return ui.Print(logs...)
+
+	ui.Print(logs...)
+	return nil
 }
 
 func getUserComparerByLastAuthentication(outputs []userOutput) func(i, j int) bool {

--- a/internal/commands/user/list_test.go
+++ b/internal/commands/user/list_test.go
@@ -11,18 +11,6 @@ import (
 	"github.com/10gen/realm-cli/internal/utils/test/mock"
 )
 
-func TestUserListSetup(t *testing.T) {
-	t.Run("Should construct a Realm client with the configured base url", func(t *testing.T) {
-		profile := mock.NewProfile(t)
-		profile.SetRealmBaseURL("http://localhost:8080")
-		cmd := &CommandList{inputs: listInputs{}}
-
-		assert.Nil(t, cmd.realmClient)
-		assert.Nil(t, cmd.Setup(profile, nil))
-		assert.NotNil(t, cmd.realmClient)
-	})
-}
-
 func TestUserListHandler(t *testing.T) {
 	projectID := "projectID"
 	appID := "appID"
@@ -33,36 +21,110 @@ func TestUserListHandler(t *testing.T) {
 		Name:        "eggcorn",
 	}
 
+	t.Run("should display empty state message no users are found", func(t *testing.T) {
+		out, ui := mock.NewUI()
+
+		realmClient := mock.RealmClient{}
+		realmClient.FindAppsFn = func(filter realm.AppFilter) ([]realm.App, error) {
+			return []realm.App{app}, nil
+		}
+		realmClient.FindUsersFn = func(groupID, appID string, filter realm.UserFilter) ([]realm.User, error) {
+			return nil, nil
+		}
+		realmClient.DeleteUserFn = func(groupID, appID, userID string) error {
+			return nil
+		}
+
+		cmd := &CommandList{listInputs{ProjectInputs: cli.ProjectInputs{
+			Project: projectID,
+			App:     appID,
+		}}}
+
+		assert.Nil(t, cmd.Handler(nil, ui, cli.Clients{Realm: realmClient}))
+		assert.Equal(t, "01:23:45 UTC INFO  No available users to show\n", out.String())
+	})
+
+	t.Run("should display users by auth provider type", func(t *testing.T) {
+		out, ui := mock.NewUI()
+
+		realmClient := mock.RealmClient{}
+		realmClient.FindAppsFn = func(filter realm.AppFilter) ([]realm.App, error) {
+			return []realm.App{app}, nil
+		}
+		realmClient.FindUsersFn = func(groupID, appID string, filter realm.UserFilter) ([]realm.User, error) {
+			return testUsers, nil
+		}
+
+		cmd := &CommandList{listInputs{
+			ProjectInputs: cli.ProjectInputs{
+				Project: projectID,
+				App:     appID,
+			},
+			multiUserInputs: multiUserInputs{
+				Users: []string{testUsers[0].ID},
+			},
+		}}
+
+		assert.Nil(t, cmd.Handler(nil, ui, cli.Clients{Realm: realmClient}))
+		assert.Equal(t, strings.Join([]string{
+			"01:23:45 UTC INFO  Provider type: User/Password",
+			"  Email            ID      Type  Enabled  Last Authenticated",
+			"  ---------------  ------  ----  -------  ------------------",
+			"  user-2@test.com  user-2        true     n/a               ",
+			"01:23:45 UTC INFO  Provider type: ApiKey",
+			"  Name    ID      Type  Enabled  Last Authenticated",
+			"  ------  ------  ----  -------  ------------------",
+			"  name-3  user-3        true     n/a               ",
+			"01:23:45 UTC INFO  Provider type: Anonymous",
+			"  ID      Type    Enabled  Last Authenticated",
+			"  ------  ------  -------  ------------------",
+			"  user-1  type-1  true     n/a               ",
+			"01:23:45 UTC INFO  Provider type: Custom JWT",
+			"  ID      Type  Enabled  Last Authenticated",
+			"  ------  ----  -------  ------------------",
+			"  user-4        true     n/a               ",
+			"",
+		}, "\n"), out.String())
+	})
+
 	t.Run("should find app users", func(t *testing.T) {
-		testUsers := []realm.User{{ID: "user1"}, {ID: "user2"}}
+		out, ui := mock.NewUI()
+
 		var capturedAppFilter realm.AppFilter
 		var capturedProjectID, capturedAppID string
+
 		realmClient := mock.RealmClient{}
+
 		realmClient.FindAppsFn = func(filter realm.AppFilter) ([]realm.App, error) {
 			capturedAppFilter = filter
 			return []realm.App{app}, nil
 		}
+
 		realmClient.FindUsersFn = func(groupID, appID string, filter realm.UserFilter) ([]realm.User, error) {
 			capturedProjectID = groupID
 			capturedAppID = appID
-			return testUsers, nil
-		}
-		cmd := &CommandList{
-			inputs: listInputs{
-				ProjectInputs: cli.ProjectInputs{
-					Project: projectID,
-					App:     appID,
-				},
-			},
-			realmClient: realmClient,
+			return testUsers[:1], nil
 		}
 
-		assert.Nil(t, cmd.Handler(nil, nil))
+		cmd := &CommandList{listInputs{
+			ProjectInputs: cli.ProjectInputs{
+				Project: projectID,
+				App:     appID,
+			},
+		}}
+
+		assert.Nil(t, cmd.Handler(nil, ui, cli.Clients{Realm: realmClient}))
+		assert.Equal(t, strings.Join([]string{
+			"01:23:45 UTC INFO  Provider type: Anonymous",
+			"  ID      Type    Enabled  Last Authenticated",
+			"  ------  ------  -------  ------------------",
+			"  user-1  type-1  true     n/a               ",
+			"",
+		}, "\n"), out.String())
+
 		assert.Equal(t, realm.AppFilter{App: appID, GroupID: projectID}, capturedAppFilter)
 		assert.Equal(t, projectID, capturedProjectID)
 		assert.Equal(t, appID, capturedAppID)
-		assert.Equal(t, testUsers[0], cmd.outputs[0].user)
-		assert.Equal(t, testUsers[1], cmd.outputs[1].user)
 	})
 
 	t.Run("should return an error", func(t *testing.T) {
@@ -98,91 +160,13 @@ func TestUserListHandler(t *testing.T) {
 			},
 		} {
 			t.Run(tc.description, func(t *testing.T) {
-				realmClient := tc.setupClient()
-				cmd := &CommandList{
-					realmClient: realmClient,
-				}
-				err := cmd.Handler(nil, nil)
+				cmd := &CommandList{}
+
+				err := cmd.Handler(nil, nil, cli.Clients{Realm: tc.setupClient()})
 				assert.Equal(t, tc.expectedErr, err)
 			})
 		}
 	})
-}
-
-func TestUserListFeedback(t *testing.T) {
-	for _, tc := range []struct {
-		description     string
-		outputs         userOutputs
-		expectedContent string
-	}{
-		{
-			description:     "whould indicate no users found when none are found",
-			expectedContent: "01:23:45 UTC INFO  No available users to show\n",
-		},
-		{
-			description: "whould group the users by provider type and sort by LastAuthenticationDate",
-			outputs: userOutputs{
-				{user: realm.User{
-					ID:                     "id1",
-					Identities:             []realm.UserIdentity{{ProviderType: realm.AuthProviderTypeUserPassword}},
-					Type:                   "type1",
-					Data:                   map[string]interface{}{"email": "myEmail1"},
-					CreationDate:           1111111111,
-					LastAuthenticationDate: 1111111111,
-				}},
-				{user: realm.User{
-					ID:                     "id2",
-					Identities:             []realm.UserIdentity{{ProviderType: realm.AuthProviderTypeUserPassword}},
-					Type:                   "type2",
-					Data:                   map[string]interface{}{"email": "myEmail2"},
-					CreationDate:           1111333333,
-					LastAuthenticationDate: 1111333333,
-				}},
-				{user: realm.User{
-					ID:                     "id3",
-					Identities:             []realm.UserIdentity{{ProviderType: realm.AuthProviderTypeUserPassword}},
-					Type:                   "type1",
-					Data:                   map[string]interface{}{"email": "myEmail3"},
-					CreationDate:           1111222222,
-					LastAuthenticationDate: 1111222222,
-				}},
-				{user: realm.User{
-					ID:                     "id4",
-					Identities:             []realm.UserIdentity{{ProviderType: realm.AuthProviderTypeAPIKey}},
-					Type:                   "type1",
-					Data:                   map[string]interface{}{"name": "myName"},
-					CreationDate:           1111111111,
-					LastAuthenticationDate: 1111111111,
-				}},
-			},
-			expectedContent: strings.Join(
-				[]string{
-					"01:23:45 UTC INFO  Provider type: User/Password",
-					"  Email     ID   Type   Enabled  Last Authenticated           ",
-					"  --------  ---  -----  -------  -----------------------------",
-					"  myEmail2  id2  type2  true     2005-03-20 15:42:13 +0000 UTC",
-					"  myEmail3  id3  type1  true     2005-03-19 08:50:22 +0000 UTC",
-					"  myEmail1  id1  type1  true     2005-03-18 01:58:31 +0000 UTC",
-					"01:23:45 UTC INFO  Provider type: ApiKey",
-					"  Name    ID   Type   Enabled  Last Authenticated           ",
-					"  ------  ---  -----  -------  -----------------------------",
-					"  myName  id4  type1  true     2005-03-18 01:58:31 +0000 UTC",
-					"",
-				},
-				"\n",
-			),
-		},
-	} {
-		t.Run(tc.description, func(t *testing.T) {
-			out, ui := mock.NewUI()
-			cmd := &CommandList{
-				outputs: tc.outputs,
-			}
-
-			assert.Nil(t, cmd.Feedback(nil, ui))
-			assert.Equal(t, tc.expectedContent, out.String())
-		})
-	}
 }
 
 func TestUserListRow(t *testing.T) {

--- a/internal/commands/user/output.go
+++ b/internal/commands/user/output.go
@@ -19,7 +19,7 @@ const (
 
 type userOutputs []userOutput
 
-func (outputs userOutputs) mapByProviderType() map[realm.AuthProviderType]userOutputs {
+func (outputs userOutputs) byProviderType() map[realm.AuthProviderType]userOutputs {
 	var outputsM = map[realm.AuthProviderType]userOutputs{}
 	for _, output := range outputs {
 		for _, identity := range output.user.Identities {

--- a/internal/commands/whoami/command.go
+++ b/internal/commands/whoami/command.go
@@ -9,22 +9,20 @@ import (
 type Command struct{}
 
 // Handler is the command handler
-func (cmd *Command) Handler(profile *cli.Profile, ui terminal.UI) error {
-	return nil // commands without handlers show help text and usage when ran
-}
-
-// Feedback is the command feedback
-func (cmd *Command) Feedback(profile *cli.Profile, ui terminal.UI) error {
+func (cmd *Command) Handler(profile *cli.Profile, ui terminal.UI, clients cli.Clients) error {
 	user := profile.User()
 	session := profile.Session()
 
 	if user.PrivateAPIKey == "" {
-		return ui.Print(terminal.NewTextLog("No user is currently logged in"))
+		ui.Print(terminal.NewTextLog("No user is currently logged in"))
+		return nil
 	}
 
 	if session.AccessToken == "" {
-		return ui.Print(terminal.NewTextLog("The user, %s, is not currently logged in", user.PublicAPIKey))
+		ui.Print(terminal.NewTextLog("The user, %s, is not currently logged in", user.PublicAPIKey))
+		return nil
 	}
 
-	return ui.Print(terminal.NewTextLog("Currently logged in user: %s (%s)", user.PublicAPIKey, user.RedactedPrivateAPIKey()))
+	ui.Print(terminal.NewTextLog("Currently logged in user: %s (%s)", user.PublicAPIKey, user.RedactedPrivateAPIKey()))
+	return nil
 }

--- a/internal/commands/whoami/command_test.go
+++ b/internal/commands/whoami/command_test.go
@@ -9,17 +9,8 @@ import (
 	"github.com/10gen/realm-cli/internal/utils/test/mock"
 )
 
-func TestWhoamiHandler(t *testing.T) {
-	t.Run("Handler should run as a noop", func(t *testing.T) {
-		cmd := &Command{}
-
-		err := cmd.Handler(nil, nil)
-		assert.Nil(t, err)
-	})
-}
-
 func TestWhoamiFeedback(t *testing.T) {
-	t.Run("Feedback should print the auth details", func(t *testing.T) {
+	t.Run("should print the auth details", func(t *testing.T) {
 		for _, tc := range []struct {
 			description string
 			setup       func(t *testing.T, profile *cli.Profile)
@@ -61,7 +52,7 @@ func TestWhoamiFeedback(t *testing.T) {
 				out, ui := mock.NewUI()
 
 				cmd := &Command{}
-				err := cmd.Feedback(profile, ui)
+				err := cmd.Handler(profile, ui, cli.Clients{})
 				assert.Nil(t, err)
 
 				tc.test(t, out.String())

--- a/internal/terminal/ui_test.go
+++ b/internal/terminal/ui_test.go
@@ -3,6 +3,8 @@ package terminal_test
 import (
 	"bytes"
 	"errors"
+	"log"
+	"os"
 	"testing"
 
 	"github.com/10gen/realm-cli/internal/terminal"
@@ -31,10 +33,10 @@ func TestUIPrint(t *testing.T) {
 		} {
 			t.Run(tc.description, func(t *testing.T) {
 				out, err := new(bytes.Buffer), new(bytes.Buffer)
-				ui := terminal.NewUI(terminal.UIConfig{}, nil, out, err)
+				ui := terminal.NewUI(terminal.UIConfig{}, nil, out, err, logger)
 
 				tc.log.Time = mock.StaticTime
-				assert.Nil(t, ui.Print(tc.log))
+				ui.Print(tc.log)
 
 				assert.Equal(t, tc.expectedOut, out.String())
 				assert.Equal(t, tc.expectedErr, err.String())
@@ -42,3 +44,7 @@ func TestUIPrint(t *testing.T) {
 		}
 	})
 }
+
+var (
+	logger = log.New(os.Stderr, "UTC ERROR ", log.Ltime|log.Lmsgprefix)
+)

--- a/internal/utils/test/mock/realm_client.go
+++ b/internal/utils/test/mock/realm_client.go
@@ -32,13 +32,13 @@ type RealmClient struct {
 	DeleteSecretFn func(groupID, appID, secretID string) error
 	UpdateSecretFn func(groupID, appID, secretID, name, value string) error
 
-	CreateAPIKeyFn       func(groupID, appID, apiKeyName string) (realm.APIKey, error)
-	CreateUserFn         func(groupID, appID, email, password string) (realm.User, error)
-	DeleteUserFn         func(groupID, appID, userID string) error
-	DisableUserFn        func(groupID, appID, userID string) error
-	EnableUserFn         func(groupID, appID, userID string) error
-	FindUsersFn          func(groupID, appID string, filter realm.UserFilter) ([]realm.User, error)
-	RevokeUserSessionsFn func(groupID, appID, userID string) error
+	CreateAPIKeyFn      func(groupID, appID, apiKeyName string) (realm.APIKey, error)
+	CreateUserFn        func(groupID, appID, email, password string) (realm.User, error)
+	DeleteUserFn        func(groupID, appID, userID string) error
+	DisableUserFn       func(groupID, appID, userID string) error
+	EnableUserFn        func(groupID, appID, userID string) error
+	FindUsersFn         func(groupID, appID string, filter realm.UserFilter) ([]realm.User, error)
+	RevokeUserSessionFn func(groupID, appID, userID string) error
 
 	StatusFn func() error
 }
@@ -277,8 +277,8 @@ func (rc RealmClient) FindUsers(groupID, appID string, filter realm.UserFilter) 
 // otherwise the call falls back to the underlying realm.Client implementation.
 // NOTE: this may panic if the underlying realm.Client is left undefined
 func (rc RealmClient) RevokeUserSessions(groupID, appID, userID string) error {
-	if rc.RevokeUserSessionsFn != nil {
-		return rc.RevokeUserSessionsFn(groupID, appID, userID)
+	if rc.RevokeUserSessionFn != nil {
+		return rc.RevokeUserSessionFn(groupID, appID, userID)
 	}
 	return rc.Client.RevokeUserSessions(groupID, appID, userID)
 }

--- a/internal/utils/test/mock/terminal_ui.go
+++ b/internal/utils/test/mock/terminal_ui.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"strings"
 	"testing"
@@ -44,11 +45,11 @@ type ui struct {
 	terminal.UI
 }
 
-func (ui ui) Print(logs ...terminal.Log) error {
+func (ui ui) Print(logs ...terminal.Log) {
 	for i := range logs {
 		logs[i].Time = StaticTime
 	}
-	return ui.UI.Print(logs...)
+	ui.UI.Print(logs...)
 }
 
 // NewUI returns a new *bytes.Buffer and a mock terminal UI that writes to the buffer
@@ -64,6 +65,7 @@ func NewUIWithOptions(options UIOptions, writer io.Writer) terminal.UI {
 		nil,
 		writer,
 		writer,
+		errLogger(writer),
 	)}
 }
 
@@ -88,6 +90,7 @@ func NewConsoleWithOptions(options UIOptions, writers ...io.Writer) (*expect.Con
 		console.Tty(),
 		console.Tty(),
 		console.Tty(),
+		errLogger(console.Tty()),
 	)}
 
 	return console, ui, nil
@@ -114,6 +117,7 @@ func NewVT10XConsoleWithOptions(options UIOptions, writers ...io.Writer) (*expec
 		console.Tty(),
 		console.Tty(),
 		console.Tty(),
+		errLogger(console.Tty()),
 	)}
 
 	return console, state, ui, nil
@@ -126,4 +130,8 @@ func FileWriter(t *testing.T) (*os.File, error) {
 	filename := strings.ReplaceAll(fmt.Sprintf("%s.log", t.Name()), "/", "_")
 
 	return os.OpenFile(filename, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
+}
+
+func errLogger(w io.Writer) *log.Logger {
+	return log.New(os.Stderr, "UTC ERROR ", log.Ltime|log.Lmsgprefix)
 }

--- a/tmp/new_app/realm_config.json
+++ b/tmp/new_app/realm_config.json
@@ -1,0 +1,7 @@
+{
+    "config_version": 20210101,
+    "app_id": "new_app-ryrcd",
+    "name": "new_app",
+    "location": "US-VA",
+    "deployment_model": "GLOBAL"
+}


### PR DESCRIPTION
Definitely a noisy one, hopefully the commits help explain a bit what's going on, but in short:

* removed the `Setup` interface (all it was doing was creating and setting clients on the command structs, these are now simply passed in to the command handler as args)
* removed the `Feedback` interface
  * this allows us to be more declarative/explicit about command execution
* `UI.Print` now does not return an error (but the error handling remains effectively the same as before this change)