### PR TITLE
REALMC-8444: Disable Segment tracking output

### DIFF
--- a/internal/telemetry/service_test.go
+++ b/internal/telemetry/service_test.go
@@ -33,13 +33,6 @@ func TestNewService(t *testing.T) {
 		segmentWriteKey = "testing"
 		testServiceOutput(t, ModeOn, "")
 	})
-
-	t.Run("Should disable the service if the segmentWriteKey is empty", func(t *testing.T) {
-		swk := segmentWriteKey
-		defer func() { segmentWriteKey = swk }()
-		segmentWriteKey = ""
-		testServiceOutput(t, ModeOn, "LogPrefix unable to connect to Segment due to missing key, CLI telemetry will be disabled\n")
-	})
 }
 
 func TestServiceTrackEvent(t *testing.T) {

--- a/internal/telemetry/tracker.go
+++ b/internal/telemetry/tracker.go
@@ -40,7 +40,6 @@ type segmentTracker struct {
 
 func newSegmentTracker(logger *log.Logger) Tracker {
 	if len(segmentWriteKey) == 0 {
-		logger.Print("unable to connect to Segment due to missing key, CLI telemetry will be disabled")
 		return &noopTracker{}
 	}
 	client := analytics.New(segmentWriteKey)


### PR DESCRIPTION
segment key is currently not populated, resulting in an awkward `12:17:34 UTC ERROR unable to connect to Segment due to missing key, CLI telemetry will be disabled` message being printed for every command. we probably shouldn't ever log this.

will get the segment key populated as a separate ticket, but this is fine for now