### PR TITLE
REALMC-7429: Finalize CLI help text

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,9 @@ import (
 
 // Run runs the CLI
 func Run() {
+	// print commands in help/usage text in the order they are declared
+	cobra.EnableCommandSorting = false
+
 	cmd := &cobra.Command{
 		Version:       version.Version,
 		Use:           cli.Name,
@@ -25,13 +28,14 @@ func Run() {
 	cobra.OnInitialize(factory.Setup)
 	defer factory.Close()
 
+	cmd.Flags().SortFlags = false // ensures CLI help text displays global flags unsorted
 	factory.SetGlobalFlags(cmd.PersistentFlags())
 
-	cmd.AddCommand(factory.Build(commands.App))
 	cmd.AddCommand(factory.Build(commands.Login))
 	cmd.AddCommand(factory.Build(commands.Logout))
-	cmd.AddCommand(factory.Build(commands.Pull))
 	cmd.AddCommand(factory.Build(commands.Push))
+	cmd.AddCommand(factory.Build(commands.Pull))
+	cmd.AddCommand(factory.Build(commands.App))
 	cmd.AddCommand(factory.Build(commands.Secrets))
 	cmd.AddCommand(factory.Build(commands.User))
 	cmd.AddCommand(factory.Build(commands.Whoami))

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/segmentio/backo-go v0.0.0-20200129164019-23eae7c10bd3 // indirect
 	github.com/spf13/afero v1.1.2
-	github.com/spf13/cobra v1.1.1
+	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1
 	github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c // indirect

--- a/go.sum
+++ b/go.sum
@@ -445,6 +445,8 @@ github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkU
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v1.1.1 h1:KfztREH0tPxJJ+geloSLaAkaPkr4ki2Er5quFV1TDo4=
 github.com/spf13/cobra v1.1.1/go.mod h1:WnodtKOvamDL/PwE2M4iKs8aMDBZ5Q5klgD3qfVJQMI=
+github.com/spf13/cobra v1.1.3 h1:xghbfqPkxzxP3C/f3n5DdpAbdKLj4ZE4BWQI362l53M=
+github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSWzOo=
 github.com/spf13/jwalterweatherman v1.0.0 h1:XHEdyB+EcvlqZamSM4ZOMGlc93t6AcsBEu9Gc1vn7yk=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
@@ -721,6 +723,8 @@ gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/internal/cli/inputs.go
+++ b/internal/cli/inputs.go
@@ -8,6 +8,7 @@ import (
 	"github.com/10gen/realm-cli/internal/cloud/realm"
 	"github.com/10gen/realm-cli/internal/local"
 	"github.com/10gen/realm-cli/internal/terminal"
+	"github.com/10gen/realm-cli/internal/utils/flags"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/spf13/pflag"
@@ -15,7 +16,8 @@ import (
 
 const (
 	flagApp      = "app"
-	flagAppUsage = "the Realm app name or id to manage"
+	flagAppShort = "a"
+	flagAppUsage = "the remote Realm app name or id"
 
 	flagProject      = "project"
 	flagProjectUsage = "the MongoDB cloud project id"
@@ -32,8 +34,10 @@ func (i ProjectInputs) Filter() realm.AppFilter { return realm.AppFilter{i.Proje
 
 // Flags registers the project app input flags to the provided flag set
 func (i *ProjectInputs) Flags(fs *pflag.FlagSet) {
+	fs.StringVarP(&i.App, flagApp, flagAppShort, "", flagAppUsage)
+
 	fs.StringVar(&i.Project, flagProject, "", flagProjectUsage)
-	fs.StringVar(&i.App, flagApp, "", flagAppUsage)
+	flags.MarkHidden(fs, flagProject)
 }
 
 // Resolve resolves the necessary inputs that remain unset after flags have been parsed

--- a/internal/cli/profile.go
+++ b/internal/cli/profile.go
@@ -21,8 +21,7 @@ const (
 	profileType = "yaml"
 
 	flagProfile      = "profile"
-	flagProfileShort = "i"
-	flagProfileUsage = "this is the --profile, -p usage"
+	flagProfileUsage = "specify the profile name to use"
 
 	flagAtlasBaseURL      = "atlas-url"
 	flagAtlasBaseURLUsage = "specify the base Atlas server URL"

--- a/internal/cloud/realm/client.go
+++ b/internal/cloud/realm/client.go
@@ -84,6 +84,7 @@ func (c *client) doJSON(method, path string, payload interface{}, options api.Re
 	if err != nil {
 		return nil, err
 	}
+
 	options.Body = bytes.NewReader(body)
 	options.ContentType = api.MediaTypeJSON
 

--- a/internal/cloud/realm/realm.go
+++ b/internal/cloud/realm/realm.go
@@ -96,7 +96,7 @@ func (dm DeploymentModel) Type() string { return flags.TypeString }
 
 // Set validates and sets the deployment model value
 func (dm *DeploymentModel) Set(val string) error {
-	newDeploymentModel := DeploymentModel(val)
+	newDeploymentModel := DeploymentModel(strings.ToUpper(val))
 
 	if !isValidDeploymentModel(newDeploymentModel) {
 		return errInvalidDeploymentModel
@@ -151,7 +151,7 @@ func (l Location) Type() string { return flags.TypeString }
 
 // Set validates and sets the Location value
 func (l *Location) Set(val string) error {
-	newLocation := Location(val)
+	newLocation := Location(strings.ToUpper(val))
 
 	if !isValidLocation(newLocation) {
 		return errInvalidLocation

--- a/internal/commands/app/create.go
+++ b/internal/commands/app/create.go
@@ -7,6 +7,7 @@ import (
 	"github.com/10gen/realm-cli/internal/cloud/realm"
 	"github.com/10gen/realm-cli/internal/local"
 	"github.com/10gen/realm-cli/internal/terminal"
+	"github.com/10gen/realm-cli/internal/utils/flags"
 
 	"github.com/spf13/pflag"
 )
@@ -23,17 +24,20 @@ type CommandCreate struct {
 
 // Flags is the command flags
 func (cmd *CommandCreate) Flags(fs *pflag.FlagSet) {
-	fs.StringVar(&cmd.inputs.Project, flagProject, "", flagProjectUsage)
+	fs.StringVar(&cmd.inputs.LocalPath, flagLocalPathCreate, "", flagLocalPathCreateUsage)
 	fs.StringVarP(&cmd.inputs.Name, flagName, flagNameShort, "", flagNameUsage)
 	fs.StringVar(&cmd.inputs.RemoteApp, flagRemote, "", flagRemoteUsage)
-	fs.StringVar(&cmd.inputs.LocalPath, flagLocalPath, "", flagLocalPathUsage)
-	fs.VarP(&cmd.inputs.DeploymentModel, flagDeploymentModel, flagDeploymentModelShort, flagDeploymentModelUsage)
 	fs.VarP(&cmd.inputs.Location, flagLocation, flagLocationShort, flagLocationUsage)
+	fs.VarP(&cmd.inputs.DeploymentModel, flagDeploymentModel, flagDeploymentModelShort, flagDeploymentModelUsage)
 	fs.StringVar(&cmd.inputs.Cluster, flagCluster, "", flagClusterUsage)
 	fs.StringVar(&cmd.inputs.DataLake, flagDataLake, "", flagDataLakeUsage)
 	fs.BoolVarP(&cmd.inputs.DryRun, flagDryRun, flagDryRunShort, false, flagDryRunUsage)
+
+	fs.StringVar(&cmd.inputs.Project, flagProject, "", flagProjectUsage)
+	flags.MarkHidden(fs, flagProject)
+
 	fs.Var(&cmd.inputs.ConfigVersion, flagConfigVersion, flagConfigVersionUsage)
-	fs.MarkHidden(flagConfigVersion) //nolint: errcheck
+	flags.MarkHidden(fs, flagConfigVersion)
 }
 
 // Inputs is the command inputs

--- a/internal/commands/app/create_inputs.go
+++ b/internal/commands/app/create_inputs.go
@@ -16,8 +16,8 @@ import (
 )
 
 var (
-	flagLocalPath      = "local"
-	flagLocalPathUsage = "the local path to create your new Realm app, defaults to Realm app name"
+	flagLocalPathCreate      = "local"
+	flagLocalPathCreateUsage = "the local path to create your new Realm app in, defaults to the Realm app name"
 
 	flagCluster      = "cluster"
 	flagClusterUsage = "include to link an Atlas cluster to your Realm app"
@@ -27,7 +27,7 @@ var (
 
 	flagDryRun      = "dry-run"
 	flagDryRunShort = "x"
-	flagDryRunUsage = "include to run without writing any changes to the file system or import/export the new Realm app"
+	flagDryRunUsage = "include to run without writing any changes to the file system nor deploying any changes to the Realm servers"
 )
 
 type createInputs struct {
@@ -194,7 +194,7 @@ func (i createInputs) args(omitDryRun bool) []flags.Arg {
 		args = append(args, flags.Arg{flagRemote, i.RemoteApp})
 	}
 	if i.LocalPath != "" {
-		args = append(args, flags.Arg{flagLocalPath, i.LocalPath})
+		args = append(args, flags.Arg{flagLocalPathCreate, i.LocalPath})
 	}
 	if i.Location != flagLocationDefault {
 		args = append(args, flags.Arg{flagLocation, i.Location.String()})

--- a/internal/commands/app/delete.go
+++ b/internal/commands/app/delete.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/10gen/realm-cli/internal/cli"
 	"github.com/10gen/realm-cli/internal/terminal"
+	"github.com/10gen/realm-cli/internal/utils/flags"
 
 	"github.com/spf13/pflag"
 )
@@ -16,8 +17,10 @@ type CommandDelete struct {
 
 // Flags is the command flags
 func (cmd *CommandDelete) Flags(fs *pflag.FlagSet) {
-	fs.StringSliceVarP(&cmd.inputs.Apps, flagApps, "", []string{}, flagAppsUsage)
+	fs.StringSliceVarP(&cmd.inputs.Apps, flagApp, flagAppShort, []string{}, flagAppUsage)
+
 	fs.StringVar(&cmd.inputs.Project, flagProject, "", flagProjectUsage)
+	flags.MarkHidden(fs, flagProject)
 }
 
 // Handler is the command handler

--- a/internal/commands/app/delete_inputs.go
+++ b/internal/commands/app/delete_inputs.go
@@ -11,8 +11,9 @@ import (
 )
 
 var (
-	flagApps      = "apps"
-	flagAppsUsage = "the Realm app names or ids to manage"
+	flagApp      = "app"
+	flagAppShort = "a"
+	flagAppUsage = "the remote Realm app name or id"
 )
 
 type deleteInputs struct {

--- a/internal/commands/app/diff.go
+++ b/internal/commands/app/diff.go
@@ -11,6 +11,8 @@ import (
 )
 
 const (
+	flagLocalPathDiff            = "local"
+	flagLocalPathDiffUsage       = "the local path to your Realm app"
 	flagIncludeDependencies      = "include-dependencies"
 	flagIncludeDependenciesShort = "d"
 	flagIncludeDependenciesUsage = "include to diff Realm app dependencies changes as well"
@@ -40,11 +42,11 @@ type CommandDiff struct {
 
 // Flags is the command flags
 func (cmd *CommandDiff) Flags(fs *pflag.FlagSet) {
-	fs.StringVar(&cmd.inputs.LocalPath, flagLocalPath, "", flagLocalPathUsage)
+	cmd.inputs.Flags(fs)
+
+	fs.StringVar(&cmd.inputs.LocalPath, flagLocalPathDiff, "", flagLocalPathDiffUsage)
 	fs.BoolVarP(&cmd.inputs.IncludeDependencies, flagIncludeDependencies, flagIncludeDependenciesShort, false, flagIncludeDependenciesUsage)
 	fs.BoolVarP(&cmd.inputs.IncludeHosting, flagIncludeHosting, flagIncludeHostingShort, false, flagIncludeHostingUsage)
-
-	cmd.inputs.Flags(fs)
 }
 
 // Inputs is the command inputs

--- a/internal/commands/app/init.go
+++ b/internal/commands/app/init.go
@@ -5,6 +5,7 @@ import (
 	"github.com/10gen/realm-cli/internal/cloud/realm"
 	"github.com/10gen/realm-cli/internal/local"
 	"github.com/10gen/realm-cli/internal/terminal"
+	"github.com/10gen/realm-cli/internal/utils/flags"
 
 	"github.com/spf13/pflag"
 )
@@ -16,13 +17,16 @@ type CommandInit struct {
 
 // Flags is the command flags
 func (cmd *CommandInit) Flags(fs *pflag.FlagSet) {
-	fs.StringVar(&cmd.inputs.Project, flagProject, "", flagProjectUsage)
-	fs.StringVar(&cmd.inputs.RemoteApp, flagRemote, "", flagRemoteUsage)
 	fs.StringVarP(&cmd.inputs.Name, flagName, flagNameShort, "", flagNameUsage)
-	fs.VarP(&cmd.inputs.DeploymentModel, flagDeploymentModel, flagDeploymentModelShort, flagDeploymentModelUsage)
+	fs.StringVar(&cmd.inputs.RemoteApp, flagRemote, "", flagRemoteUsage)
 	fs.VarP(&cmd.inputs.Location, flagLocation, flagLocationShort, flagLocationUsage)
+	fs.VarP(&cmd.inputs.DeploymentModel, flagDeploymentModel, flagDeploymentModelShort, flagDeploymentModelUsage)
+
+	fs.StringVar(&cmd.inputs.Project, flagProject, "", flagProjectUsage)
+	flags.MarkHidden(fs, flagProject)
+
 	fs.Var(&cmd.inputs.ConfigVersion, flagConfigVersion, flagConfigVersionUsage)
-	fs.MarkHidden(flagConfigVersion) //nolint: errcheck
+	flags.MarkHidden(fs, flagConfigVersion)
 }
 
 // Inputs is the command inputs

--- a/internal/commands/app/new_app_inputs.go
+++ b/internal/commands/app/new_app_inputs.go
@@ -7,25 +7,25 @@ import (
 )
 
 const (
-	flagProject      = "project"
-	flagProjectUsage = "the MongoDB cloud project id"
-
-	flagRemote      = "remote"
-	flagRemoteUsage = "choose an application to initialize the Realm app with"
-
 	flagName      = "name"
 	flagNameShort = "n"
-	flagNameUsage = "set the name of the Realm app to be initialized"
+	flagNameUsage = "set the name of the new Realm app"
+
+	flagRemote      = "remote"
+	flagRemoteUsage = "choose an application to build the new Realm app from"
 
 	flagDeploymentModel        = "deployment-model"
 	flagDeploymentModelShort   = "d"
-	flagDeploymentModelUsage   = `select the Realm app's deployment model, available options: ["global", "local"]`
+	flagDeploymentModelUsage   = `select the Realm app's deployment model, available options: ["GLOBAL", "LOCAL"]`
 	flagDeploymentModelDefault = realm.DeploymentModelGlobal
 
 	flagLocation        = "location"
 	flagLocationShort   = "l"
 	flagLocationUsage   = `select the Realm app's location, available options: ["US-VA", "local"]`
 	flagLocationDefault = realm.LocationVirginia
+
+	flagProject      = "project"
+	flagProjectUsage = "the MongoDB cloud project id"
 
 	flagConfigVersion      = "config-version"
 	flagConfigVersionUsage = "the config version of the Realm app structure; defaults to latest stable config version"

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -17,151 +17,172 @@ var (
 	Login = cli.CommandDefinition{
 		Command:     &login.Command{},
 		Use:         "login",
-		Description: "Authenticate with an Atlas programmatic API Key",
-		Help:        "login", // TODO(REALMC-7429): add help text description
+		Description: "Log in to your Realm App backend with a MongoDB Cloud API key",
+		Help: `Begins an authenticated session with Realm. To get a MongoDB Cloud
+API Key, open your Realm app in the Realm UI. Navigate to Deploy in the left
+navigation menu, and select the Export App tab. From there, create a
+programmatic API key to authenticate your realm-cli session`,
 	}
+
 	Logout = cli.CommandDefinition{
 		Command:     &logout.Command{},
 		Use:         "logout",
-		Description: "Terminate the current user’s session",
-		Help:        "logout", // TODO(REALMC-7429): add help text description
+		Description: "Log out of your Realm app backend and MongoDB Cloud",
+		Help: `Ends the authenticated session and deletes cached access tokens. To
+re-authenticate, you must call 'login' with your API Key.`,
 	}
+
 	Whoami = cli.CommandDefinition{
 		Command:     &whoami.Command{},
 		Use:         "whoami",
-		Description: "Display the current user's details",
-		Help:        "whoami", // TODO(REALMC-7429): add help text description
+		Description: "Display information about the current user.",
+		Help: `
+Displays a table that includes your Public API Key and redacted Private API Key
+(e.g. ********-****-****-****-3ba985aa367a). No session data will be surfaced if
+you are not logged in.
+
+To log in, authenticate your information using the following command:
+
+realm-cli login --profile <profile-name>`,
 	}
 
 	Push = cli.CommandDefinition{
 		Command:     &push.Command{},
 		Use:         push.CommandUse,
 		Aliases:     push.CommandAliases,
-		Description: "Push and deploy changes from your local directory to your Realm app",
-		Help: `Push and deploy changes from your local directory to your Realm app
-
-	Updates a remote Realm application with your local directory. First, input a
-	Realm app that you would like changes pushed to. This input can be either the
-	application Client App ID of an existing Realm app you would like to update, or
-	the name of a new Realm app you would like to create. Changes pushed are
-	automatically deployed.`,
+		Description: "Import and deploy changes from your local directory to your Realm app",
+		Help: `Updates a remote Realm app with your local directory. First, input a Realm app
+that you would like changes pushed to. This input can be either the App ID or
+Name of an existing Realm app you would like to update, or the name of a new
+Realm app you would like to create. Changes pushed are automatically deployed.`,
 	}
 
 	Pull = cli.CommandDefinition{
 		Command:     &pull.Command{},
-		Use:         "pull",
-		Aliases:     []string{"export"},
-		Description: "Pull the latest version of your Realm app into your local directory",
-		Help: `Pull the latest version of your Realm app into your local directory
-
-Updates a remote Realm app with your local directory by pulling changes from the
-former into the latter. Input a Realm app that you would like to have changes
-pushed from. If applicable, hosting and/or dependencies associated with your
-Realm app will be exported as well.`,
+		Use:         "export",
+		Aliases:     []string{"pull"},
+		Description: "Export the latest version of your Realm app into your local directory",
+		Help: `Updates your local directory with a remote Realm app by pulling changes from the
+latter into the former. Input a Realm app that you would like to have changes
+pulled from. If applicable, hosting files and/or dependencies associated with
+your Realm app will be exported as well.`,
 	}
 
 	App = cli.CommandDefinition{
-		Use:         "app",
-		Aliases:     []string{"apps"},
-		Description: "Manage the apps associated with the current user",
-		Help:        "app help", // TODO(REALMC-7429): add help text description
+		Use:         "apps",
+		Aliases:     []string{"app"},
+		Description: "Manage the Realm apps associated with the current user",
 		SubCommands: []cli.CommandDefinition{
 			{
+				Command:     &app.CommandInit{},
 				Use:         "init",
 				Aliases:     []string{"initialize"},
 				Display:     "app init",
-				Description: "Initialize a Realm app in your current local directory",
-				Help:        "",
-				Command:     &app.CommandInit{},
+				Description: "Initialize a Realm app in your current working directory",
+				Help: `Initializes configuration files and directories to represent a minimal Realm app
+within your current working directory. This command only affects your local
+environment and does not deploy your app to the Realm servers. To create a new
+Realm app and have it deployed, use ‘app create’.
+
+You can specify a ‘--remote’ flag to initialize a Realm app from an existing
+app; if you do not specify a '--remote' flag, the CLI will initialize a default
+Realm app.`,
 			},
 			{
+				Command:     &app.CommandCreate{},
 				Use:         "create",
 				Display:     app.CommandCreateDisplay,
-				Description: "Create a remote Realm app from your current working directory",
-				Help: `Creates a new Realm app in the cloud, and saves your configuration files on
-a new disk. This command will create a new directory for your project.
-To initialize a Realm app in your current working directory, use ‘app init’.
+				Description: "Create a Realm app in a local directory and deploy it to the Realm server",
+				Help: `Creates a new Realm app in the cloud and saves your configuration files in a
+local directory.  This command will also deploy the new app to the Realm servers.
+This command will create a new directory for your project. To create a Realm app
+and not have it deployed, use ‘app init’.
 
-You can specify a '--remote' input to create a Realm app from
-an existing app. If you do not specify a '--remote' input,
-the CLI will create a non-personalized Realm app.`,
-				Command: &app.CommandCreate{},
-			},
-			cli.CommandDefinition{
-				Use:         "list",
-				Aliases:     []string{"ls"},
-				Display:     "app list",
-				Description: "List the MongoDB Realm applications associated with the current user",
-				Help:        "list help", // TODO(REALMC-7429): add help text description
-				Command:     &app.CommandList{},
+You can specify a '--remote' flag to create a Realm app from an existing app; if
+you do not specify a '--remote' flag, the CLI will create a default Realm app.`,
 			},
 			{
+				Command:     &app.CommandList{},
+				Use:         "list",
+				Aliases:     []string{"ls"},
+				Display:     "apps list",
+				Description: "List the Realm apps you have access to",
+				Help:        `Lists and filters your Realm apps`,
+			},
+			{
+				Command:     &app.CommandDiff{},
 				Use:         "diff",
 				Aliases:     []string{},
 				Display:     "app diff",
 				Description: "Show differences between your Realm app and your local directory",
-				Help: `Displays file-by-file differences between the latest version of your Realm app and your local directory.
-If you have more than one Realm app, you will be prompted to select a Realm app that you would like to
-display from a list of all Realm apps associated with your user profile.`,
-				Command: &app.CommandDiff{},
+				Help: `Displays file-by-file differences between the latest version of your Realm app
+and your local directory. If you have more than one Realm app, you will be
+prompted to select a Realm app that you would like to display from a list of all
+Realm apps associated with your user profile.`,
 			},
 			{
+				Command:     &app.CommandDelete{},
 				Use:         "delete",
 				Display:     "app delete",
 				Description: "Delete a Realm app",
-				Help: `If you have more than one Realm app, you will be prompted to select one or multiple app(s) that you would like to delete
-from a list of all your Realm apps. The list includes Realm apps from all projects associated with your user profile.`,
-				Command: &app.CommandDelete{},
+				Help: `If you have more than one Realm app, you will be prompted to select one or
+multiple app(s) that you would like to delete from a list of all your Realm apps.
+The list includes Realm apps from all projects associated with your user profile.`,
 			},
 		},
 	}
 
 	User = cli.CommandDefinition{
-		Use:         "user",
-		Aliases:     []string{"users"},
-		Description: "Manage the users of your MongoDB Realm application",
-		Help:        "user",
+		Use:         "users",
+		Aliases:     []string{"user"},
+		Description: "Manage the users of your Realm app",
 		SubCommands: []cli.CommandDefinition{
 			{
+				Command:     &user.CommandCreate{},
 				Use:         "create",
 				Display:     "user create",
-				Description: "Create a user for a Realm application",
-				Help:        "user create",
-				Command:     &user.CommandCreate{},
+				Description: "Create an application user in your Realm app",
+				Help: `Adds a new user to your Realm app. You can create a user
+				using an Email/Password or an API Key.`,
 			},
 			{
+				Command:     &user.CommandList{},
+				Use:         "list",
+				Description: "List the application users in your Realm app",
+				Help: `Displays a list of your Realm app's users' details. The list is grouped by
+auth provider type and sorted by last authentication date.`,
+			},
+			{
+				Command:     &user.CommandDisable{},
+				Use:         "disable",
+				Display:     "user disable",
+				Description: "Disable an application user in your Realm app",
+				Help: `Deactivates a user on your Realm app. A user that has been disabled will not be
+allowed to log in, even if they provide valid credentials.`,
+			},
+			{
+				Command:     &user.CommandEnable{},
+				Use:         "enable",
+				Display:     "user enable",
+				Description: "Enable an application user in your Realm app",
+				Help: `Activates a user on your Realm app. A user that has been enabled will have no
+restrictions with logging in.`,
+			},
+			{
+				Command:     &user.CommandRevoke{},
+				Use:         "revoke",
+				Display:     "user revoke",
+				Description: "Revoke an application user’s sessions from your Realm app",
+				Help: `Logs a user out of your Realm app. A user who’s user session has been revoked
+can log in again if they provide valid credentials.`,
+			},
+			{
+				Command:     &user.CommandDelete{},
 				Use:         "delete",
 				Display:     "user delete",
 				Description: "Delete an application user from your Realm app",
-				Help:        "Removes a specific user from your Realm app.",
-				Command:     &user.CommandDelete{},
-			},
-			{
-				Use:         "disable",
-				Display:     "user disable",
-				Description: "Disable an application user of your Realm app",
-				Help:        "Deactivates a user on your Realm app. A user that has been disabled will not be allowed to log in, even if they provide valid credentials.",
-				Command:     &user.CommandDisable{},
-			},
-			{
-				Use:         "enable",
-				Display:     "user enable",
-				Description: "Enable an application user of your Realm app",
-				Help:        "Activates a user on your Realm app. A user that has been disabled will not be allowed to log in, even if they provide valid credentials.",
-				Command:     &user.CommandEnable{},
-			},
-			{
-				Use:         "list",
-				Description: "List the users of your Realm application",
-				Help:        "user list",
-				Command:     &user.CommandList{},
-			},
-			{
-				Use:         "revoke",
-				Display:     "user revoke",
-				Description: "Revoke an application user’s sessions on your Realm app",
-				Help:        "Logs a user out of your Realm app. A user who’s user session has been revoked can log in again if they provide valid credentials.",
-				Command:     &user.CommandRevoke{},
+				// TODO(REALMC-7662): Document downstream events after deleting a user
+				Help: `Removes a specific user from your Realm app.`,
 			},
 		},
 	}
@@ -169,37 +190,38 @@ from a list of all your Realm apps. The list includes Realm apps from all projec
 	Secrets = cli.CommandDefinition{
 		Use:         "secrets",
 		Aliases:     []string{"secret"},
-		Description: "Manage the secrets of your MongoDB Realm app",
-		Help:        "secrets",
+		Description: "Manage the secrets of your Realm app",
 		SubCommands: []cli.CommandDefinition{
 			{
+				Command:     &secrets.CommandCreate{},
 				Use:         "create",
 				Display:     "secrets create",
-				Description: "Create a secret for your Realm app",
-				Help:        "Adds a new secret to your Realm app. You will be prompted to name your Secret, and define the value of your Secret.",
-				Command:     &secrets.CommandCreate{},
+				Description: "Create a secret in your Realm app",
+				Help: `Adds a new secret to your Realm app. You will be prompted to name your secret
+and define the value of your secret.`,
 			},
 			{
+				Command:     &secrets.CommandList{},
 				Use:         "list",
 				Aliases:     []string{"ls"},
 				Display:     "secrets list",
-				Description: "List the names of secrets in your Realm app",
-				Help:        "Displays a list of data tables. Each data table displays the Name and ID of one (1) secret.",
-				Command:     &secrets.CommandList{},
+				Description: "List the secrets in your Realm app",
+				Help:        `Displays a list of your Realm app's secrets.`,
 			},
 			{
+				Command:     &secrets.CommandUpdate{},
+				Use:         "update",
+				Display:     "secret update",
+				Description: "Update a secret in your Realm app",
+				Help: `Modifies the value of a secret in your Realm app. The name of the secret cannot
+be modified.`,
+			},
+			{
+				Command:     &secrets.CommandDelete{},
 				Use:         "delete",
 				Display:     "secrets delete",
 				Description: "Delete a secret from your Realm app",
-				Help:        "Removes one or many secrets from your Realm app depending on how many you specify.",
-				Command:     &secrets.CommandDelete{},
-			},
-			cli.CommandDefinition{
-				Use:         "update",
-				Display:     "secrets update",
-				Description: "Update a secret in your Realm app",
-				Help:        "Updates one secret from your Realm app. Select the secret to update or provide a name or ID.",
-				Command:     &secrets.CommandUpdate{},
+				Help:        `Removes a secret from your Realm app.`,
 			},
 		},
 	}

--- a/internal/commands/login/command.go
+++ b/internal/commands/login/command.go
@@ -15,8 +15,8 @@ type Command struct {
 
 // Flags is the command flags
 func (cmd *Command) Flags(fs *pflag.FlagSet) {
-	fs.StringVarP(&cmd.inputs.PublicAPIKey, flagPublicAPIKey, flagPublicAPIKeyShort, "", flagPublicAPIKeyUsage)
-	fs.StringVarP(&cmd.inputs.PrivateAPIKey, flagPrivateAPIKey, flagPrivateAPIKeyShort, "", flagPrivateAPIKeyUsage)
+	fs.StringVar(&cmd.inputs.PublicAPIKey, flagPublicAPIKey, "", flagPublicAPIKeyUsage)
+	fs.StringVar(&cmd.inputs.PrivateAPIKey, flagPrivateAPIKey, "", flagPrivateAPIKeyUsage)
 }
 
 // Inputs is the command inputs

--- a/internal/commands/login/inputs.go
+++ b/internal/commands/login/inputs.go
@@ -8,12 +8,10 @@ import (
 
 const (
 	flagPublicAPIKey      = "api-key"
-	flagPublicAPIKeyShort = "u"
-	flagPublicAPIKeyUsage = "this is the --api-key usage"
+	flagPublicAPIKeyUsage = "the public key of your programmatic API Key"
 
 	flagPrivateAPIKey      = "private-api-key"
-	flagPrivateAPIKeyShort = "p"
-	flagPrivateAPIKeyUsage = "this is the --private-api-key usage"
+	flagPrivateAPIKeyUsage = "the private key of your programmatic API Key"
 
 	inputFieldPublicAPIKey  = "publicAPIKey"
 	inputFieldPrivateAPIKey = "privateAPIKey"

--- a/internal/commands/pull/command.go
+++ b/internal/commands/pull/command.go
@@ -11,6 +11,7 @@ import (
 	"github.com/10gen/realm-cli/internal/cloud/realm"
 	"github.com/10gen/realm-cli/internal/local"
 	"github.com/10gen/realm-cli/internal/terminal"
+	"github.com/10gen/realm-cli/internal/utils/flags"
 
 	"github.com/briandowns/spinner"
 	"github.com/spf13/pflag"
@@ -24,12 +25,16 @@ type Command struct {
 // Flags is the command flags
 func (cmd *Command) Flags(fs *pflag.FlagSet) {
 	fs.StringVar(&cmd.inputs.LocalPath, flagLocalPath, "", flagLocalPathUsage)
-	fs.StringVar(&cmd.inputs.Project, flagProject, "", flagProjectUsage)
 	fs.StringVar(&cmd.inputs.RemoteApp, flagRemote, "", flagRemoteUsage)
-	fs.Var(&cmd.inputs.AppVersion, flagAppVersion, flagAppVersionUsage)
-	fs.BoolVarP(&cmd.inputs.DryRun, flagDryRun, flagDryRunShort, false, flagDryRunUsage)
 	fs.BoolVarP(&cmd.inputs.IncludeDependencies, flagIncludeDependencies, flagIncludeDependenciesShort, false, flagIncludeDependenciesUsage)
 	fs.BoolVarP(&cmd.inputs.IncludeHosting, flagIncludeHosting, flagIncludeHostingShort, false, flagIncludeHostingUsage)
+	fs.BoolVarP(&cmd.inputs.DryRun, flagDryRun, flagDryRunShort, false, flagDryRunUsage)
+
+	fs.StringVar(&cmd.inputs.Project, flagProject, "", flagProjectUsage)
+	flags.MarkHidden(fs, flagProject)
+
+	fs.Var(&cmd.inputs.AppVersion, flagConfigVersion, flagConfigVersionUsage)
+	flags.MarkHidden(fs, flagConfigVersion)
 }
 
 // Inputs is the command inputs

--- a/internal/commands/pull/command_test.go
+++ b/internal/commands/pull/command_test.go
@@ -39,7 +39,7 @@ func TestPullHandler(t *testing.T) {
 
 		var realmClient mock.RealmClient
 		realmClient.FindAppsFn = func(filter realm.AppFilter) ([]realm.App, error) {
-			return nil, nil
+			return []realm.App{{ID: "appID", Name: "appName"}}, nil
 		}
 		realmClient.ExportFn = func(groupID, appID string, req realm.ExportRequest) (string, *zip.Reader, error) {
 			return "", nil, errors.New("something bad happened")

--- a/internal/commands/pull/errors.go
+++ b/internal/commands/pull/errors.go
@@ -1,0 +1,10 @@
+package pull
+
+type errProjectNotFound struct {
+}
+
+func (err errProjectNotFound) Error() string {
+	return "must specify --remote or run command from inside a Realm app directory"
+}
+
+func (err errProjectNotFound) DisableUsage() struct{} { return struct{}{} }

--- a/internal/commands/pull/inputs.go
+++ b/internal/commands/pull/inputs.go
@@ -12,29 +12,29 @@ import (
 )
 
 const (
-	flagRemote      = "remote"
-	flagRemoteUsage = "specify the remote app to pull changes down from"
-
-	flagProject      = "project"
-	flagProjectUsage = "the MongoDB cloud project id"
-
-	flagAppVersion      = "app-version"
-	flagAppVersionUsage = "specify the app config version to pull changes down as"
-
 	flagLocalPath      = "local"
 	flagLocalPathUsage = "specify the local path to export a Realm app to"
 
+	flagRemote      = "remote"
+	flagRemoteUsage = "specify the remote app to pull changes down from"
+
 	flagIncludeDependencies      = "include-dependencies"
 	flagIncludeDependenciesShort = "d"
-	flagIncludeDependenciesUsage = "include to to push Realm app dependencies changes as well"
+	flagIncludeDependenciesUsage = "include to to export Realm app dependencies changes as well"
 
 	flagIncludeHosting      = "include-hosting"
 	flagIncludeHostingShort = "s"
-	flagIncludeHostingUsage = "include to push Realm app hosting changes as well"
+	flagIncludeHostingUsage = "include to export Realm app hosting changes as well"
 
 	flagDryRun      = "dry-run"
 	flagDryRunShort = "x"
 	flagDryRunUsage = "include to run without writing any changes to the file system"
+
+	flagProject      = "project"
+	flagProjectUsage = "the MongoDB cloud project id"
+
+	flagConfigVersion      = "config-version"
+	flagConfigVersionUsage = "specify the app config version to export as"
 )
 
 var (
@@ -96,16 +96,16 @@ type appRemote struct {
 
 func (i inputs) resolveRemoteApp(ui terminal.UI, client realm.Client) (appRemote, error) {
 	r := appRemote{GroupID: i.Project}
-
 	if i.RemoteApp == "" {
 		return r, nil
 	}
 
 	app, err := cli.ResolveApp(ui, client, realm.AppFilter{GroupID: i.Project, App: i.RemoteApp})
 	if err != nil {
-		if _, ok := err.(cli.ErrAppNotFound); !ok {
-			return appRemote{}, err
+		if _, ok := err.(cli.ErrAppNotFound); ok {
+			return appRemote{}, errProjectNotFound{}
 		}
+		return appRemote{}, err
 	}
 
 	r.GroupID = app.GroupID

--- a/internal/commands/push/command.go
+++ b/internal/commands/push/command.go
@@ -9,6 +9,7 @@ import (
 	"github.com/10gen/realm-cli/internal/cloud/realm"
 	"github.com/10gen/realm-cli/internal/local"
 	"github.com/10gen/realm-cli/internal/terminal"
+	"github.com/10gen/realm-cli/internal/utils/flags"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/briandowns/spinner"
@@ -17,12 +18,12 @@ import (
 
 // set of supported `push` command strings
 const (
-	CommandUse = "push"
+	CommandUse = "import"
 )
 
 // set of supported `push` command strings
 var (
-	CommandAliases = []string{"import"}
+	CommandAliases = []string{"push"}
 )
 
 // Command is the `push` command
@@ -33,12 +34,14 @@ type Command struct {
 // Flags is the command flags
 func (cmd *Command) Flags(fs *pflag.FlagSet) {
 	fs.StringVar(&cmd.inputs.LocalPath, flagLocalPath, "", flagLocalPathUsage)
-	fs.StringVar(&cmd.inputs.Project, flagProject, "", flagProjectUsage)
 	fs.StringVar(&cmd.inputs.RemoteApp, flagRemote, "", flagRemoteUsage)
-	fs.BoolVarP(&cmd.inputs.DryRun, flagDryRun, flagDryRunShort, false, flagDryRunUsage)
 	fs.BoolVarP(&cmd.inputs.IncludeDependencies, flagIncludeDependencies, flagIncludeDependenciesShort, false, flagIncludeDependenciesUsage)
 	fs.BoolVarP(&cmd.inputs.IncludeHosting, flagIncludeHosting, flagIncludeHostingShort, false, flagIncludeHostingUsage)
 	fs.BoolVarP(&cmd.inputs.ResetCDNCache, flagResetCDNCache, flagResetCDNCacheShort, false, flagResetCDNCacheUsage)
+	fs.BoolVarP(&cmd.inputs.DryRun, flagDryRun, flagDryRunShort, false, flagDryRunUsage)
+
+	fs.StringVar(&cmd.inputs.Project, flagProject, "", flagProjectUsage)
+	flags.MarkHidden(fs, flagProject)
 }
 
 // Inputs is the command inputs

--- a/internal/commands/push/command_test.go
+++ b/internal/commands/push/command_test.go
@@ -625,7 +625,7 @@ func TestPushHandler(t *testing.T) {
 
 				assert.Equal(t, tc.groupsCalled, calledGroups)
 				assert.Equal(t, `01:23:45 UTC INFO  This is a new app. To create a new app, you must omit the 'dry-run' flag to proceed
-01:23:45 UTC DEBUG Try running instead: realm-cli push --local testdata/project --remote appID
+01:23:45 UTC DEBUG Try running instead: realm-cli import --local testdata/project --remote appID
 `, out.String())
 			})
 		}
@@ -701,7 +701,7 @@ func TestPushHandler(t *testing.T) {
 diff1
 diff2
 01:23:45 UTC INFO  To push these changes, you must omit the 'dry-run' flag to proceed
-01:23:45 UTC DEBUG Try running instead: realm-cli push --local testdata/project --remote appID
+01:23:45 UTC DEBUG Try running instead: realm-cli import --local testdata/project --remote appID
 `, out.String())
 	})
 
@@ -1358,18 +1358,18 @@ func TestPushCommandDisplay(t *testing.T) {
 	}{
 		{
 			description: "should print a minimal command string",
-			display:     "realm-cli push",
+			display:     "realm-cli import",
 		},
 		{
 			description: "should print a minimal dry run command string",
 			inputs:      inputs{DryRun: true},
-			display:     "realm-cli push --dry-run",
+			display:     "realm-cli import --dry-run",
 		},
 		{
 			description: "should print a minimal command string with dry run set but omitted",
 			inputs:      inputs{DryRun: true},
 			omitDryRun:  true,
-			display:     "realm-cli push",
+			display:     "realm-cli import",
 		},
 		{
 			description: "should print a complete command string",
@@ -1382,7 +1382,7 @@ func TestPushCommandDisplay(t *testing.T) {
 				ResetCDNCache:       true,
 				DryRun:              true,
 			},
-			display: "realm-cli push --project project --local directory --remote remote --include-dependencies --include-hosting --reset-cdn-cache --dry-run",
+			display: "realm-cli import --project project --local directory --remote remote --include-dependencies --include-hosting --reset-cdn-cache --dry-run",
 		},
 	} {
 		t.Run(tc.description, func(t *testing.T) {

--- a/internal/commands/push/inputs.go
+++ b/internal/commands/push/inputs.go
@@ -10,29 +10,29 @@ import (
 
 const (
 	flagLocalPath      = "local"
-	flagLocalPathUsage = "specify the local path to a Realm app containing the changes to push"
-
-	flagProject      = "project"
-	flagProjectUsage = "the MongoDB cloud project id"
+	flagLocalPathUsage = "specify the local path to a Realm app to import"
 
 	flagRemote      = "remote"
-	flagRemoteUsage = "specify a remote Realm app to push changes towards"
+	flagRemoteUsage = "specify a remote Realm app (id or name) to push changes to"
+
+	flagIncludeDependencies      = "include-dependencies"
+	flagIncludeDependenciesShort = "d"
+	flagIncludeDependenciesUsage = "include to import Realm app dependencies changes as well"
+
+	flagIncludeHosting      = "include-hosting"
+	flagIncludeHostingShort = "s"
+	flagIncludeHostingUsage = "include to import Realm app hosting changes as well"
+
+	flagResetCDNCache      = "reset-cdn-cache"
+	flagResetCDNCacheShort = "c"
+	flagResetCDNCacheUsage = "include to reset the Realm app hosting CDN cache"
 
 	flagDryRun      = "dry-run"
 	flagDryRunShort = "x"
 	flagDryRunUsage = "include to run without pushing any changes to the Realm server"
 
-	flagIncludeDependencies      = "include-dependencies"
-	flagIncludeDependenciesShort = "d"
-	flagIncludeDependenciesUsage = "include to push Realm app dependencies changes as well"
-
-	flagIncludeHosting      = "include-hosting"
-	flagIncludeHostingShort = "s"
-	flagIncludeHostingUsage = "include to push Realm app hosting changes as well"
-
-	flagResetCDNCache      = "reset-cdn-cache"
-	flagResetCDNCacheShort = "c"
-	flagResetCDNCacheUsage = "include to reset the Realm app hosting CDN cache"
+	flagProject      = "project"
+	flagProjectUsage = "the MongoDB cloud project id"
 )
 
 type appRemote struct {

--- a/internal/commands/secrets/inputs.go
+++ b/internal/commands/secrets/inputs.go
@@ -4,16 +4,16 @@ package secrets
 const (
 	flagName            = "name"
 	flagNameShort       = "n"
-	flagNameUsageCreate = "the name of the secret to add to your Realm App"
-	flagNameUsageUpdate = "the new name for the secret"
+	flagNameUsageCreate = "the name of the secret"
+	flagNameUsageUpdate = "the new name of the secret"
 
 	flagValue            = "value"
 	flagValueShort       = "v"
-	flagValueUsageCreate = "the value of the secret to add to your Realm App"
-	flagValueUsageUpdate = "the new value for the secret"
+	flagValueUsageCreate = "the value of the secret"
+	flagValueUsageUpdate = "the new value of the secret"
 
 	flagSecret            = "secret"
 	flagSecretShort       = "s"
-	flagSecretUsageUpdate = "ID or name of the secret to update"
-	flagSecretUsageDelete = "set the list of secrets to delete by ID or Name"
+	flagSecretUsageUpdate = "the name or id of the secret to update"
+	flagSecretUsageDelete = "the name or id of the secret to delete"
 )

--- a/internal/commands/user/create.go
+++ b/internal/commands/user/create.go
@@ -18,10 +18,10 @@ type CommandCreate struct {
 func (cmd *CommandCreate) Flags(fs *pflag.FlagSet) {
 	cmd.inputs.Flags(fs)
 
-	fs.VarP(&cmd.inputs.UserType, flagUserType, flagUserTypeShort, flagUserTypeUsage)
-	fs.StringVarP(&cmd.inputs.Email, flagEmail, flagEmailShort, "", flagEmailUsage)
-	fs.StringVarP(&cmd.inputs.Password, flagPassword, flagPasswordShort, "", flagPasswordUsage)
-	fs.StringVarP(&cmd.inputs.APIKeyName, flagAPIKeyName, flagAPIKeyNameShort, "", flagAPIKeyNameUsage)
+	fs.Var(&cmd.inputs.UserType, flagUserType, flagUserTypeUsage)
+	fs.StringVar(&cmd.inputs.APIKeyName, flagAPIKeyName, "", flagAPIKeyNameUsage)
+	fs.StringVar(&cmd.inputs.Email, flagEmail, "", flagEmailUsage)
+	fs.StringVar(&cmd.inputs.Password, flagPassword, "", flagPasswordUsage)
 }
 
 // Inputs is the command inputs

--- a/internal/commands/user/create_inputs.go
+++ b/internal/commands/user/create_inputs.go
@@ -14,19 +14,15 @@ import (
 
 const (
 	flagUserType      = "type"
-	flagUserTypeShort = "t"
 	flagUserTypeUsage = `select the type of user to create, available options: ["api-key", "email"]`
 
 	flagEmail      = "email"
-	flagEmailShort = "u"
 	flagEmailUsage = "sets the email of the user to be created"
 
 	flagPassword      = "password"
-	flagPasswordShort = "p"
 	flagPasswordUsage = "sets the password of the user to be created"
 
 	flagAPIKeyName      = "name"
-	flagAPIKeyNameShort = "n"
 	flagAPIKeyNameUsage = "sets the name of the api key to be created"
 )
 

--- a/internal/commands/user/delete.go
+++ b/internal/commands/user/delete.go
@@ -21,14 +21,13 @@ type CommandDelete struct {
 func (cmd *CommandDelete) Flags(fs *pflag.FlagSet) {
 	cmd.inputs.Flags(fs)
 	fs.StringSliceVarP(&cmd.inputs.Users, flagUser, flagUserShort, []string{}, flagUserDeleteUsage)
-	fs.VarP(
+	fs.BoolVar(&cmd.inputs.Pending, flagPending, false, flagPendingUsage)
+	fs.Var(&cmd.inputs.State, flagState, flagStateUsage)
+	fs.Var(
 		flags.NewEnumSet(&cmd.inputs.ProviderTypes, validAuthProviderTypes()),
 		flagProvider,
-		flagProviderShort,
 		flagProviderUsage,
 	)
-	fs.VarP(&cmd.inputs.State, flagState, flagStateShort, flagStateUsage)
-	fs.BoolVarP(&cmd.inputs.Pending, flagPending, flagPendingShort, false, flagPendingUsage)
 }
 
 // Inputs is the command inputs

--- a/internal/commands/user/flags.go
+++ b/internal/commands/user/flags.go
@@ -2,23 +2,20 @@ package user
 
 const (
 	flagState      = "state"
-	flagStateShort = "s"
 	flagStateUsage = `select the state of users to list, available options: ["enabled", "disabled"]`
 
 	flagPending      = "pending"
-	flagPendingShort = "p"
-	flagPendingUsage = `select to show users with pending status`
+	flagPendingUsage = `include to show users with pending status`
 
 	flagProvider      = "provider"
-	flagProviderShort = "t"
 	flagProviderUsage = `set the provider types for which to filter the list of app users with, available options: ` +
 		`["local-userpass", "api-key", "oauth2-facebook", "oauth2-google", "oauth2-apple", ` +
 		`"anon-user", "custom-token", "custom-function"]`
 
 	flagUser             = "user"
 	flagUserShort        = "u"
-	flagUserUsage        = `set the user ids for which to filter the list of app users with`
-	flagUserDeleteUsage  = `set the user ids for which to delete from the app`
+	flagUserListUsage    = `set the user ids for which to filter the list of app users with`
+	flagUserDeleteUsage  = `set the user ids for which to delete in the app`
 	flagUserDisableUsage = `set the user ids for which to disable in the app`
 	flagUserEnableUsage  = `set the user ids for which to enable in the app`
 	flagUserRevokeUsage  = `set the user ids for which to revoke sessions from`

--- a/internal/commands/user/list.go
+++ b/internal/commands/user/list.go
@@ -27,15 +27,14 @@ type listInputs struct {
 func (cmd *CommandList) Flags(fs *pflag.FlagSet) {
 	cmd.inputs.Flags(fs)
 
-	fs.VarP(&cmd.inputs.State, flagState, flagStateShort, flagStateUsage)
-	fs.BoolVarP(&cmd.inputs.Pending, flagPending, flagPendingShort, false, flagPendingUsage)
-	fs.VarP(
+	fs.StringSliceVarP(&cmd.inputs.Users, flagUser, flagUserShort, []string{}, flagUserListUsage)
+	fs.BoolVar(&cmd.inputs.Pending, flagPending, false, flagPendingUsage)
+	fs.Var(&cmd.inputs.State, flagState, flagStateUsage)
+	fs.Var(
 		flags.NewEnumSet(&cmd.inputs.ProviderTypes, validAuthProviderTypes()),
 		flagProvider,
-		flagProviderShort,
 		flagProviderUsage,
 	)
-	fs.StringSliceVarP(&cmd.inputs.Users, flagUser, flagUserShort, []string{}, flagUserUsage)
 }
 
 // Inputs is the command inputs

--- a/internal/commands/user/revoke.go
+++ b/internal/commands/user/revoke.go
@@ -21,14 +21,13 @@ type CommandRevoke struct {
 func (cmd *CommandRevoke) Flags(fs *pflag.FlagSet) {
 	cmd.inputs.Flags(fs)
 	fs.StringSliceVarP(&cmd.inputs.Users, flagUser, flagUserShort, []string{}, flagUserRevokeUsage)
-	fs.VarP(
+	fs.BoolVar(&cmd.inputs.Pending, flagPending, false, flagPendingUsage)
+	fs.Var(&cmd.inputs.State, flagState, flagStateUsage)
+	fs.Var(
 		flags.NewEnumSet(&cmd.inputs.ProviderTypes, validAuthProviderTypes()),
 		flagProvider,
-		flagProviderShort,
 		flagProviderUsage,
 	)
-	fs.VarP(&cmd.inputs.State, flagState, flagStateShort, flagStateUsage)
-	fs.BoolVarP(&cmd.inputs.Pending, flagPending, flagPendingShort, false, flagPendingUsage)
 }
 
 // Inputs is the command inputs

--- a/internal/telemetry/flags.go
+++ b/internal/telemetry/flags.go
@@ -10,7 +10,6 @@ import (
 // set of supported telemetry flags
 const (
 	FlagMode      = "telemetry"
-	FlagModeShort = "m"
 	FlagModeUsage = `enable or disable telemetry (this setting is remembered), available options: ["off", "on"]`
 )
 

--- a/internal/terminal/flags.go
+++ b/internal/terminal/flags.go
@@ -8,7 +8,6 @@ import (
 )
 
 // set of supported terminal flags
-// TODO(REALMC-7429): fill out the flag usages
 const (
 	FlagAutoConfirm      = "yes"
 	FlagAutoConfirmShort = "y"

--- a/internal/utils/flags/flags.go
+++ b/internal/utils/flags/flags.go
@@ -1,0 +1,11 @@
+package flags
+
+import "github.com/spf13/pflag"
+
+// MarkHidden marks the specified flag as hidden from the provided flag set
+// TODO(REALMC-8369): this method should go away if/when we can get
+// golangci-lint to play nicely with errcheck and our exclude .errcheck file
+// For now, we use this to isolate and minimize the nolint directives in this repo
+func MarkHidden(fs *pflag.FlagSet, name string) {
+	fs.MarkHidden(name) //nolint: errcheck
+}


### PR DESCRIPTION
looking for all kinds of thoughts/suggestions here.  a bulk of these changes are centered around:
* sorting the commands/flags so they appeared logically and consistently
* trying to keep language consistent across the various command texts
* removing most shorthands for flags, some of them became pretty unintuitive (e.g. `s` for `include-hosting`??) and i think the better approach here long-term would be figuring out proper auto-complete
* various command text cleanups with regards to spacing and such