### PR TITLE
REALMC-8613: Remove timestamp and log level from text messages

### DIFF
--- a/internal/cli/command_factory.go
+++ b/internal/cli/command_factory.go
@@ -25,23 +25,17 @@ type CommandFactory struct {
 	inReader         *os.File
 	outWriter        *os.File
 	errWriter        *os.File
-	errLogger        *log.Logger
 	telemetryService *telemetry.Service
 }
 
 // NewCommandFactory creates a new command factory
 func NewCommandFactory() *CommandFactory {
-	errLogger := log.New(os.Stderr, "UTC ERROR ", log.Ltime|log.Lmsgprefix)
-
 	profile, profileErr := NewDefaultProfile()
 	if profileErr != nil {
-		errLogger.Fatal(profileErr)
+		log.Fatal(profileErr)
 	}
 
-	return &CommandFactory{
-		profile:   profile,
-		errLogger: errLogger,
-	}
+	return &CommandFactory{profile: profile}
 }
 
 // Build builds a Cobra command from the specified CommandDefinition
@@ -159,7 +153,7 @@ func (factory *CommandFactory) Run(cmd *cobra.Command) {
 		handleUsage(cmd, err)
 
 		if factory.ui == nil {
-			factory.errLogger.Fatal(err)
+			log.Fatal(err)
 		}
 
 		logs := []terminal.Log{terminal.NewErrorLog(err)}
@@ -200,13 +194,13 @@ func (factory *CommandFactory) SetGlobalFlags(fs *pflag.FlagSet) {
 // Setup initializes the command factory
 func (factory *CommandFactory) Setup() {
 	if err := factory.profile.Load(); err != nil {
-		factory.errLogger.Fatal(err)
+		log.Fatal(err)
 	}
 
 	if filepath := factory.uiConfig.OutputTarget; filepath != "" {
 		f, err := os.OpenFile(filepath, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0660)
 		if err != nil {
-			factory.errLogger.Fatal(fmt.Errorf("failed to open target file: %w", err))
+			log.Fatal(fmt.Errorf("failed to open target file: %w", err))
 		}
 		factory.outWriter = f
 	}
@@ -230,7 +224,7 @@ func (factory *CommandFactory) ensureUI() {
 	}
 
 	if factory.ui == nil {
-		factory.ui = terminal.NewUI(factory.uiConfig, factory.inReader, factory.outWriter, factory.errWriter, factory.errLogger)
+		factory.ui = terminal.NewUI(factory.uiConfig, factory.inReader, factory.outWriter, factory.errWriter)
 	}
 }
 

--- a/internal/commands/app/create_test.go
+++ b/internal/commands/app/create_test.go
@@ -109,13 +109,13 @@ func TestAppCreateHandler(t *testing.T) {
 		fmtStr := fmt.Sprintf("%%-%ds", dirLength)
 
 		assert.Equal(t, strings.Join([]string{
-			"01:23:45 UTC INFO  Successfully created app",
+			"Successfully created app",
 			fmt.Sprintf("  Info             "+fmtStr, "Details"),
 			"  ---------------  " + strings.Repeat("-", dirLength),
 			fmt.Sprintf("  Client App ID    "+fmtStr, "test-app-abcde"),
 			"  Realm Directory  " + appLocal.RootDir,
 			fmt.Sprintf("  Realm UI         "+fmtStr, "http://localhost:8080/groups/123/apps/456/dashboard"),
-			"01:23:45 UTC DEBUG Check out your app: cd ./test-app && realm-cli app describe",
+			"Check out your app: cd ./test-app && realm-cli app describe",
 			"",
 		}, "\n"), out.String())
 
@@ -383,13 +383,13 @@ func TestAppCreateHandler(t *testing.T) {
 		fmtStr := fmt.Sprintf("%%-%ds", dirLength)
 
 		assert.Equal(t, strings.Join([]string{
-			"01:23:45 UTC INFO  Successfully created app",
+			"Successfully created app",
 			fmt.Sprintf("  Info             "+fmtStr, "Details"),
 			"  ---------------  " + strings.Repeat("-", dirLength),
 			fmt.Sprintf("  Client App ID    "+fmtStr, "remote-app-abcde"),
 			"  Realm Directory  " + appLocal.RootDir,
 			fmt.Sprintf("  Realm UI         "+fmtStr, "http://localhost:8080/groups/123/apps/456/dashboard"),
-			"01:23:45 UTC DEBUG Check out your app: cd ./remote-app && realm-cli app describe",
+			"Check out your app: cd ./remote-app && realm-cli app describe",
 			"",
 		}, "\n"), out.String())
 	})
@@ -499,7 +499,7 @@ func TestAppCreateHandler(t *testing.T) {
 			}
 
 			display := make([]string, 0, 10)
-			display = append(display, "01:23:45 UTC INFO  Successfully created app",
+			display = append(display, "Successfully created app",
 				fmt.Sprintf("  Info                   "+spaceBuffer+fmtStr, "Details"),
 				"  ---------------------"+dashBuffer+"  "+strings.Repeat("-", dirLength),
 				fmt.Sprintf("  Client App ID          "+spaceBuffer+fmtStr, "test-app-abcde"),
@@ -512,7 +512,7 @@ func TestAppCreateHandler(t *testing.T) {
 			if tc.dataLake != "" {
 				display = append(display, fmt.Sprintf("  Data Source (Data Lake)  "+fmtStr, "mongodb-datalake"))
 			}
-			display = append(display, "01:23:45 UTC DEBUG Check out your app: cd ./test-app && realm-cli app describe", "")
+			display = append(display, "Check out your app: cd ./test-app && realm-cli app describe", "")
 			assert.Equal(t, strings.Join(display, "\n"), out.String())
 		})
 	}
@@ -537,8 +537,8 @@ func TestAppCreateHandler(t *testing.T) {
 			description: "should create a minimal project dry run",
 			displayExpected: func(dir string, cmd *CommandCreate) string {
 				return strings.Join([]string{
-					fmt.Sprintf("01:23:45 UTC INFO  A minimal Realm app would be created at %s", dir),
-					"01:23:45 UTC DEBUG To create this app run: " + cmd.display(true),
+					fmt.Sprintf("A minimal Realm app would be created at %s", dir),
+					"To create this app run: " + cmd.display(true),
 					"",
 				}, "\n")
 			},
@@ -555,8 +555,8 @@ func TestAppCreateHandler(t *testing.T) {
 			},
 			displayExpected: func(dir string, cmd *CommandCreate) string {
 				return strings.Join([]string{
-					fmt.Sprintf("01:23:45 UTC INFO  A Realm app based on the Realm app 'remote-app' would be created at %s", dir),
-					"01:23:45 UTC DEBUG To create this app run: " + cmd.display(true),
+					fmt.Sprintf("A Realm app based on the Realm app 'remote-app' would be created at %s", dir),
+					"To create this app run: " + cmd.display(true),
 					"",
 				}, "\n")
 			},
@@ -573,9 +573,9 @@ func TestAppCreateHandler(t *testing.T) {
 			},
 			displayExpected: func(dir string, cmd *CommandCreate) string {
 				return strings.Join([]string{
-					fmt.Sprintf("01:23:45 UTC INFO  A minimal Realm app would be created at %s", dir),
-					"01:23:45 UTC INFO  The cluster 'test-cluster' would be linked as data source 'mongodb-atlas'",
-					"01:23:45 UTC DEBUG To create this app run: " + cmd.display(true),
+					fmt.Sprintf("A minimal Realm app would be created at %s", dir),
+					"The cluster 'test-cluster' would be linked as data source 'mongodb-atlas'",
+					"To create this app run: " + cmd.display(true),
 					"",
 				}, "\n")
 			},
@@ -592,9 +592,9 @@ func TestAppCreateHandler(t *testing.T) {
 			},
 			displayExpected: func(dir string, cmd *CommandCreate) string {
 				return strings.Join([]string{
-					fmt.Sprintf("01:23:45 UTC INFO  A minimal Realm app would be created at %s", dir),
-					"01:23:45 UTC INFO  The data lake 'test-datalake' would be linked as data source 'mongodb-datalake'",
-					"01:23:45 UTC DEBUG To create this app run: " + cmd.display(true),
+					fmt.Sprintf("A minimal Realm app would be created at %s", dir),
+					"The data lake 'test-datalake' would be linked as data source 'mongodb-datalake'",
+					"To create this app run: " + cmd.display(true),
 					"",
 				}, "\n")
 			},

--- a/internal/commands/app/delete_inputs.go
+++ b/internal/commands/app/delete_inputs.go
@@ -53,7 +53,7 @@ func (inputs *deleteInputs) resolveApps(ui terminal.UI, client realm.Client) ([]
 
 		if len(missingApps) > 0 {
 			ui.Print(terminal.NewWarningLog(
-				"unable to delete certain apps because they were not found: %s",
+				"Unable to delete certain apps because they were not found: %s",
 				strings.Join(missingApps, ", "),
 			))
 		}

--- a/internal/commands/app/delete_inputs_test.go
+++ b/internal/commands/app/delete_inputs_test.go
@@ -118,7 +118,7 @@ func TestResolveApps(t *testing.T) {
 			inputs := deleteInputs{Apps: []string{"nonexistent", "app1"}}
 			apps, err := inputs.resolveApps(ui, realmClient)
 			assert.Nil(t, err)
-			assert.Equal(t, "01:23:45 UTC WARN  unable to delete certain apps because they were not found: nonexistent\n", out.String())
+			assert.Equal(t, "Unable to delete certain apps because they were not found: nonexistent\n", out.String())
 			assert.Equal(t, []realm.App{app1}, apps)
 		})
 
@@ -133,7 +133,7 @@ func TestResolveApps(t *testing.T) {
 			inputs := deleteInputs{Apps: []string{"nonexistent", "missing"}}
 			apps, err := inputs.resolveApps(ui, realmClient)
 			assert.Nil(t, err)
-			assert.Equal(t, "01:23:45 UTC WARN  unable to delete certain apps because they were not found: nonexistent, missing\n", out.String())
+			assert.Equal(t, "Unable to delete certain apps because they were not found: nonexistent, missing\n", out.String())
 			assert.Equal(t, []realm.App{}, apps)
 		})
 	})

--- a/internal/commands/app/delete_test.go
+++ b/internal/commands/app/delete_test.go
@@ -48,7 +48,7 @@ func TestAppDeleteHandler(t *testing.T) {
 	}{
 		{
 			description:    "should delete no apps if none are found",
-			expectedOutput: "01:23:45 UTC INFO  No apps to delete\n",
+			expectedOutput: "No apps to delete\n",
 		},
 		{
 			description:  "with no project flag set and an apps flag set should delete all apps that match the apps flag",
@@ -57,7 +57,7 @@ func TestAppDeleteHandler(t *testing.T) {
 			expectedApps: []string{appID1},
 			expectedOutput: strings.Join(
 				[]string{
-					"01:23:45 UTC INFO  Successfully deleted 1/1 app(s)",
+					"Successfully deleted 1/1 app(s)",
 					"  ID                        Name  Deleted  Details",
 					"  ------------------------  ----  -------  -------",
 					"  60344735b37e3733de2adf40  app1  true            ",
@@ -73,7 +73,7 @@ func TestAppDeleteHandler(t *testing.T) {
 			expectedApps: []string{appID1, appID3},
 			expectedOutput: strings.Join(
 				[]string{
-					"01:23:45 UTC INFO  Successfully deleted 2/2 app(s)",
+					"Successfully deleted 2/2 app(s)",
 					"  ID                        Name  Deleted  Details",
 					"  ------------------------  ----  -------  -------",
 					"  60344735b37e3733de2adf40  app1  true            ",
@@ -91,7 +91,7 @@ func TestAppDeleteHandler(t *testing.T) {
 			deleteErr:    errors.New("client error"),
 			expectedOutput: strings.Join(
 				[]string{
-					"01:23:45 UTC INFO  Successfully deleted 0/1 app(s)",
+					"Successfully deleted 0/1 app(s)",
 					"  ID                        Name  Deleted  Details     ",
 					"  ------------------------  ----  -------  ------------",
 					"  60344735b37e3733de2adf40  app1  false    client error",

--- a/internal/commands/app/describe_test.go
+++ b/internal/commands/app/describe_test.go
@@ -213,7 +213,7 @@ func TestAppDescribeHandler(t *testing.T) {
 		cmd := &CommandDescribe{inputs: describeInputs{cli.ProjectInputs{App: "test-app-abcde"}}}
 		assert.Nil(t, cmd.Handler(nil, ui, cli.Clients{Realm: realmClient}))
 
-		assert.Equal(t, `01:23:45 UTC INFO  App description
+		assert.Equal(t, `App description
 {
   "client_app_id": "todo-abcde",
   "name": "todo",

--- a/internal/commands/app/diff_test.go
+++ b/internal/commands/app/diff_test.go
@@ -36,27 +36,27 @@ func TestAppDiffHandler(t *testing.T) {
 		{
 			description:        "with no project nor app flag set should diff based on input",
 			expectedDiff:       []string{"diff1"},
-			expectedDiffOutput: "01:23:45 UTC INFO  The following reflects the proposed changes to your Realm app\ndiff1\n",
+			expectedDiffOutput: "The following reflects the proposed changes to your Realm app\ndiff1\n",
 		},
 		{
 			description:        "with no project flag set and an app flag set should show the diff for the app",
 			inputs:             diffInputs{LocalPath: "testdata/project", ProjectInputs: cli.ProjectInputs{App: "app1"}},
 			expectedAppFilter:  realm.AppFilter{App: "app1"},
 			expectedDiff:       []string{"diff1"},
-			expectedDiffOutput: "01:23:45 UTC INFO  The following reflects the proposed changes to your Realm app\ndiff1\n",
+			expectedDiffOutput: "The following reflects the proposed changes to your Realm app\ndiff1\n",
 		},
 		{
 			description:        "with no diffs between local and remote app",
 			inputs:             diffInputs{LocalPath: "testdata/project", ProjectInputs: cli.ProjectInputs{App: "app1"}},
 			expectedAppFilter:  realm.AppFilter{App: "app1"},
-			expectedDiffOutput: "01:23:45 UTC INFO  Deployed app is identical to proposed version\n",
+			expectedDiffOutput: "Deployed app is identical to proposed version\n",
 		},
 		{
 			description:        "with a project flag set and no app flag set should diff based on input",
 			inputs:             diffInputs{LocalPath: "testdata/project", ProjectInputs: cli.ProjectInputs{Project: groupID1}},
 			expectedAppFilter:  realm.AppFilter{GroupID: groupID1},
 			expectedDiff:       []string{"diff1"},
-			expectedDiffOutput: "01:23:45 UTC INFO  The following reflects the proposed changes to your Realm app\ndiff1\n",
+			expectedDiffOutput: "The following reflects the proposed changes to your Realm app\ndiff1\n",
 		},
 		{
 			description:       "error on the diff",
@@ -111,7 +111,7 @@ func TestAppDiffHandler(t *testing.T) {
 		cmd := &CommandDiff{diffInputs{IncludeDependencies: true}}
 		assert.Equal(t, nil, cmd.Handler(nil, ui, cli.Clients{Realm: realmClient}))
 
-		assert.Equal(t, `01:23:45 UTC INFO  The following reflects the proposed changes to your Realm app
+		assert.Equal(t, `The following reflects the proposed changes to your Realm app
 diff1
 diff2
 + New function dependencies
@@ -144,7 +144,7 @@ diff2
 		cmd := &CommandDiff{diffInputs{LocalPath: "testdata/diff", IncludeHosting: true}}
 		assert.Equal(t, nil, cmd.Handler(profile, ui, cli.Clients{Realm: realmClient}))
 
-		assert.Equal(t, `01:23:45 UTC INFO  The following reflects the proposed changes to your Realm app
+		assert.Equal(t, `The following reflects the proposed changes to your Realm app
 diff1
 diff2
 New hosting files

--- a/internal/commands/app/init_test.go
+++ b/internal/commands/app/init_test.go
@@ -37,7 +37,7 @@ func TestAppInitHandler(t *testing.T) {
 		data, err := ioutil.ReadFile(filepath.Join(profile.WorkingDirectory, local.FileRealmConfig.String()))
 		assert.Nil(t, err)
 
-		assert.Equal(t, "01:23:45 UTC INFO  Successfully initialized app\n", out.String())
+		assert.Equal(t, "Successfully initialized app\n", out.String())
 
 		var config local.AppRealmConfigJSON
 		assert.Nil(t, json.Unmarshal(data, &config))
@@ -152,7 +152,7 @@ func TestAppInitHandler(t *testing.T) {
 
 		assert.Nil(t, cmd.Handler(profile, ui, cli.Clients{Realm: client}))
 
-		assert.Equal(t, "01:23:45 UTC INFO  Successfully initialized app\n", out.String())
+		assert.Equal(t, "Successfully initialized app\n", out.String())
 
 		t.Run("should have the expected contents in the app config file", func(t *testing.T) {
 			data, readErr := ioutil.ReadFile(filepath.Join(profile.WorkingDirectory, local.FileRealmConfig.String()))

--- a/internal/commands/app/list_test.go
+++ b/internal/commands/app/list_test.go
@@ -74,7 +74,7 @@ func TestAppListHandler(t *testing.T) {
 			assert.Nil(t, cmd.Handler(nil, ui, cli.Clients{Realm: realmClient}))
 
 			assert.Equal(t, tc.expectedAppFilter, appFilter)
-			assert.Equal(t, fmt.Sprintf(`01:23:45 UTC INFO  Found 3 apps
+			assert.Equal(t, fmt.Sprintf(`Found 3 apps
   app1-abcde (%s)
   app2-abcde (%s)
   app1-fghij (%s)

--- a/internal/commands/function/command_test.go
+++ b/internal/commands/function/command_test.go
@@ -54,7 +54,7 @@ func TestFunctionHandler(t *testing.T) {
 		}}
 		assert.Nil(t, cmd.Handler(profile, ui, clients))
 
-		display := `01:23:45 UTC INFO  Result
+		display := `Result
 {
   "arg": [
     "hello",
@@ -115,7 +115,7 @@ func TestFunctionHandler(t *testing.T) {
 		}}
 		assert.Nil(t, cmd.Handler(profile, ui, clients))
 
-		display := `01:23:45 UTC INFO  Result
+		display := `Result
 {
   "arg1": {
     "abcs": [

--- a/internal/commands/login/command_test.go
+++ b/internal/commands/login/command_test.go
@@ -176,7 +176,7 @@ func TestLoginFeedback(t *testing.T) {
 		err := cmd.Handler(tc.profile, ui, cli.Clients{Realm: tc.realmClient})
 		assert.Nil(t, err)
 
-		assert.Equal(t, "01:23:45 UTC INFO  Successfully logged in\n", out.String())
+		assert.Equal(t, "Successfully logged in\n", out.String())
 	})
 }
 

--- a/internal/commands/logout/command_test.go
+++ b/internal/commands/logout/command_test.go
@@ -72,6 +72,6 @@ func TestLogoutFeedback(t *testing.T) {
 
 		assert.Nil(t, cmd.Handler(profile, ui, cli.Clients{}))
 
-		assert.Equal(t, "01:23:45 UTC INFO  Successfully logged out\n", out.String())
+		assert.Equal(t, "Successfully logged out\n", out.String())
 	})
 }

--- a/internal/commands/pull/command_test.go
+++ b/internal/commands/pull/command_test.go
@@ -74,8 +74,8 @@ func TestPullHandler(t *testing.T) {
 			assert.Nil(t, cmd.Handler(profile, ui, cli.Clients{Realm: realmClient}))
 			destination := filepath.Join(profile.WorkingDirectory, "app")
 
-			assert.Equal(t, `01:23:45 UTC INFO  No changes were written to your file system
-01:23:45 UTC DEBUG Contents would have been written to: app
+			assert.Equal(t, `No changes were written to your file system
+Contents would have been written to: app
 `, out.String())
 
 			_, err := os.Stat(destination)
@@ -93,8 +93,8 @@ func TestPullHandler(t *testing.T) {
 			assert.Nil(t, cmd.Handler(profile, ui, cli.Clients{Realm: realmClient}))
 			destination := filepath.Join(profile.WorkingDirectory, "app")
 
-			assert.Equal(t, `01:23:45 UTC INFO  Saved app to disk
-01:23:45 UTC INFO  Successfully pulled app down: app
+			assert.Equal(t, `Saved app to disk
+Successfully pulled app down: app
 `, out.String())
 
 			_, err := os.Stat(destination)
@@ -132,8 +132,8 @@ func TestPullHandler(t *testing.T) {
 
 			assert.Nil(t, cmd.Handler(profile, ui, cli.Clients{Realm: realmClient}))
 
-			assert.Equal(t, `01:23:45 UTC INFO  Saved app to disk
-01:23:45 UTC INFO  Successfully pulled app down: app
+			assert.Equal(t, `Saved app to disk
+Successfully pulled app down: app
 `, out.String())
 		})
 
@@ -178,9 +178,9 @@ func TestPullHandler(t *testing.T) {
 		cmd := &Command{inputs{LocalPath: "app", IncludeDependencies: true}}
 
 		assert.Nil(t, cmd.Handler(profile, ui, cli.Clients{Realm: realmClient}))
-		assert.Equal(t, `01:23:45 UTC INFO  Saved app to disk
-01:23:45 UTC INFO  Fetched dependencies archive
-01:23:45 UTC INFO  Successfully pulled app down: app
+		assert.Equal(t, `Saved app to disk
+Fetched dependencies archive
+Successfully pulled app down: app
 `, out.String())
 
 		_, pkgErr := os.Stat(filepath.Join(profile.WorkingDirectory, "app", local.NameFunctions, "node_modules.zip"))
@@ -213,8 +213,8 @@ func TestPullHandler(t *testing.T) {
 
 			assert.Nil(t, cmd.Handler(profile, ui, cli.Clients{Realm: realmClient}))
 
-			assert.Equal(t, `01:23:45 UTC INFO  Saved app to disk
-01:23:45 UTC INFO  Successfully pulled app down: app
+			assert.Equal(t, `Saved app to disk
+Successfully pulled app down: app
 `, out.String())
 		})
 
@@ -294,9 +294,9 @@ func TestPullHandler(t *testing.T) {
 		cmd := &Command{inputs{LocalPath: "app", IncludeHosting: true}}
 
 		assert.Nil(t, cmd.Handler(profile, ui, cli.Clients{Realm: realmClient, HostingAsset: hostingAssetClient}))
-		assert.Equal(t, `01:23:45 UTC INFO  Saved app to disk
-01:23:45 UTC DEBUG Fetched hosting assets
-01:23:45 UTC INFO  Successfully pulled app down: app
+		assert.Equal(t, `Saved app to disk
+Fetched hosting assets
+Successfully pulled app down: app
 `, out.String())
 
 		t.Log("should have added the new file")

--- a/internal/commands/push/command.go
+++ b/internal/commands/push/command.go
@@ -224,7 +224,9 @@ func (cmd *Command) Handler(profile *cli.Profile, ui terminal.UI, clients cli.Cl
 				appRemote.GroupID,
 				appRemote.AppID,
 				hostingDiffs,
-				func(err error) { ui.Print(terminal.NewWarningLog(err.Error())) },
+				func(err error) {
+					ui.Print(terminal.NewWarningLog("An error occurred while uploading hosting assets: %s", err.Error()))
+				},
 			)
 		}
 

--- a/internal/commands/push/command_test.go
+++ b/internal/commands/push/command_test.go
@@ -294,13 +294,13 @@ func TestPushHandler(t *testing.T) {
 
 				err := cmd.Handler(profile, ui, cli.Clients{Realm: realmClient})
 				assert.Equal(t, errors.New("2 error(s) occurred while importing hosting assets"), err)
-				assert.Equal(t, `01:23:45 UTC INFO  Determining changes
-01:23:45 UTC INFO  Creating draft
-01:23:45 UTC INFO  Pushing changes
-01:23:45 UTC INFO  Deploying draft
-01:23:45 UTC INFO  Deployment complete
-01:23:45 UTC WARN  failed to add /404.html: something bad happened
-01:23:45 UTC WARN  failed to add /index.html: something bad happened
+				assert.Equal(t, `Determining changes
+Creating draft
+Pushing changes
+Deploying draft
+Deployment complete
+An error occurred while uploading hosting assets: failed to add /404.html: something bad happened
+An error occurred while uploading hosting assets: failed to add /index.html: something bad happened
 `, out.String())
 			})
 
@@ -319,13 +319,13 @@ func TestPushHandler(t *testing.T) {
 
 				err := cmd.Handler(profile, ui, cli.Clients{Realm: realmClient})
 				assert.Equal(t, errors.New("2 error(s) occurred while importing hosting assets"), err)
-				assert.Equal(t, `01:23:45 UTC INFO  Determining changes
-01:23:45 UTC INFO  Creating draft
-01:23:45 UTC INFO  Pushing changes
-01:23:45 UTC INFO  Deploying draft
-01:23:45 UTC INFO  Deployment complete
-01:23:45 UTC WARN  failed to update /404.html: something bad happened
-01:23:45 UTC WARN  failed to update /index.html: something bad happened
+				assert.Equal(t, `Determining changes
+Creating draft
+Pushing changes
+Deploying draft
+Deployment complete
+An error occurred while uploading hosting assets: failed to update /404.html: something bad happened
+An error occurred while uploading hosting assets: failed to update /index.html: something bad happened
 `, out.String())
 			})
 		})
@@ -360,12 +360,12 @@ func TestPushHandler(t *testing.T) {
 
 				err := cmd.Handler(profile, ui, cli.Clients{Realm: realmClient})
 				assert.Equal(t, errors.New("1 error(s) occurred while importing hosting assets"), err)
-				assert.Equal(t, `01:23:45 UTC INFO  Determining changes
-01:23:45 UTC INFO  Creating draft
-01:23:45 UTC INFO  Pushing changes
-01:23:45 UTC INFO  Deploying draft
-01:23:45 UTC INFO  Deployment complete
-01:23:45 UTC WARN  failed to remove /deleteme.html: something bad happened
+				assert.Equal(t, `Determining changes
+Creating draft
+Pushing changes
+Deploying draft
+Deployment complete
+An error occurred while uploading hosting assets: failed to remove /deleteme.html: something bad happened
 `, out.String())
 			})
 		})
@@ -403,13 +403,13 @@ func TestPushHandler(t *testing.T) {
 
 				err := cmd.Handler(profile, ui, cli.Clients{Realm: realmClient})
 				assert.Equal(t, errors.New("2 error(s) occurred while importing hosting assets"), err)
-				assert.Equal(t, `01:23:45 UTC INFO  Determining changes
-01:23:45 UTC INFO  Creating draft
-01:23:45 UTC INFO  Pushing changes
-01:23:45 UTC INFO  Deploying draft
-01:23:45 UTC INFO  Deployment complete
-01:23:45 UTC WARN  failed to update attributes for /404.html: something bad happened
-01:23:45 UTC WARN  failed to update attributes for /index.html: something bad happened
+				assert.Equal(t, `Determining changes
+Creating draft
+Pushing changes
+Deploying draft
+Deployment complete
+An error occurred while uploading hosting assets: failed to update attributes for /404.html: something bad happened
+An error occurred while uploading hosting assets: failed to update attributes for /index.html: something bad happened
 `, out.String())
 			})
 		})
@@ -449,13 +449,13 @@ func TestPushHandler(t *testing.T) {
 
 			err := cmd.Handler(profile, ui, cli.Clients{Realm: realmClient})
 			assert.Nil(t, err)
-			assert.Equal(t, `01:23:45 UTC INFO  Determining changes
-01:23:45 UTC INFO  Creating draft
-01:23:45 UTC INFO  Pushing changes
-01:23:45 UTC INFO  Deploying draft
-01:23:45 UTC INFO  Deployment complete
-01:23:45 UTC INFO  Import hosting assets
-01:23:45 UTC INFO  Successfully pushed app up: eggcorn-abcde
+			assert.Equal(t, `Determining changes
+Creating draft
+Pushing changes
+Deploying draft
+Deployment complete
+Import hosting assets
+Successfully pushed app up: eggcorn-abcde
 `, out.String())
 
 			assert.Equal(t, []string{"/index.html"}, added)
@@ -519,14 +519,14 @@ func TestPushHandler(t *testing.T) {
 
 			err := cmd.Handler(profile, ui, cli.Clients{Realm: realmClient})
 			assert.Nil(t, err)
-			assert.Equal(t, `01:23:45 UTC INFO  Determining changes
-01:23:45 UTC INFO  Creating draft
-01:23:45 UTC INFO  Pushing changes
-01:23:45 UTC INFO  Deploying draft
-01:23:45 UTC INFO  Deployment complete
-01:23:45 UTC INFO  Import hosting assets
-01:23:45 UTC INFO  Reset CDN cache
-01:23:45 UTC INFO  Successfully pushed app up: eggcorn-abcde
+			assert.Equal(t, `Determining changes
+Creating draft
+Pushing changes
+Deploying draft
+Deployment complete
+Import hosting assets
+Reset CDN cache
+Successfully pushed app up: eggcorn-abcde
 `, out.String())
 		})
 
@@ -542,12 +542,12 @@ func TestPushHandler(t *testing.T) {
 				cmd := &Command{inputs{LocalPath: "testdata/project", RemoteApp: "appID"}}
 
 				assert.Nil(t, cmd.Handler(nil, ui, cli.Clients{Realm: realmClient}))
-				assert.Equal(t, `01:23:45 UTC INFO  Determining changes
-01:23:45 UTC INFO  Creating draft
-01:23:45 UTC INFO  Pushing changes
-01:23:45 UTC INFO  Deploying draft
-01:23:45 UTC INFO  Deployment complete
-01:23:45 UTC INFO  Successfully pushed app up: eggcorn-abcde
+				assert.Equal(t, `Determining changes
+Creating draft
+Pushing changes
+Deploying draft
+Deployment complete
+Successfully pushed app up: eggcorn-abcde
 `, out.String())
 			})
 
@@ -573,14 +573,14 @@ func TestPushHandler(t *testing.T) {
 			cmd := &Command{inputs{LocalPath: "testdata/project", RemoteApp: "appID", IncludeDependencies: true}}
 
 			assert.Nil(t, cmd.Handler(nil, ui, cli.Clients{Realm: realmClient}))
-			assert.Equal(t, `01:23:45 UTC INFO  Determining changes
-01:23:45 UTC INFO  Creating draft
-01:23:45 UTC INFO  Pushing changes
-01:23:45 UTC INFO  Deploying draft
-01:23:45 UTC INFO  Deployment complete
-01:23:45 UTC INFO  Transpiled dependency sources
-01:23:45 UTC INFO  Uploaded dependencies archive
-01:23:45 UTC INFO  Successfully pushed app up: eggcorn-abcde
+			assert.Equal(t, `Determining changes
+Creating draft
+Pushing changes
+Deploying draft
+Deployment complete
+Transpiled dependency sources
+Uploaded dependencies archive
+Successfully pushed app up: eggcorn-abcde
 `, out.String())
 		})
 	})
@@ -624,8 +624,8 @@ func TestPushHandler(t *testing.T) {
 				assert.Nil(t, err)
 
 				assert.Equal(t, tc.groupsCalled, calledGroups)
-				assert.Equal(t, `01:23:45 UTC INFO  This is a new app. To create a new app, you must omit the 'dry-run' flag to proceed
-01:23:45 UTC DEBUG Try running instead: realm-cli import --local testdata/project --remote appID
+				assert.Equal(t, `This is a new app. To create a new app, you must omit the 'dry-run' flag to proceed
+Try running instead: realm-cli import --local testdata/project --remote appID
 `, out.String())
 			})
 		}
@@ -675,8 +675,8 @@ func TestPushHandler(t *testing.T) {
 
 		err := cmd.Handler(nil, ui, cli.Clients{Realm: realmClient})
 		assert.Nil(t, err)
-		assert.Equal(t, `01:23:45 UTC INFO  Determining changes
-01:23:45 UTC INFO  Deployed app is identical to proposed version, nothing to do
+		assert.Equal(t, `Determining changes
+Deployed app is identical to proposed version, nothing to do
 `, out.String())
 	})
 
@@ -696,12 +696,12 @@ func TestPushHandler(t *testing.T) {
 		err := cmd.Handler(nil, ui, cli.Clients{Realm: realmClient})
 
 		assert.Nil(t, err)
-		assert.Equal(t, `01:23:45 UTC INFO  Determining changes
-01:23:45 UTC INFO  The following reflects the proposed changes to your Realm app
+		assert.Equal(t, `Determining changes
+The following reflects the proposed changes to your Realm app
 diff1
 diff2
-01:23:45 UTC INFO  To push these changes, you must omit the 'dry-run' flag to proceed
-01:23:45 UTC DEBUG Try running instead: realm-cli import --local testdata/project --remote appID
+To push these changes, you must omit the 'dry-run' flag to proceed
+Try running instead: realm-cli import --local testdata/project --remote appID
 `, out.String())
 	})
 
@@ -1190,14 +1190,14 @@ func TestPushCommandDiffDraft(t *testing.T) {
 		}{
 			{
 				description:      "with a client that returns an empty diff",
-				expectedContents: "01:23:45 UTC INFO  An empty draft already exists for your app\n",
+				expectedContents: "An empty draft already exists for your app\n",
 			},
 			{
 				description: "with a client that returns a minimal diff",
 				actualDiff:  realm.AppDraftDiff{Diffs: []string{"diff1", "diff2", "diff3"}},
 				expectedContents: strings.Join(
 					[]string{
-						"01:23:45 UTC INFO  The following draft already exists for your app...",
+						"The following draft already exists for your app...",
 						"  diff1",
 						"  diff2",
 						"  diff3\n",
@@ -1228,21 +1228,21 @@ func TestPushCommandDiffDraft(t *testing.T) {
 				},
 				expectedContents: strings.Join(
 					[]string{
-						"01:23:45 UTC INFO  The following draft already exists for your app...",
+						"The following draft already exists for your app...",
 						"  diff1",
 						"  diff2",
 						"  diff3",
-						"01:23:45 UTC INFO  With changes to your static hosting files...",
+						"With changes to your static hosting files...",
 						"  added: hosting_added1",
 						"  added: hosting_added2",
 						"  deleted: hosting_deleted1",
-						"01:23:45 UTC INFO  With changes to your app dependencies...",
+						"With changes to your app dependencies...",
 						"  + dep_added1@v1",
 						"  dep_modified1@v2 -> dep_modified1@v1",
 						"  dep_modified2@v1 -> dep_modified2@v2",
-						"01:23:45 UTC INFO  With changes to your GraphQL configuration...",
+						"With changes to your GraphQL configuration...",
 						"  gql_field1: previous -> updated",
-						"01:23:45 UTC INFO  With changes to your app schema...",
+						"With changes to your app schema...",
 						"  gql_validation_field1: old -> new",
 						"  rest_validation_field1: old -> new",
 						"",
@@ -1310,7 +1310,7 @@ func TestPushCommandDeployDraftAndWait(t *testing.T) {
 				{
 					description:      "and fails to discard the draft should return the deployment error and print a warning message",
 					discardDraftErr:  errors.New("failed to discard draft"),
-					expectedContents: "01:23:45 UTC WARN  Failed to discard the draft created for your deployment\n",
+					expectedContents: "Failed to discard the draft created for your deployment\n",
 				},
 			} {
 				t.Run(tc.description, func(t *testing.T) {
@@ -1344,7 +1344,7 @@ func TestPushCommandDeployDraftAndWait(t *testing.T) {
 			err := deployDraftAndWait(ui, realmClient, appRemote{groupID, appID}, draftID)
 			assert.Nil(t, err)
 
-			assert.Equal(t, "01:23:45 UTC INFO  Deployment complete\n", out.String())
+			assert.Equal(t, "Deployment complete\n", out.String())
 		})
 	})
 }
@@ -1399,11 +1399,11 @@ func runImport(t *testing.T, realmClient realm.Client, appDirectory string) {
 	cmd := &Command{inputs{LocalPath: appDirectory, RemoteApp: "appID"}}
 
 	assert.Nil(t, cmd.Handler(nil, ui, cli.Clients{Realm: realmClient}))
-	assert.Equal(t, `01:23:45 UTC INFO  Determining changes
-01:23:45 UTC INFO  Creating draft
-01:23:45 UTC INFO  Pushing changes
-01:23:45 UTC INFO  Deploying draft
-01:23:45 UTC INFO  Deployment complete
-01:23:45 UTC INFO  Successfully pushed app up: eggcorn-abcde
+	assert.Equal(t, `Determining changes
+Creating draft
+Pushing changes
+Deploying draft
+Deployment complete
+Successfully pushed app up: eggcorn-abcde
 `, out.String())
 }

--- a/internal/commands/secrets/create_test.go
+++ b/internal/commands/secrets/create_test.go
@@ -52,7 +52,7 @@ func TestSecretsCreateHandler(t *testing.T) {
 		}}
 
 		assert.Nil(t, cmd.Handler(nil, ui, cli.Clients{Realm: realmClient}))
-		assert.Equal(t, "01:23:45 UTC INFO  Successfully created secret, id: secretID\n", out.String())
+		assert.Equal(t, "Successfully created secret, id: secretID\n", out.String())
 
 		t.Log("and should properly pass through the expected inputs")
 		assert.Equal(t, realm.AppFilter{projectID, appID}, capturedFilter)

--- a/internal/commands/secrets/delete_test.go
+++ b/internal/commands/secrets/delete_test.go
@@ -52,7 +52,7 @@ func TestSecretsDeleteHandler(t *testing.T) {
 
 		assert.Nil(t, cmd.Handler(nil, ui, cli.Clients{Realm: realmClient}))
 
-		assert.Equal(t, "01:23:45 UTC INFO  No secrets to delete\n", out.String())
+		assert.Equal(t, "No secrets to delete\n", out.String())
 	})
 
 	for _, tc := range []struct {
@@ -65,7 +65,7 @@ func TestSecretsDeleteHandler(t *testing.T) {
 			description: "should return successful outputs for proper secret inputs",
 			testInput:   []string{"secret_id_1"},
 			expectedOutput: strings.Join([]string{
-				"01:23:45 UTC INFO  Deleted 1 secret(s)",
+				"Deleted 1 secret(s)",
 				"  ID           Name           Deleted  Details",
 				"  -----------  -------------  -------  -------",
 				"  secret_id_1  secret_name_1  true            ",
@@ -77,7 +77,7 @@ func TestSecretsDeleteHandler(t *testing.T) {
 			testInput:   []string{"secret_id_0", "secret_id_6"},
 			deleteErr:   errors.New("something happened"),
 			expectedOutput: strings.Join([]string{
-				"01:23:45 UTC INFO  Deleted 2 secret(s)",
+				"Deleted 2 secret(s)",
 				"  ID           Name           Deleted  Details           ",
 				"  -----------  -------------  -------  ------------------",
 				"  secret_id_0  secret_name_0  false    something happened",

--- a/internal/commands/secrets/list_test.go
+++ b/internal/commands/secrets/list_test.go
@@ -34,14 +34,14 @@ func TestSecretsListHandler(t *testing.T) {
 	}{
 		{
 			description:    "should list no secrets with no app secrets found",
-			expectedOutput: "01:23:45 UTC INFO  No available secrets to show\n",
+			expectedOutput: "No available secrets to show\n",
 		},
 		{
 			description: "should list the secrets found for the app",
 			secrets:     testSecrets,
 			expectedOutput: strings.Join(
 				[]string{
-					"01:23:45 UTC INFO  Found 4 secrets",
+					"Found 4 secrets",
 					"  ID       Name ",
 					"  -------  -----",
 					"  secret1  test1",

--- a/internal/commands/secrets/update_test.go
+++ b/internal/commands/secrets/update_test.go
@@ -81,7 +81,7 @@ func TestSecretUpdateHandler(t *testing.T) {
 
 			assert.Nil(t, cmd.Handler(nil, ui, cli.Clients{Realm: realmClient}))
 
-			assert.Equal(t, "01:23:45 UTC INFO  Successfully updated secret\n", out.String())
+			assert.Equal(t, "Successfully updated secret\n", out.String())
 		})
 	}
 

--- a/internal/commands/user/create_test.go
+++ b/internal/commands/user/create_test.go
@@ -45,7 +45,7 @@ func TestUserCreateHandler(t *testing.T) {
 
 		assert.Nil(t, cmd.Handler(nil, ui, cli.Clients{Realm: realmClient}))
 		assert.Equal(t, strings.Join([]string{
-			"01:23:45 UTC INFO  Successfully created user",
+			"Successfully created user",
 			"  ID                        Enabled  Email            Type  ",
 			"  ------------------------  -------  ---------------  ------",
 			fmt.Sprintf("  %s  true     user@domain.com  normal", id),
@@ -68,7 +68,7 @@ func TestUserCreateHandler(t *testing.T) {
 
 		assert.Nil(t, cmd.Handler(nil, ui, cli.Clients{Realm: realmClient}))
 		assert.Equal(t, strings.Join([]string{
-			"01:23:45 UTC INFO  Successfully created api key",
+			"Successfully created api key",
 			"  ID                        Enabled  Name  API Key",
 			"  ------------------------  -------  ----  -------",
 			fmt.Sprintf("  %s  true     name  key    ", id),

--- a/internal/commands/user/delete_test.go
+++ b/internal/commands/user/delete_test.go
@@ -65,7 +65,7 @@ func TestUserDeleteHandler(t *testing.T) {
 		}}}
 
 		assert.Nil(t, cmd.Handler(nil, ui, cli.Clients{Realm: realmClient}))
-		assert.Equal(t, "01:23:45 UTC INFO  No users to delete\n", out.String())
+		assert.Equal(t, "No users to delete\n", out.String())
 	})
 
 	t.Run("should display users deleted by auth provider type", func(t *testing.T) {
@@ -94,19 +94,19 @@ func TestUserDeleteHandler(t *testing.T) {
 
 		assert.Nil(t, cmd.Handler(nil, ui, cli.Clients{Realm: realmClient}))
 		assert.Equal(t, strings.Join([]string{
-			"01:23:45 UTC INFO  Provider type: User/Password",
+			"Provider type: User/Password",
 			"  Email            ID      Type  Deleted  Details",
 			"  ---------------  ------  ----  -------  -------",
 			"  user-2@test.com  user-2        true            ",
-			"01:23:45 UTC INFO  Provider type: ApiKey",
+			"Provider type: ApiKey",
 			"  Name    ID      Type  Deleted  Details",
 			"  ------  ------  ----  -------  -------",
 			"  name-3  user-3        true            ",
-			"01:23:45 UTC INFO  Provider type: Anonymous",
+			"Provider type: Anonymous",
 			"  ID      Type    Deleted  Details",
 			"  ------  ------  -------  -------",
 			"  user-1  type-1  true            ",
-			"01:23:45 UTC INFO  Provider type: Custom JWT",
+			"Provider type: Custom JWT",
 			"  ID      Type  Deleted  Details",
 			"  ------  ----  -------  -------",
 			"  user-4        true            ",
@@ -122,7 +122,7 @@ func TestUserDeleteHandler(t *testing.T) {
 		{
 			description: "should delete a user when a user id is provided",
 			expectedOutput: strings.Join([]string{
-				"01:23:45 UTC INFO  Provider type: Anonymous",
+				"Provider type: Anonymous",
 				"  ID      Type    Deleted  Details",
 				"  ------  ------  -------  -------",
 				"  user-1  type-1  true            ",
@@ -133,7 +133,7 @@ func TestUserDeleteHandler(t *testing.T) {
 			description: "should save failed deletion errors",
 			deleteErr:   errors.New("client error"),
 			expectedOutput: strings.Join([]string{
-				"01:23:45 UTC INFO  Provider type: Anonymous",
+				"Provider type: Anonymous",
 				"  ID      Type    Deleted  Details     ",
 				"  ------  ------  -------  ------------",
 				"  user-1  type-1  false    client error",

--- a/internal/commands/user/disable_test.go
+++ b/internal/commands/user/disable_test.go
@@ -41,7 +41,7 @@ func TestUserDisableHandler(t *testing.T) {
 		}}}
 
 		assert.Nil(t, cmd.Handler(nil, ui, cli.Clients{Realm: realmClient}))
-		assert.Equal(t, "01:23:45 UTC INFO  No users to disable\n", out.String())
+		assert.Equal(t, "No users to disable\n", out.String())
 	})
 
 	t.Run("should display users disabled by auth provider type", func(t *testing.T) {
@@ -70,19 +70,19 @@ func TestUserDisableHandler(t *testing.T) {
 
 		assert.Nil(t, cmd.Handler(nil, ui, cli.Clients{Realm: realmClient}))
 		assert.Equal(t, strings.Join([]string{
-			"01:23:45 UTC INFO  Provider type: User/Password",
+			"Provider type: User/Password",
 			"  Email            ID      Type  Enabled  Details",
 			"  ---------------  ------  ----  -------  -------",
 			"  user-2@test.com  user-2        false           ",
-			"01:23:45 UTC INFO  Provider type: ApiKey",
+			"Provider type: ApiKey",
 			"  Name    ID      Type  Enabled  Details",
 			"  ------  ------  ----  -------  -------",
 			"  name-3  user-3        false           ",
-			"01:23:45 UTC INFO  Provider type: Anonymous",
+			"Provider type: Anonymous",
 			"  ID      Type    Enabled  Details",
 			"  ------  ------  -------  -------",
 			"  user-1  type-1  false           ",
-			"01:23:45 UTC INFO  Provider type: Custom JWT",
+			"Provider type: Custom JWT",
 			"  ID      Type  Enabled  Details",
 			"  ------  ----  -------  -------",
 			"  user-4        false           ",
@@ -98,7 +98,7 @@ func TestUserDisableHandler(t *testing.T) {
 		{
 			description: "should disable a user when a user id is provided",
 			expectedOutput: strings.Join([]string{
-				"01:23:45 UTC INFO  Provider type: Anonymous",
+				"Provider type: Anonymous",
 				"  ID      Type    Enabled  Details",
 				"  ------  ------  -------  -------",
 				"  user-1  type-1  false           ",
@@ -109,7 +109,7 @@ func TestUserDisableHandler(t *testing.T) {
 			description: "should save failed disable errors",
 			disableErr:  errors.New("client error"),
 			expectedOutput: strings.Join([]string{
-				"01:23:45 UTC INFO  Provider type: Anonymous",
+				"Provider type: Anonymous",
 				"  ID      Type    Enabled  Details     ",
 				"  ------  ------  -------  ------------",
 				"  user-1  type-1  true     client error",

--- a/internal/commands/user/enable_test.go
+++ b/internal/commands/user/enable_test.go
@@ -41,7 +41,7 @@ func TestUserEnableHandler(t *testing.T) {
 		}}}
 
 		assert.Nil(t, cmd.Handler(nil, ui, cli.Clients{Realm: realmClient}))
-		assert.Equal(t, "01:23:45 UTC INFO  No users to enable\n", out.String())
+		assert.Equal(t, "No users to enable\n", out.String())
 	})
 
 	t.Run("should display users enabled by auth provider type", func(t *testing.T) {
@@ -70,19 +70,19 @@ func TestUserEnableHandler(t *testing.T) {
 
 		assert.Nil(t, cmd.Handler(nil, ui, cli.Clients{Realm: realmClient}))
 		assert.Equal(t, strings.Join([]string{
-			"01:23:45 UTC INFO  Provider type: User/Password",
+			"Provider type: User/Password",
 			"  Email            ID      Type  Enabled  Details",
 			"  ---------------  ------  ----  -------  -------",
 			"  user-2@test.com  user-2        true            ",
-			"01:23:45 UTC INFO  Provider type: ApiKey",
+			"Provider type: ApiKey",
 			"  Name    ID      Type  Enabled  Details",
 			"  ------  ------  ----  -------  -------",
 			"  name-3  user-3        true            ",
-			"01:23:45 UTC INFO  Provider type: Anonymous",
+			"Provider type: Anonymous",
 			"  ID      Type    Enabled  Details",
 			"  ------  ------  -------  -------",
 			"  user-1  type-1  true            ",
-			"01:23:45 UTC INFO  Provider type: Custom JWT",
+			"Provider type: Custom JWT",
 			"  ID      Type  Enabled  Details",
 			"  ------  ----  -------  -------",
 			"  user-4        true            ",
@@ -98,7 +98,7 @@ func TestUserEnableHandler(t *testing.T) {
 		{
 			description: "should enable a user when a user id is provided",
 			expectedOutput: strings.Join([]string{
-				"01:23:45 UTC INFO  Provider type: Anonymous",
+				"Provider type: Anonymous",
 				"  ID      Type    Enabled  Details",
 				"  ------  ------  -------  -------",
 				"  user-1  type-1  true            ",
@@ -109,7 +109,7 @@ func TestUserEnableHandler(t *testing.T) {
 			description: "should save failed enable errors",
 			enableErr:   errors.New("client error"),
 			expectedOutput: strings.Join([]string{
-				"01:23:45 UTC INFO  Provider type: Anonymous",
+				"Provider type: Anonymous",
 				"  ID      Type    Enabled  Details     ",
 				"  ------  ------  -------  ------------",
 				"  user-1  type-1  false    client error",

--- a/internal/commands/user/list_test.go
+++ b/internal/commands/user/list_test.go
@@ -41,7 +41,7 @@ func TestUserListHandler(t *testing.T) {
 		}}}
 
 		assert.Nil(t, cmd.Handler(nil, ui, cli.Clients{Realm: realmClient}))
-		assert.Equal(t, "01:23:45 UTC INFO  No available users to show\n", out.String())
+		assert.Equal(t, "No available users to show\n", out.String())
 	})
 
 	t.Run("should display users by auth provider type", func(t *testing.T) {
@@ -67,19 +67,19 @@ func TestUserListHandler(t *testing.T) {
 
 		assert.Nil(t, cmd.Handler(nil, ui, cli.Clients{Realm: realmClient}))
 		assert.Equal(t, strings.Join([]string{
-			"01:23:45 UTC INFO  Provider type: User/Password",
+			"Provider type: User/Password",
 			"  Email            ID      Type  Enabled  Last Authenticated",
 			"  ---------------  ------  ----  -------  ------------------",
 			"  user-2@test.com  user-2        true     n/a               ",
-			"01:23:45 UTC INFO  Provider type: ApiKey",
+			"Provider type: ApiKey",
 			"  Name    ID      Type  Enabled  Last Authenticated",
 			"  ------  ------  ----  -------  ------------------",
 			"  name-3  user-3        true     n/a               ",
-			"01:23:45 UTC INFO  Provider type: Anonymous",
+			"Provider type: Anonymous",
 			"  ID      Type    Enabled  Last Authenticated",
 			"  ------  ------  -------  ------------------",
 			"  user-1  type-1  true     n/a               ",
-			"01:23:45 UTC INFO  Provider type: Custom JWT",
+			"Provider type: Custom JWT",
 			"  ID      Type  Enabled  Last Authenticated",
 			"  ------  ----  -------  ------------------",
 			"  user-4        true     n/a               ",
@@ -115,7 +115,7 @@ func TestUserListHandler(t *testing.T) {
 
 		assert.Nil(t, cmd.Handler(nil, ui, cli.Clients{Realm: realmClient}))
 		assert.Equal(t, strings.Join([]string{
-			"01:23:45 UTC INFO  Provider type: Anonymous",
+			"Provider type: Anonymous",
 			"  ID      Type    Enabled  Last Authenticated",
 			"  ------  ------  -------  ------------------",
 			"  user-1  type-1  true     n/a               ",

--- a/internal/commands/user/revoke_test.go
+++ b/internal/commands/user/revoke_test.go
@@ -41,7 +41,7 @@ func TestUserRevokeHandler(t *testing.T) {
 		}}}
 
 		assert.Nil(t, cmd.Handler(nil, ui, cli.Clients{Realm: realmClient}))
-		assert.Equal(t, "01:23:45 UTC INFO  No users to revoke sessions for\n", out.String())
+		assert.Equal(t, "No users to revoke sessions for\n", out.String())
 	})
 
 	t.Run("should display users deleted by auth provider type", func(t *testing.T) {
@@ -70,19 +70,19 @@ func TestUserRevokeHandler(t *testing.T) {
 
 		assert.Nil(t, cmd.Handler(nil, ui, cli.Clients{Realm: realmClient}))
 		assert.Equal(t, strings.Join([]string{
-			"01:23:45 UTC INFO  Provider type: User/Password",
+			"Provider type: User/Password",
 			"  Email            ID      Type  Session Revoked  Details",
 			"  ---------------  ------  ----  ---------------  -------",
 			"  user-2@test.com  user-2        true                    ",
-			"01:23:45 UTC INFO  Provider type: ApiKey",
+			"Provider type: ApiKey",
 			"  Name    ID      Type  Session Revoked  Details",
 			"  ------  ------  ----  ---------------  -------",
 			"  name-3  user-3        true                    ",
-			"01:23:45 UTC INFO  Provider type: Anonymous",
+			"Provider type: Anonymous",
 			"  ID      Type    Session Revoked  Details",
 			"  ------  ------  ---------------  -------",
 			"  user-1  type-1  true                    ",
-			"01:23:45 UTC INFO  Provider type: Custom JWT",
+			"Provider type: Custom JWT",
 			"  ID      Type  Session Revoked  Details",
 			"  ------  ----  ---------------  -------",
 			"  user-4        true                    ",
@@ -98,7 +98,7 @@ func TestUserRevokeHandler(t *testing.T) {
 		{
 			description: "should revoke user sessions when a user id is provided",
 			expectedOutput: strings.Join([]string{
-				"01:23:45 UTC INFO  Provider type: Anonymous",
+				"Provider type: Anonymous",
 				"  ID      Type    Session Revoked  Details",
 				"  ------  ------  ---------------  -------",
 				"  user-1  type-1  true                    ",
@@ -109,7 +109,7 @@ func TestUserRevokeHandler(t *testing.T) {
 			description: "should save failed revoke errors",
 			revokeErr:   errors.New("client error"),
 			expectedOutput: strings.Join([]string{
-				"01:23:45 UTC INFO  Provider type: Anonymous",
+				"Provider type: Anonymous",
 				"  ID      Type    Session Revoked  Details     ",
 				"  ------  ------  ---------------  ------------",
 				"  user-1  type-1  false            client error",

--- a/internal/commands/whoami/command_test.go
+++ b/internal/commands/whoami/command_test.go
@@ -19,7 +19,7 @@ func TestWhoamiFeedback(t *testing.T) {
 			{
 				description: "with no user logged in",
 				test: func(t *testing.T, output string) {
-					assert.Equal(t, "01:23:45 UTC INFO  No user is currently logged in\n", output)
+					assert.Equal(t, "No user is currently logged in\n", output)
 				},
 			},
 			{
@@ -28,7 +28,7 @@ func TestWhoamiFeedback(t *testing.T) {
 					profile.SetUser(auth.User{"username", "my-super-secret-key"})
 				},
 				test: func(t *testing.T, output string) {
-					assert.Equal(t, "01:23:45 UTC INFO  The user, username, is not currently logged in\n", output)
+					assert.Equal(t, "The user, username, is not currently logged in\n", output)
 				},
 			},
 			{
@@ -38,7 +38,7 @@ func TestWhoamiFeedback(t *testing.T) {
 					profile.SetSession(auth.Session{"accessToken", "refreshToken"})
 				},
 				test: func(t *testing.T, output string) {
-					assert.Equal(t, "01:23:45 UTC INFO  Currently logged in user: username (**-*****-******-key)\n", output)
+					assert.Equal(t, "Currently logged in user: username (**-*****-******-key)\n", output)
 				},
 			},
 		} {

--- a/internal/telemetry/tracker.go
+++ b/internal/telemetry/tracker.go
@@ -2,7 +2,6 @@ package telemetry
 
 import (
 	"fmt"
-	"time"
 
 	"gopkg.in/segmentio/analytics-go.v3"
 )
@@ -25,13 +24,7 @@ func (tracker *noopTracker) Close()            {}
 type stdoutTracker struct{}
 
 func (tracker *stdoutTracker) Track(event event) {
-	fmt.Printf(
-		"%s UTC TELEM %s: %s%v\n",
-		event.time.In(time.UTC).Format("15:04:05"),
-		event.command,
-		event.eventType,
-		event.data,
-	)
+	fmt.Printf("%s: %s%v\n", event.command, event.eventType, event.data)
 }
 
 func (tracker *stdoutTracker) Close() {}

--- a/internal/telemetry/tracker_test.go
+++ b/internal/telemetry/tracker_test.go
@@ -53,7 +53,7 @@ func TestStdoutTracker(t *testing.T) {
 	t.Run("should create an stdout tracker and should print the tracking information to stdout", func(t *testing.T) {
 		tracker := stdoutTracker{}
 		testEvent := createEvent(EventTypeCommandComplete, nil, testCommand)
-		testTrackerOutput(t, &tracker, testEvent, "03:04:05 UTC TELEM command: COMMAND_COMPLETE[]\n")
+		testTrackerOutput(t, &tracker, testEvent, "command: COMMAND_COMPLETE[]\n")
 	})
 }
 

--- a/internal/terminal/log.go
+++ b/internal/terminal/log.go
@@ -3,7 +3,6 @@ package terminal
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/iancoleman/orderedmap"
@@ -18,20 +17,6 @@ const (
 	LogLevelError LogLevel = "error"
 	LogLevelWarn  LogLevel = "warn"
 	LogLevelDebug LogLevel = "debug"
-)
-
-var (
-	allLogLevels = []LogLevel{LogLevelInfo, LogLevelError}
-
-	longestLogLevel = func() LogLevel {
-		var longest LogLevel
-		for _, level := range allLogLevels {
-			if len(level) > len(longest) {
-				longest = level
-			}
-		}
-		return longest
-	}()
 )
 
 // LogData produces the log data
@@ -115,12 +100,7 @@ func (l Log) textLog() (string, error) {
 		return "", err
 	}
 
-	return fmt.Sprintf(
-		fmt.Sprintf("%%s UTC %%-%ds %%s", len(longestLogLevel)),
-		l.Time.In(time.UTC).Format("15:04:05"),
-		strings.ToUpper(string(l.Level)),
-		message,
-	), nil
+	return message, nil
 }
 
 const (

--- a/internal/terminal/log_test.go
+++ b/internal/terminal/log_test.go
@@ -72,7 +72,7 @@ func TestLogMessage(t *testing.T) {
 			level: LogLevelInfo,
 			data:  textMessage("this is a test log"),
 			expectedOutputs: map[OutputFormat]string{
-				OutputFormatText: "07:54:00 UTC INFO  this is a test log",
+				OutputFormatText: "this is a test log",
 				OutputFormatJSON: `{"time":"1989-06-22T07:54:00Z","level":"info","message":"this is a test log"}`,
 			},
 		},
@@ -80,7 +80,7 @@ func TestLogMessage(t *testing.T) {
 			level: LogLevelInfo,
 			data:  jsonDocument{"a json document", map[string]interface{}{"a": true, "b": 1, "c": "sea"}},
 			expectedOutputs: map[OutputFormat]string{
-				OutputFormatText: `07:54:00 UTC INFO  a json document
+				OutputFormatText: `a json document
 {
   "a": true,
   "b": 1,
@@ -93,7 +93,7 @@ func TestLogMessage(t *testing.T) {
 			level: LogLevelError,
 			data:  errorMessage{errors.New("something bad happened")},
 			expectedOutputs: map[OutputFormat]string{
-				OutputFormatText: "07:54:00 UTC ERROR something bad happened",
+				OutputFormatText: "something bad happened",
 				OutputFormatJSON: `{"time":"1989-06-22T07:54:00Z","level":"error","err":"something bad happened"}`,
 			},
 		},

--- a/internal/terminal/ui_test.go
+++ b/internal/terminal/ui_test.go
@@ -3,8 +3,6 @@ package terminal_test
 import (
 	"bytes"
 	"errors"
-	"log"
-	"os"
 	"testing"
 
 	"github.com/10gen/realm-cli/internal/terminal"
@@ -23,17 +21,17 @@ func TestUIPrint(t *testing.T) {
 			{
 				description: "Should use the default writer while printing an INFO log",
 				log:         terminal.NewTextLog("test log"),
-				expectedOut: "01:23:45 UTC INFO  test log\n",
+				expectedOut: "test log\n",
 			},
 			{
 				description: "Should use the error writer while printing an ERROR log",
 				log:         terminal.NewErrorLog(errors.New("something bad happened")),
-				expectedErr: "01:23:45 UTC ERROR something bad happened\n",
+				expectedErr: "something bad happened\n",
 			},
 		} {
 			t.Run(tc.description, func(t *testing.T) {
 				out, err := new(bytes.Buffer), new(bytes.Buffer)
-				ui := terminal.NewUI(terminal.UIConfig{}, nil, out, err, logger)
+				ui := terminal.NewUI(terminal.UIConfig{}, nil, out, err)
 
 				tc.log.Time = mock.StaticTime
 				ui.Print(tc.log)
@@ -44,7 +42,3 @@ func TestUIPrint(t *testing.T) {
 		}
 	})
 }
-
-var (
-	logger = log.New(os.Stderr, "UTC ERROR ", log.Ltime|log.Lmsgprefix)
-)

--- a/internal/utils/test/mock/terminal_ui.go
+++ b/internal/utils/test/mock/terminal_ui.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"strings"
 	"testing"
@@ -65,7 +64,6 @@ func NewUIWithOptions(options UIOptions, writer io.Writer) terminal.UI {
 		nil,
 		writer,
 		writer,
-		errLogger(writer),
 	)}
 }
 
@@ -90,7 +88,6 @@ func NewConsoleWithOptions(options UIOptions, writers ...io.Writer) (*expect.Con
 		console.Tty(),
 		console.Tty(),
 		console.Tty(),
-		errLogger(console.Tty()),
 	)}
 
 	return console, ui, nil
@@ -117,7 +114,6 @@ func NewVT10XConsoleWithOptions(options UIOptions, writers ...io.Writer) (*expec
 		console.Tty(),
 		console.Tty(),
 		console.Tty(),
-		errLogger(console.Tty()),
 	)}
 
 	return console, state, ui, nil
@@ -130,8 +126,4 @@ func FileWriter(t *testing.T) (*os.File, error) {
 	filename := strings.ReplaceAll(fmt.Sprintf("%s.log", t.Name()), "/", "_")
 
 	return os.OpenFile(filename, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
-}
-
-func errLogger(w io.Writer) *log.Logger {
-	return log.New(os.Stderr, "UTC ERROR ", log.Ltime|log.Lmsgprefix)
 }


### PR DESCRIPTION
For context here, with trying to display logs output, timestamps were getting a little noisy/difficult to discern which were "command timestamps" and which were "server timestamps".  The log level was probably never all that important (although maybe we need some differentiator for ERROR?).

This has been run by @sumedham and @drewdipalma ... though maybe they have further thoughts regarding the need to differentiate errors at all

These fields are still exported as the JSON/structured log message.  The log level also can be useful down the line for niche formatting (error in red, warn in yellow, etc) as well as a potential verbose/quiet flag.