### PR TITLE
REALMC-8645: Enable delete app using client app id

### DIFF
--- a/internal/commands/app/delete_inputs.go
+++ b/internal/commands/app/delete_inputs.go
@@ -46,15 +46,13 @@ func (inputs *deleteInputs) resolveApps(ui terminal.UI, client realm.Client) ([]
 		appsFiltered := make([]realm.App, 0, len(inputs.Apps))
 		for _, inputApp := range inputs.Apps {
 
-			appByClientAppID, ok := appsByClientAppID[inputApp]
-			if ok {
-				appsFiltered = append(appsFiltered, appByClientAppID)
+			if app, ok := appsByClientAppID[inputApp]; ok {
+				appsFiltered = append(appsFiltered, app)
 				continue
 			}
 
-			appByName, ok := appsByName[inputApp]
-			if ok {
-				appsFiltered = append(appsFiltered, appByName)
+			if app, ok := appsByName[inputApp]; ok {
+				appsFiltered = append(appsFiltered, app)
 				continue
 			}
 

--- a/internal/commands/app/delete_inputs.go
+++ b/internal/commands/app/delete_inputs.go
@@ -35,20 +35,30 @@ func (inputs *deleteInputs) resolveApps(ui terminal.UI, client realm.Client) ([]
 	}
 
 	if len(inputs.Apps) > 0 {
+		appsByClientAppID := map[string]realm.App{}
 		appsByName := map[string]realm.App{}
 		for _, app := range apps {
 			appsByName[app.Name] = app
+			appsByClientAppID[app.ClientAppID] = app
 		}
 
 		missingApps := make([]string, 0)
 		appsFiltered := make([]realm.App, 0, len(inputs.Apps))
 		for _, inputApp := range inputs.Apps {
-			app, ok := appsByName[inputApp]
-			if !ok {
-				missingApps = append(missingApps, inputApp)
+
+			appByClientAppID, ok := appsByClientAppID[inputApp]
+			if ok {
+				appsFiltered = append(appsFiltered, appByClientAppID)
 				continue
 			}
-			appsFiltered = append(appsFiltered, app)
+
+			appByName, ok := appsByName[inputApp]
+			if ok {
+				appsFiltered = append(appsFiltered, appByName)
+				continue
+			}
+
+			missingApps = append(missingApps, inputApp)
 		}
 
 		if len(missingApps) > 0 {

--- a/internal/commands/app/delete_inputs_test.go
+++ b/internal/commands/app/delete_inputs_test.go
@@ -71,6 +71,12 @@ func TestResolveApps(t *testing.T) {
 				apps:         testApps,
 				expectedApps: []realm.App{app1, app2},
 			},
+			{
+				description:  "should return found apps without prompting based on app client ID or name inputs provided",
+				inputs:       deleteInputs{Apps: []string{"app1-abcde", "app3"}},
+				apps:         testApps,
+				expectedApps: []realm.App{app1, app3},
+			},
 		} {
 			t.Run(tc.description, func(t *testing.T) {
 				realmClient := mock.RealmClient{}

--- a/internal/commands/app/delete_inputs_test.go
+++ b/internal/commands/app/delete_inputs_test.go
@@ -60,10 +60,16 @@ func TestResolveApps(t *testing.T) {
 				description: "should return no apps with no found apps nor input apps without prompting",
 			},
 			{
-				description:  "should return found apps without prompting based on inputs provided",
+				description:  "should return found apps without prompting based on app name inputs provided",
 				inputs:       deleteInputs{Apps: []string{"app2", "app3"}},
 				apps:         testApps,
 				expectedApps: []realm.App{app2, app3},
+			},
+			{
+				description:  "should return found apps without prompting based on app client ID inputs provided",
+				inputs:       deleteInputs{Apps: []string{"app1-abcde", "app2-hijkl"}},
+				apps:         testApps,
+				expectedApps: []realm.App{app1, app2},
 			},
 		} {
 			t.Run(tc.description, func(t *testing.T) {


### PR DESCRIPTION
failures [here](https://spruce.mongodb.com/task/realm_cli_rhel70_test_with_cloud_patch_f83299f1742a4550a12b5f3b25a1dbf860e07372_60aeafdb5623436b0bcb854c_21_05_26_20_30_29/logs?execution=0) are unrelated to these changes, proceeding with merge