### PR TITLE
REALMC-8826: Update cli help text

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,7 +18,7 @@ func Run() {
 		Version:       cli.Version,
 		Use:           cli.Name,
 		Short:         "CLI tool to manage your MongoDB Realm application",
-		Long:          fmt.Sprintf("Use %s command help for information on a specific command", cli.Name),
+		Long:          fmt.Sprintf(`Use "%s [command] --help" for information on a specific command`, cli.Name),
 		SilenceErrors: true,
 		SilenceUsage:  true,
 	}
@@ -30,16 +30,16 @@ func Run() {
 	cmd.Flags().SortFlags = false // ensures CLI help text displays global flags unsorted
 	factory.SetGlobalFlags(cmd.PersistentFlags())
 
+	cmd.AddCommand(factory.Build(commands.Whoami))
 	cmd.AddCommand(factory.Build(commands.Login))
 	cmd.AddCommand(factory.Build(commands.Logout))
 	cmd.AddCommand(factory.Build(commands.Push))
 	cmd.AddCommand(factory.Build(commands.Pull))
 	cmd.AddCommand(factory.Build(commands.App))
-	cmd.AddCommand(factory.Build(commands.Secrets))
 	cmd.AddCommand(factory.Build(commands.User))
-	cmd.AddCommand(factory.Build(commands.Whoami))
-	cmd.AddCommand(factory.Build(commands.Function))
+	cmd.AddCommand(factory.Build(commands.Secrets))
 	cmd.AddCommand(factory.Build(commands.Logs))
+	cmd.AddCommand(factory.Build(commands.Function))
 	cmd.AddCommand(factory.Build(commands.Schema))
 
 	factory.Run(cmd)

--- a/internal/cli/command.go
+++ b/internal/cli/command.go
@@ -54,6 +54,8 @@ type InputResolver interface {
 // CommandDefinition is a command's definition that the CommandFactory
 // can build a *cobra.Command from
 type CommandDefinition struct {
+	CommandMeta
+
 	// Command is the command's implementation
 	// If present, this value is used to specify the cobra.Command execution phases
 	Command Command
@@ -61,15 +63,10 @@ type CommandDefinition struct {
 	// SubCommands are the command's sub commands
 	// This array is iteratively added to this Cobra command via (cobra.Command).AddCommand
 	SubCommands []CommandDefinition
+}
 
-	// Description is the short command description shown in the 'help' output
-	// This value maps 1:1 to Cobra's `Short` property
-	Description string
-
-	// Help is the long message shown in the 'help <this-command>' output
-	// This value maps 1:1 to Cobra's `Long` property
-	Help string
-
+// CommandMeta is the command metadata
+type CommandMeta struct {
 	// Use defines how the command is used
 	// This value maps 1:1 to Cobra's `Use` property
 	Use string
@@ -81,6 +78,13 @@ type CommandDefinition struct {
 	// Aliases is the list of supported aliases for the command
 	// This value maps 1:1 to Cobra's `Aliases` property
 	Aliases []string
+
+	// Description is the text shown in the 'help' output of the parent command
+	Description string
+
+	// HelpText is the text shown in the 'help' output of the actual command
+	// right below the command's description
+	HelpText string
 }
 
 // CommandDisplay returns the command display with the provided flags

--- a/internal/cli/command_factory.go
+++ b/internal/cli/command_factory.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/10gen/realm-cli/internal/cli/user"
@@ -47,10 +48,17 @@ func (factory *CommandFactory) Build(command CommandDefinition) *cobra.Command {
 		display = command.Use
 	}
 
+	var aliasHelp string
+	if len(command.Aliases) == 1 {
+		aliasHelp = fmt.Sprintf(" (alias: %s)", command.Aliases[0])
+	} else if len(command.Aliases) > 1 {
+		aliasHelp = fmt.Sprintf(" (aliases: %s)", strings.Join(command.Aliases, ", "))
+	}
+
 	cmd := cobra.Command{
 		Use:     command.Use,
-		Short:   command.Description,
-		Long:    command.Help,
+		Short:   command.Description + aliasHelp,
+		Long:    command.Description + "\n\n" + command.HelpText,
 		Aliases: command.Aliases,
 	}
 

--- a/internal/commands/app/create.go
+++ b/internal/commands/app/create.go
@@ -13,10 +13,20 @@ import (
 	"github.com/spf13/pflag"
 )
 
-// set of supported `app create` command strings
-const (
-	CommandCreateDisplay = "app create"
-)
+// CommandMetaCreate is the command meta for the `app create` command
+var CommandMetaCreate = cli.CommandMeta{
+	Use:         "create",
+	Display:     "app create",
+	Description: "Create a new app from your current working directory and deploy it to the Realm server",
+	HelpText: `Creates a new Realm app by saving your configuration files in a local directory
+and deploying the new app to the Realm server. This command will create a new
+directory for your project.
+
+You can specify a "--remote" flag to create a Realm app from an existing app;
+if you do not specify a "--remote" flag, the CLI will create a default Realm app.
+
+NOTE: To create a Realm app without deploying it, use "app init".`,
+}
 
 // CommandCreate is the `app create` command
 type CommandCreate struct {
@@ -200,5 +210,5 @@ func (cmd *CommandCreate) Handler(profile *user.Profile, ui terminal.UI, clients
 }
 
 func (cmd *CommandCreate) display(omitDryRun bool) string {
-	return cli.CommandDisplay(CommandCreateDisplay, cmd.inputs.args(omitDryRun))
+	return cli.CommandDisplay(CommandMetaCreate.Display, cmd.inputs.args(omitDryRun))
 }

--- a/internal/commands/app/create_inputs.go
+++ b/internal/commands/app/create_inputs.go
@@ -28,7 +28,7 @@ var (
 
 	flagDryRun      = "dry-run"
 	flagDryRunShort = "x"
-	flagDryRunUsage = "include to run without writing any changes to the file system nor deploying any changes to the Realm servers"
+	flagDryRunUsage = "include to run without writing any changes to the file system nor deploying any changes to the Realm server"
 )
 
 type createInputs struct {

--- a/internal/commands/app/delete.go
+++ b/internal/commands/app/delete.go
@@ -11,6 +11,16 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// CommandMetaDelete is the command meta for the `app delete` command
+var CommandMetaDelete = cli.CommandMeta{
+	Use:         "delete",
+	Display:     "app delete",
+	Description: "Delete a Realm app",
+	HelpText: `If you have more than one Realm app, you will be prompted to select one or
+multiple app(s) that you would like to delete from a list of all your Realm apps.
+The list includes Realm apps from all projects associated with your user profile.`,
+}
+
 // CommandDelete is the `app delete` command
 type CommandDelete struct {
 	inputs deleteInputs

--- a/internal/commands/app/describe.go
+++ b/internal/commands/app/describe.go
@@ -8,17 +8,23 @@ import (
 	"github.com/spf13/pflag"
 )
 
-type describeInputs struct {
-	cli.ProjectInputs
-}
-
-func (i *describeInputs) Resolve(profile *user.Profile, ui terminal.UI) error {
-	return i.ProjectInputs.Resolve(ui, profile.WorkingDirectory, true)
+// CommandMetaDescribe is the command meta for the `app describe` command
+var CommandMetaDescribe = cli.CommandMeta{
+	Use:         "describe",
+	Display:     "app describe",
+	Description: "Displays information about your Realm app",
+	HelpText: `View all of the aspects of your Realm app to see what is configured and enabled
+(e.g. services, functions, etc.). If you have more than one Realm app, you will
+be prompted to select a Realm app to view.`,
 }
 
 // CommandDescribe is the `app describe` command
 type CommandDescribe struct {
 	inputs describeInputs
+}
+
+type describeInputs struct {
+	cli.ProjectInputs
 }
 
 // Flags is the command flags
@@ -45,4 +51,8 @@ func (cmd *CommandDescribe) Handler(profile *user.Profile, ui terminal.UI, clien
 
 	ui.Print(terminal.NewJSONLog("App description", appDesc))
 	return nil
+}
+
+func (i *describeInputs) Resolve(profile *user.Profile, ui terminal.UI) error {
+	return i.ProjectInputs.Resolve(ui, profile.WorkingDirectory, true)
 }

--- a/internal/commands/app/diff.go
+++ b/internal/commands/app/diff.go
@@ -12,6 +12,29 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// CommandMetaDiff is the command meta
+var CommandMetaDiff = cli.CommandMeta{
+	Use:         "diff",
+	Aliases:     []string{},
+	Display:     "app diff",
+	Description: "Show differences between your local directory and your Realm app",
+	HelpText: `Displays file-by-file differences between your local directory and the latest
+version of your Realm app. If you have more than one Realm app, you will be
+prompted to select a Realm app to view.`,
+}
+
+// CommandDiff is the `app diff` command
+type CommandDiff struct {
+	inputs diffInputs
+}
+
+type diffInputs struct {
+	cli.ProjectInputs
+	LocalPath           string
+	IncludeDependencies bool
+	IncludeHosting      bool
+}
+
 const (
 	flagLocalPathDiff            = "local"
 	flagLocalPathDiffUsage       = "the local path to your Realm app"
@@ -22,29 +45,6 @@ const (
 	flagIncludeHostingShort      = "s"
 	flagIncludeHostingUsage      = "include to diff Realm app hosting changes as well"
 )
-
-type diffInputs struct {
-	LocalPath           string
-	IncludeDependencies bool
-	IncludeHosting      bool
-	cli.ProjectInputs
-}
-
-func (i *diffInputs) Resolve(profile *user.Profile, ui terminal.UI) error {
-	if err := i.ProjectInputs.Resolve(ui, profile.WorkingDirectory, true); err != nil {
-		return err
-	}
-
-	if i.LocalPath == "" {
-		i.LocalPath = profile.WorkingDirectory
-	}
-	return nil
-}
-
-// CommandDiff is the `app diff` command
-type CommandDiff struct {
-	inputs diffInputs
-}
 
 // Flags is the command flags
 func (cmd *CommandDiff) Flags(fs *pflag.FlagSet) {
@@ -121,5 +121,16 @@ func (cmd *CommandDiff) Handler(profile *user.Profile, ui terminal.UI, clients c
 		strings.Join(diffs, "\n"),
 	))
 
+	return nil
+}
+
+func (i *diffInputs) Resolve(profile *user.Profile, ui terminal.UI) error {
+	if err := i.ProjectInputs.Resolve(ui, profile.WorkingDirectory, true); err != nil {
+		return err
+	}
+
+	if i.LocalPath == "" {
+		i.LocalPath = profile.WorkingDirectory
+	}
 	return nil
 }

--- a/internal/commands/app/init.go
+++ b/internal/commands/app/init.go
@@ -11,6 +11,22 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// CommandMetaInit is the command meta for the `app init` command
+var CommandMetaInit = cli.CommandMeta{
+	Use:         "init",
+	Aliases:     []string{"initialize"},
+	Display:     "app init",
+	Description: "Initialize a Realm app in your current working directory",
+	HelpText: `Initializes a new Realm app by saving your configuration files in your current
+working directory.
+
+You can specify a "--remote" flag to initialize a Realm app from an existing app;
+if you do not specify a "--remote" flag, the CLI will initialize a default
+Realm app.
+
+NOTE: To create a new Realm app and have it deployed, use "app create".`,
+}
+
 // CommandInit is the `app init` command
 type CommandInit struct {
 	inputs initInputs

--- a/internal/commands/app/list.go
+++ b/internal/commands/app/list.go
@@ -10,6 +10,15 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// CommandMetaList is the command meta for the `app list` command
+var CommandMetaList = cli.CommandMeta{
+	Use:         "list",
+	Aliases:     []string{"ls"},
+	Display:     "apps list",
+	Description: "List the Realm apps you have access to",
+	HelpText:    `Lists and filters your Realm apps.`,
+}
+
 // CommandList is the `app list` command
 type CommandList struct {
 	inputs cli.ProjectInputs

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -19,284 +19,161 @@ import (
 var (
 	Login = cli.CommandDefinition{
 		Command:     &login.Command{},
-		Use:         "login",
-		Description: "Log in to your Realm App backend with a MongoDB Cloud API key",
-		Help: `Begins an authenticated session with Realm. To get a MongoDB Cloud
-API Key, open your Realm app in the Realm UI. Navigate to Deploy in the left
-navigation menu, and select the Export App tab. From there, create a
-programmatic API key to authenticate your realm-cli session`,
+		CommandMeta: login.CommandMeta,
 	}
 
 	Logout = cli.CommandDefinition{
 		Command:     &logout.Command{},
-		Use:         "logout",
-		Description: "Log out of your Realm app backend and MongoDB Cloud",
-		Help: `Ends the authenticated session and deletes cached access tokens. To
-re-authenticate, you must call 'login' with your API Key.`,
+		CommandMeta: logout.CommandMeta,
 	}
 
 	Whoami = cli.CommandDefinition{
 		Command:     &whoami.Command{},
-		Use:         "whoami",
-		Description: "Display information about the current user.",
-		Help: `
-Displays a table that includes your Public API Key and redacted Private API Key
-(e.g. ********-****-****-****-3ba985aa367a). No session data will be surfaced if
-you are not logged in.
-
-To log in, authenticate your information using the following command:
-
-realm-cli login --profile <profile-name>`,
+		CommandMeta: whoami.CommandMeta,
 	}
 
 	Push = cli.CommandDefinition{
 		Command:     &push.Command{},
-		Use:         push.CommandUse,
-		Aliases:     push.CommandAliases,
-		Description: "Import and deploy changes from your local directory to your Realm app",
-		Help: `Updates a remote Realm app with your local directory. First, input a Realm app
-that you would like changes pushed to. This input can be either the App ID or
-Name of an existing Realm app you would like to update, or the name of a new
-Realm app you would like to create. Changes pushed are automatically deployed.`,
+		CommandMeta: push.CommandMeta,
 	}
 
 	Pull = cli.CommandDefinition{
 		Command:     &pull.Command{},
-		Use:         "export",
-		Aliases:     []string{"pull"},
-		Description: "Export the latest version of your Realm app into your local directory",
-		Help: `Updates your local directory with a remote Realm app by pulling changes from the
-latter into the former. Input a Realm app that you would like to have changes
-pulled from. If applicable, hosting files and/or dependencies associated with
-your Realm app will be exported as well.`,
+		CommandMeta: pull.CommandMeta,
 	}
 
 	App = cli.CommandDefinition{
-		Use:         "apps",
-		Aliases:     []string{"app"},
-		Description: "Manage the Realm apps associated with the current user",
+		CommandMeta: cli.CommandMeta{
+			Use:         "apps",
+			Aliases:     []string{"app"},
+			Description: "Manage the Realm apps associated with the current user",
+		},
 		SubCommands: []cli.CommandDefinition{
 			{
 				Command:     &app.CommandInit{},
-				Use:         "init",
-				Aliases:     []string{"initialize"},
-				Display:     "app init",
-				Description: "Initialize a Realm app in your current working directory",
-				Help: `Initializes configuration files and directories to represent a minimal Realm app
-within your current working directory. This command only affects your local
-environment and does not deploy your app to the Realm servers. To create a new
-Realm app and have it deployed, use ‘app create’.
-
-You can specify a ‘--remote’ flag to initialize a Realm app from an existing
-app; if you do not specify a '--remote' flag, the CLI will initialize a default
-Realm app.`,
+				CommandMeta: app.CommandMetaInit,
 			},
 			{
 				Command:     &app.CommandCreate{},
-				Use:         "create",
-				Display:     app.CommandCreateDisplay,
-				Description: "Create a Realm app in a local directory and deploy it to the Realm server",
-				Help: `Creates a new Realm app in the cloud and saves your configuration files in a
-local directory.  This command will also deploy the new app to the Realm servers.
-This command will create a new directory for your project. To create a Realm app
-and not have it deployed, use ‘app init’.
-
-You can specify a '--remote' flag to create a Realm app from an existing app; if
-you do not specify a '--remote' flag, the CLI will create a default Realm app.`,
+				CommandMeta: app.CommandMetaCreate,
 			},
 			{
 				Command:     &app.CommandList{},
-				Use:         "list",
-				Aliases:     []string{"ls"},
-				Display:     "apps list",
-				Description: "List the Realm apps you have access to",
-				Help:        `Lists and filters your Realm apps`,
-			},
-			{
-				Command:     &app.CommandDiff{},
-				Use:         "diff",
-				Aliases:     []string{},
-				Display:     "app diff",
-				Description: "Show differences between your Realm app and your local directory",
-				Help: `Displays file-by-file differences between the latest version of your Realm app
-and your local directory. If you have more than one Realm app, you will be
-prompted to select a Realm app that you would like to display from a list of all
-Realm apps associated with your user profile.`,
+				CommandMeta: app.CommandMetaList,
 			},
 			{
 				Command:     &app.CommandDelete{},
-				Use:         "delete",
-				Display:     "app delete",
-				Description: "Delete a Realm app",
-				Help: `If you have more than one Realm app, you will be prompted to select one or
-multiple app(s) that you would like to delete from a list of all your Realm apps.
-The list includes Realm apps from all projects associated with your user profile.`,
+				CommandMeta: app.CommandMetaDelete,
+			},
+			{
+				Command:     &app.CommandDiff{},
+				CommandMeta: app.CommandMetaDiff,
 			},
 			{
 				Command:     &app.CommandDescribe{},
-				Use:         "describe",
-				Display:     "app describe",
-				Description: "View all of the configured and enabled aspects of your Realm app",
-				Help: `Displays information about your Realm app.
-If you have more than one Realm app, you will be prompted to select a Realm app that
-you would like to view from a list of all Realm apps associated with your user profile.`,
+				CommandMeta: app.CommandMetaDescribe,
 			},
 		},
 	}
 
 	User = cli.CommandDefinition{
-		Use:         "users",
-		Aliases:     []string{"user"},
-		Description: "Manage the users of your Realm app",
+		CommandMeta: cli.CommandMeta{
+			Use:         "users",
+			Aliases:     []string{"user"},
+			Description: "Manage the Users of your Realm app",
+		},
 		SubCommands: []cli.CommandDefinition{
 			{
 				Command:     &user.CommandCreate{},
-				Use:         "create",
-				Display:     "user create",
-				Description: "Create an application user in your Realm app",
-				Help: `Adds a new user to your Realm app. You can create a user
-				using an Email/Password or an API Key.`,
+				CommandMeta: user.CommandMetaCreate,
 			},
 			{
 				Command:     &user.CommandList{},
-				Use:         "list",
-				Description: "List the application users in your Realm app",
-				Help: `Displays a list of your Realm app's users' details. The list is grouped by
-auth provider type and sorted by last authentication date.`,
+				CommandMeta: user.CommandMetaList,
 			},
 			{
 				Command:     &user.CommandDisable{},
-				Use:         "disable",
-				Display:     "user disable",
-				Description: "Disable an application user in your Realm app",
-				Help: `Deactivates a user on your Realm app. A user that has been disabled will not be
-allowed to log in, even if they provide valid credentials.`,
+				CommandMeta: user.CommandMetaDisable,
 			},
 			{
 				Command:     &user.CommandEnable{},
-				Use:         "enable",
-				Display:     "user enable",
-				Description: "Enable an application user in your Realm app",
-				Help: `Activates a user on your Realm app. A user that has been enabled will have no
-restrictions with logging in.`,
+				CommandMeta: user.CommandMetaEnable,
 			},
 			{
 				Command:     &user.CommandRevoke{},
-				Use:         "revoke",
-				Display:     "user revoke",
-				Description: "Revoke an application user’s sessions from your Realm app",
-				Help: `Logs a user out of your Realm app. A user who’s user session has been revoked
-can log in again if they provide valid credentials.`,
+				CommandMeta: user.CommandMetaRevoke,
 			},
 			{
 				Command:     &user.CommandDelete{},
-				Use:         "delete",
-				Display:     "user delete",
-				Description: "Delete an application user from your Realm app",
-				// TODO(REALMC-7662): Document downstream events after deleting a user
-				Help: `Removes a specific user from your Realm app.`,
+				CommandMeta: user.CommandMetaDelete,
 			},
 		},
 	}
 
 	Secrets = cli.CommandDefinition{
-		Use:         "secrets",
-		Aliases:     []string{"secret"},
-		Description: "Manage the secrets of your Realm app",
+		CommandMeta: cli.CommandMeta{
+			Use:         "secrets",
+			Aliases:     []string{"secret"},
+			Description: "Manage the Secrets of your Realm app",
+		},
 		SubCommands: []cli.CommandDefinition{
 			{
 				Command:     &secrets.CommandCreate{},
-				Use:         "create",
-				Display:     "secrets create",
-				Description: "Create a secret in your Realm app",
-				Help: `Adds a new secret to your Realm app. You will be prompted to name your secret
-and define the value of your secret.`,
+				CommandMeta: secrets.CommandMetaCreate,
 			},
 			{
 				Command:     &secrets.CommandList{},
-				Use:         "list",
-				Aliases:     []string{"ls"},
-				Display:     "secrets list",
-				Description: "List the secrets in your Realm app",
-				Help:        `Displays a list of your Realm app's secrets.`,
+				CommandMeta: secrets.CommandMetaList,
 			},
 			{
 				Command:     &secrets.CommandUpdate{},
-				Use:         "update",
-				Display:     "secret update",
-				Description: "Update a secret in your Realm app",
-				Help: `Modifies the value of a secret in your Realm app. The name of the secret cannot
-be modified.`,
+				CommandMeta: secrets.CommandMetaUpdate,
 			},
 			{
 				Command:     &secrets.CommandDelete{},
-				Use:         "delete",
-				Display:     "secrets delete",
-				Description: "Delete a secret from your Realm app",
-				Help:        `Removes a secret from your Realm app.`,
+				CommandMeta: secrets.CommandMetaDelete,
 			},
 		},
 	}
 
 	Function = cli.CommandDefinition{
-		Use:         "function",
-		Aliases:     []string{"functions"},
-		Description: "Manage the functions of your Realm app",
+		CommandMeta: cli.CommandMeta{
+			Use:         "function",
+			Aliases:     []string{"functions"},
+			Description: "Interact with the Functions of your Realm app",
+		},
 		SubCommands: []cli.CommandDefinition{
 			{
 				Command:     &function.CommandRun{},
-				Use:         "run",
-				Description: "Run a function from your Realm app",
-				Help: `Realm Functions allow you to define and execute server-side logic for your
-Realm app. Once you select and run a function for your Realm app, the
-following will be displayed:
- - A list of logs, if present
- - The function result as a document
- - A list of error logs, if present
-`,
+				CommandMeta: function.CommandMetaRun,
 			},
 		},
 	}
 
 	Logs = cli.CommandDefinition{
-		Use:         "logs",
-		Aliases:     []string{"log"},
-		Description: "Interact with the logs of your Realm app",
+		CommandMeta: cli.CommandMeta{
+			Use:         "logs",
+			Aliases:     []string{"log"},
+			Description: "Interact with the Logs of your Realm app",
+		},
 		SubCommands: []cli.CommandDefinition{
 			{
 				Command:     &logs.CommandList{},
-				Use:         "list",
-				Aliases:     []string{"ls"},
-				Display:     "logs list",
-				Description: "Lists the logs in your Realm app",
-				Help: `Displays a list of your Realm app’s logs sorted by recentness, with most recent
-logs appearing towards the bottom.  You can specify a --tail flag to monitor
-your logs and follow any newly created logs in real-time.`,
+				CommandMeta: logs.CommandMetaList,
 			},
 		},
 	}
 
 	Schema = cli.CommandDefinition{
-		Use:         "schema",
-		Aliases:     []string{"schemas"},
-		Description: "Manage the schemas of your Realm app",
+		CommandMeta: cli.CommandMeta{
+			Use:         "schema",
+			Aliases:     []string{"schemas"},
+			Description: "Manage the Schemas of your Realm app",
+		},
 		SubCommands: []cli.CommandDefinition{
 			{
 				Command:     &schema.CommandDatamodels{},
-				Use:         "datamodels",
-				Aliases:     []string{"datamodel"},
-				Display:     "schema datamodels",
-				Description: "Generate data models based on your schema",
-				Help: `Translates your schema’s objects into Realm data models. The data models define
-your data as native objects, which can be easily integrated into your
-application to use with Realm Sync. Note that you must have a valid JSON schema
-before using this command.
-
-With this command, you can:
-  - Specify the language with a --language flag
-  - Filter which schema objects you’d like to include in your output with --name flags
-  - Combine your schema objects into a single output with a --flat flag
-  - Omit import groups from your model with a --no-imports flag`,
+				CommandMeta: schema.CommandMetaDatamodels,
 			},
 		},
 	}

--- a/internal/commands/function/run.go
+++ b/internal/commands/function/run.go
@@ -15,6 +15,18 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// CommandMetaRun is the command meta for the `function run` command
+var CommandMetaRun = cli.CommandMeta{
+	Use:         "run",
+	Description: "Run a Function from your Realm app",
+	HelpText: `Realm Functions allow you to define and execute server-side logic for your Realm
+app. Once you select and run a Function for your Realm app, the following will
+be displayed:
+  - A list of logs, if present
+  - The function result as a document
+  - A list of error logs, if present`,
+}
+
 // CommandRun is the `function run` command
 type CommandRun struct {
 	inputs inputs

--- a/internal/commands/login/command.go
+++ b/internal/commands/login/command.go
@@ -8,6 +8,16 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// CommandMeta is the command meta for the `login` command
+var CommandMeta = cli.CommandMeta{
+	Use:         "login",
+	Description: "Log the CLI into Realm using a MongoDB Cloud API key",
+	HelpText: `Begins an authenticated session with Realm. To get a MongoDB Cloud API Key, open
+your Realm app in the Realm UI. Navigate to "Deployment" in the left navigation
+menu, and select the "Export App" tab. From there, create a programmatic API key
+to authenticate your realm-cli session.`,
+}
+
 // Command is the `login` command
 type Command struct {
 	inputs inputs

--- a/internal/commands/logout/command.go
+++ b/internal/commands/logout/command.go
@@ -6,6 +6,14 @@ import (
 	"github.com/10gen/realm-cli/internal/terminal"
 )
 
+// CommandMeta is the command meta for the `logout` command
+var CommandMeta = cli.CommandMeta{
+	Use:         "logout",
+	Description: "Log the CLI out of Realm",
+	HelpText: `Ends the authenticated session and deletes cached auth tokens. To
+re-authenticate, you must call Login with your Atlas programmatic API key.`,
+}
+
 // Command is the `logout` command
 type Command struct{}
 

--- a/internal/commands/logs/list.go
+++ b/internal/commands/logs/list.go
@@ -22,6 +22,17 @@ var (
 	tailLookBehind = 5
 )
 
+// CommandMetaList is the command meta for the `logs list` command
+var CommandMetaList = cli.CommandMeta{
+	Use:         "list",
+	Aliases:     []string{"ls"},
+	Display:     "logs list",
+	Description: "Lists the Logs in your Realm app",
+	HelpText: `Displays a list of your Realm app’s Logs sorted by recentness, with most recent
+Logs appearing towards the bottom. You can specify a "--tail" flag to monitor
+your Logs and follow any newly created Logs in real-time.`,
+}
+
 // CommandList is the `logs list` command
 type CommandList struct {
 	inputs listInputs

--- a/internal/commands/pull/command.go
+++ b/internal/commands/pull/command.go
@@ -18,6 +18,16 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// CommandMeta is the command meta for the `pull` command
+var CommandMeta = cli.CommandMeta{
+	Use:         "pull",
+	Aliases:     []string{"export"},
+	Description: "Exports the latest version of your Realm app into your local directory",
+	HelpText: `Pulls changes from your remote Realm app into your local directory. If
+applicable, Hosting Files and/or Dependencies associated with your Realm app will be
+exported as well.`,
+}
+
 // Command is the `pull` command
 type Command struct {
 	inputs inputs

--- a/internal/commands/push/command.go
+++ b/internal/commands/push/command.go
@@ -17,15 +17,17 @@ import (
 	"github.com/spf13/pflag"
 )
 
-// set of supported `push` command strings
-const (
-	CommandUse = "import"
-)
-
-// set of supported `push` command strings
-var (
-	CommandAliases = []string{"push"}
-)
+// CommandMeta is the command meta for the 'push' command
+var CommandMeta = cli.CommandMeta{
+	Use:         "push",
+	Aliases:     []string{"import"},
+	Description: "Imports and deploys changes from your local directory to your Realm app",
+	HelpText: `Updates a remote Realm app with your local directory. First, input a Realm app
+that you would like changes pushed to. This input can be either the application
+Client App ID of an existing Realm app you would like to update, or the Name of
+a new Realm app you would like to create. Changes pushed are automatically
+deployed.`,
+}
 
 // Command is the `push` command
 type Command struct {
@@ -246,7 +248,7 @@ func (cmd *Command) Handler(profile *user.Profile, ui terminal.UI, clients cli.C
 }
 
 func (cmd *Command) display(omitDryRun bool) string {
-	return cli.CommandDisplay(CommandUse, cmd.inputs.args(omitDryRun))
+	return cli.CommandDisplay(CommandMeta.Use, cmd.inputs.args(omitDryRun))
 }
 
 type namer interface{ Name() string }

--- a/internal/commands/push/command_test.go
+++ b/internal/commands/push/command_test.go
@@ -628,7 +628,7 @@ Successfully pushed app up: eggcorn-abcde
 
 				assert.Equal(t, tc.groupsCalled, calledGroups)
 				assert.Equal(t, `This is a new app. To create a new app, you must omit the 'dry-run' flag to proceed
-Try instead: realm-cli import --local testdata/project --remote appID
+Try instead: realm-cli push --local testdata/project --remote appID
 `, out.String())
 			})
 		}
@@ -704,7 +704,7 @@ The following reflects the proposed changes to your Realm app
 diff1
 diff2
 To push these changes, you must omit the 'dry-run' flag to proceed
-Try instead: realm-cli import --local testdata/project --remote appID
+Try instead: realm-cli push --local testdata/project --remote appID
 `, out.String())
 	})
 
@@ -743,7 +743,7 @@ Removed Dependencies
 Modified Dependencies
   * underscore@1.9.1 -> underscore@1.9.2
 To push these changes, you must omit the 'dry-run' flag to proceed
-Try instead: realm-cli import --local testdata/dependencies --remote appID --include-dependencies
+Try instead: realm-cli push --local testdata/dependencies --remote appID --include-dependencies
 `, out.String())
 	})
 
@@ -1419,18 +1419,18 @@ func TestPushCommandDisplay(t *testing.T) {
 	}{
 		{
 			description: "should print a minimal command string",
-			display:     "realm-cli import",
+			display:     "realm-cli push",
 		},
 		{
 			description: "should print a minimal dry run command string",
 			inputs:      inputs{DryRun: true},
-			display:     "realm-cli import --dry-run",
+			display:     "realm-cli push --dry-run",
 		},
 		{
 			description: "should print a minimal command string with dry run set but omitted",
 			inputs:      inputs{DryRun: true},
 			omitDryRun:  true,
-			display:     "realm-cli import",
+			display:     "realm-cli push",
 		},
 		{
 			description: "should print a complete command string",
@@ -1443,7 +1443,7 @@ func TestPushCommandDisplay(t *testing.T) {
 				ResetCDNCache:       true,
 				DryRun:              true,
 			},
-			display: "realm-cli import --project project --local directory --remote remote --include-dependencies --include-hosting --reset-cdn-cache --dry-run",
+			display: "realm-cli push --project project --local directory --remote remote --include-dependencies --include-hosting --reset-cdn-cache --dry-run",
 		},
 	} {
 		t.Run(tc.description, func(t *testing.T) {

--- a/internal/commands/schema/models.go
+++ b/internal/commands/schema/models.go
@@ -13,6 +13,25 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// CommandMetaDatamodels is the command meta for the `schema datamodels` command
+var CommandMetaDatamodels = cli.CommandMeta{
+	Use:         "datamodels",
+	Aliases:     []string{"datamodel"},
+	Display:     "schema datamodels",
+	Description: "Generate data models based on your Schema",
+	HelpText: `Translates your Schema’s objects into Realm data models. The data models define
+your data as native objects, which can be easily integrated into your own repo
+to use with Realm Sync.
+
+NOTE: You must have a valid JSON Schema before using this command.
+
+With this command, you can:
+  - Specify the language with a "--language" flag
+  - Filter which Schema objects you’d like to include in your output with "--name" flags
+  - Combine your Schema objects into a single output with a "--flat" flag
+  - Omit import groups from your model with a "--no-imports" flag`,
+}
+
 // CommandDatamodels is the `schema datamodels` command
 type CommandDatamodels struct {
 	inputs datamodelsInputs

--- a/internal/commands/secrets/create.go
+++ b/internal/commands/secrets/create.go
@@ -8,6 +8,14 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// CommandMetaCreate is the command meta for the `secrets create` command
+var CommandMetaCreate = cli.CommandMeta{
+	Use:         "create",
+	Display:     "secrets create",
+	Description: "Create a Secret for your Realm app",
+	HelpText:    `You will be prompted to name your Secret and define the value of your Secret.`,
+}
+
 // CommandCreate is the `secrets create` command
 type CommandCreate struct {
 	inputs createInputs

--- a/internal/commands/secrets/delete.go
+++ b/internal/commands/secrets/delete.go
@@ -11,6 +11,16 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// CommandMetaDelete is the command meta
+var CommandMetaDelete = cli.CommandMeta{
+	Use:         "delete",
+	Display:     "secrets delete",
+	Description: "Delete a Secret from your Realm app",
+	HelpText: `With this command, you can:
+  - Remove multiple Secrets at once with "--secret" flags. You can specify these
+    Secrets using their ID or Name values`,
+}
+
 // CommandDelete for the secrets delete command
 type CommandDelete struct {
 	inputs deleteInputs

--- a/internal/commands/secrets/list.go
+++ b/internal/commands/secrets/list.go
@@ -11,6 +11,15 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// CommandMetaList is the command meta for the `secrets list` command
+var CommandMetaList = cli.CommandMeta{
+	Use:         "list",
+	Aliases:     []string{"ls"},
+	Display:     "secrets list",
+	Description: "List the Secrets in your Realm app",
+	HelpText:    `This will display the IDs and Names of the Secrets in your Realm app.`,
+}
+
 // CommandList is the `secrets list` command
 type CommandList struct {
 	inputs listInputs

--- a/internal/commands/secrets/update.go
+++ b/internal/commands/secrets/update.go
@@ -8,6 +8,15 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// CommandMetaUpdate is the command meta for the `secrets update` command
+var CommandMetaUpdate = cli.CommandMeta{
+	Use:         "update",
+	Display:     "secret update",
+	Description: "Update a Secret in your Realm app",
+	HelpText: `NOTE: The Name of the Secret cannot be modified. In order to do so, you will
+need to delete and re-create the Secret.`,
+}
+
 // CommandUpdate is the `secret update` command
 type CommandUpdate struct {
 	inputs updateInputs

--- a/internal/commands/user/create.go
+++ b/internal/commands/user/create.go
@@ -10,6 +10,15 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// CommandMetaCreate is the command meta for the `user create` command
+var CommandMetaCreate = cli.CommandMeta{
+	Use:         "create",
+	Display:     "user create",
+	Description: "Create an application user for your Realm app",
+	HelpText: `Adds a new User to your Realm app. You can create a User for the following
+enabled Auth Providers: "Email/Password", or "API Key".`,
+}
+
 // CommandCreate is the `user create` command
 type CommandCreate struct {
 	inputs createInputs

--- a/internal/commands/user/delete.go
+++ b/internal/commands/user/delete.go
@@ -13,6 +13,15 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// CommandMetaDelete is the command meta for the `user delete` command
+var CommandMetaDelete = cli.CommandMeta{
+	Use:         "delete",
+	Display:     "user delete",
+	Description: "Delete an application user from your Realm app",
+	HelpText: `You can remove multiple Users at once with the "--user" flag. You can only
+specify these Users using their ID values.`,
+}
+
 // CommandDelete is the `user delete` command
 type CommandDelete struct {
 	inputs deleteInputs

--- a/internal/commands/user/disable.go
+++ b/internal/commands/user/disable.go
@@ -12,6 +12,15 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// CommandMetaDisable is the command meta for the `user disable` command
+var CommandMetaDisable = cli.CommandMeta{
+	Use:         "disable",
+	Display:     "user disable",
+	Description: "Disable an application User of your Realm app",
+	HelpText: `Deactivates a User on your Realm app. A User that has been disabled will not be
+allowed to log in, even if they provide valid credentials.`,
+}
+
 // CommandDisable is the `user disable` command
 type CommandDisable struct {
 	inputs disableInputs

--- a/internal/commands/user/enable.go
+++ b/internal/commands/user/enable.go
@@ -12,6 +12,15 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// CommandMetaEnable is the command meta for the `user enable` command
+var CommandMetaEnable = cli.CommandMeta{
+	Use:         "enable",
+	Display:     "user enable",
+	Description: "Enable an application User of your Realm app",
+	HelpText: `Activates a User on your Realm app. A User that has been enabled will have no
+restrictions with logging in.`,
+}
+
 // CommandEnable is the `user enable` command
 type CommandEnable struct {
 	inputs enableInputs

--- a/internal/commands/user/list.go
+++ b/internal/commands/user/list.go
@@ -14,6 +14,15 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// CommandMetaList is the command meta for the `user list` command
+var CommandMetaList = cli.CommandMeta{
+	Use:         "list",
+	Aliases:     []string{"ls"},
+	Description: "List the application users of your Realm app",
+	HelpText: `Displays a list of your Realm app's Users' details. The list is grouped by Auth
+Provider type and sorted by Last Authentication Date.`,
+}
+
 // CommandList is the `user list` command
 type CommandList struct {
 	inputs listInputs

--- a/internal/commands/user/revoke.go
+++ b/internal/commands/user/revoke.go
@@ -13,6 +13,15 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// CommandMetaRevoke is the command meta for the `user revoke` command
+var CommandMetaRevoke = cli.CommandMeta{
+	Use:         "revoke",
+	Display:     "user revoke",
+	Description: "Revoke an application User’s sessions from your Realm app",
+	HelpText: `Logs a User out of your Realm app. A revoked User can log in again if they
+provide valid credentials.`,
+}
+
 // CommandRevoke is the `user revoke` command
 type CommandRevoke struct {
 	inputs revokeInputs

--- a/internal/commands/whoami/command.go
+++ b/internal/commands/whoami/command.go
@@ -6,6 +6,20 @@ import (
 	"github.com/10gen/realm-cli/internal/terminal"
 )
 
+// CommandMeta is the command meta for the `whoami` command
+var CommandMeta = cli.CommandMeta{
+	Use:         "whoami",
+	Description: "Display information about the current user",
+	// TODO(REALMC-8832): this is an example of where standardizing cli, comamnd and flag names
+	// into a shared package would be helpful, to reduce coupling the command packages to each other
+	// (since this HelptText creates a "whoami depends on login" package cycle)
+	HelpText: `Displays a table that includes your Public and redacted Private Atlas
+programmatic API Key (e.g. ********-****-****-****-3ba985aa367a). No session
+data will be surfaced if you are not logged in.
+
+NOTE: To log in and authenticate your session, use "realm-cli login"`,
+}
+
 // Command is the `whoami` command
 type Command struct{}
 


### PR DESCRIPTION
Updated copy: https://docs.google.com/document/d/14fBZaN47HRe3-2Pk1uSfYcCxX3Dd95wK0tprS3WE1vk/edit#

Things to look for:
 - [ ] `HelpText` should neither start nor end with a new-line (read: the backticks should be on the same line as the ensuing/preceding text
 - [ ] `Description` will not end with punctuation, `HelpText` should use all punctuation (except for within bulleted lists)
 - [ ] Realm "Resources" (think `Function`, `Auth Provider`, etc) should be capitalized when referenced
 - [ ] References to commands or flags should be wrapped with quotes (`""`, none of those fancy Word quotes)

Long-term thinking here: I added a `TODO` in here hopefully to start to address the issue of commands wanting to know about other commands' names, flags, etc.  Ideally we can do this in a way that prevents creating a maze of package cycles (`whoami` would end up depending on `login` and similar situations)