### PR TITLE
REALMC-8451: Ensure all segment events are flushed

### DIFF
--- a/internal/cli/command_factory.go
+++ b/internal/cli/command_factory.go
@@ -144,6 +144,12 @@ func (factory *CommandFactory) Build(command CommandDefinition) *cobra.Command {
 
 // Close closes the command factory
 func (factory *CommandFactory) Close() {
+	if factory.telemetryService != nil {
+		if err := factory.telemetryService.Close(); err != nil {
+			factory.errLogger.Print(err)
+		}
+	}
+
 	if factory.uiConfig.OutputTarget != "" {
 		factory.outWriter.Close()
 	}

--- a/internal/telemetry/service.go
+++ b/internal/telemetry/service.go
@@ -47,3 +47,8 @@ func (service *Service) TrackEvent(eventType EventType, data ...EventData) {
 		data:        data,
 	})
 }
+
+// Close shuts down the Service
+func (service Service) Close() error {
+	return service.tracker.Close()
+}

--- a/internal/telemetry/service_test.go
+++ b/internal/telemetry/service_test.go
@@ -65,6 +65,10 @@ func (tracker *testTracker) Track(event event) {
 	tracker.lastTrackedEvent = event
 }
 
+func (tracker *testTracker) Close() error {
+	return nil
+}
+
 func newService(mode Mode, logger *log.Logger) *Service {
 	return NewService(mode, testUser, logger, testCommand)
 }

--- a/internal/telemetry/tracker.go
+++ b/internal/telemetry/tracker.go
@@ -15,11 +15,15 @@ var (
 // Tracker is a telemetry event tracker
 type Tracker interface {
 	Track(event event)
+	Close() error
 }
 
 type noopTracker struct{}
 
 func (tracker *noopTracker) Track(event event) {}
+func (tracker *noopTracker) Close() error {
+	return nil
+}
 
 type stdoutTracker struct{}
 
@@ -31,6 +35,10 @@ func (tracker *stdoutTracker) Track(event event) {
 		event.eventType,
 		event.data,
 	)
+}
+
+func (tracker *stdoutTracker) Close() error {
+	return nil
 }
 
 type segmentTracker struct {
@@ -63,4 +71,9 @@ func (tracker *segmentTracker) Track(event event) {
 	}); err != nil {
 		tracker.logger.Printf("failed to send Segment event %q: %s", event.eventType, err)
 	}
+}
+
+func (tracker *segmentTracker) Close() error {
+	// flush the client on close so that all queued events are sent
+	return tracker.client.Close()
 }


### PR DESCRIPTION
the Segment library batches enqueued events until either the batch limit is hit, or a certain amount of time has elapsed (see https://segment.com/docs/connections/sources/catalog/libraries/server/go/), which was preventing events from being sent (since the program would exit before this happened).

you can create a new analytics client with a config and set the batch size to 1 according to the docs I linked agove, but I tried this and the program still exits before dispatching the events to segment. this seems to be the best way to force a flush.

I also think we need to revisit some of this soon for the case where users are blocking calls to segment and/or paranoid about tracking. I tried this with Little Snitch and it's really noisy (the Segment library uses it's own logger by default, which prints to stderr in the event of this sort of failure... it supports passing a custom logger, which we could use to minimize this and/or send errors directly to our servers instead).