### PR TITLE
REALMC-8944: Use default urls if not previously set in profile

### DIFF
--- a/internal/cli/user/profile.go
+++ b/internal/cli/user/profile.go
@@ -190,6 +190,7 @@ const (
 	keyLastVersionCheck = "last_version_check"
 )
 
+// TelemetryMode gets the CLI profile telemetry mode
 func (p Profile) TelemetryMode() telemetry.Mode {
 	return telemetry.Mode(p.GetString(keyTelemetryMode))
 }

--- a/internal/cli/user/profile.go
+++ b/internal/cli/user/profile.go
@@ -141,14 +141,14 @@ func (p *Profile) Save() error {
 
 // ResolveFlags resolves the user profile flags
 func (p *Profile) ResolveFlags() error {
-	if p.TelemetryMode == telemetry.ModeEmpty {
-		p.TelemetryMode = telemetry.Mode(p.GetString(keyTelemetryMode))
+	if p.Flags.TelemetryMode == telemetry.ModeEmpty {
+		p.Flags.TelemetryMode = p.TelemetryMode()
 	}
-	p.SetString(keyTelemetryMode, string(p.TelemetryMode))
+	p.SetString(keyTelemetryMode, string(p.Flags.TelemetryMode))
 
 	if p.Flags.RealmBaseURL == "" {
-		realmBaseURL := p.GetString(keyRealmBaseURL)
-		if FlagRealmBaseURL == "" {
+		realmBaseURL := p.RealmBaseURL()
+		if realmBaseURL == "" {
 			realmBaseURL = defaultRealmBaseURL
 		}
 		p.Flags.RealmBaseURL = realmBaseURL
@@ -156,8 +156,8 @@ func (p *Profile) ResolveFlags() error {
 	p.SetRealmBaseURL(p.Flags.RealmBaseURL)
 
 	if p.Flags.AtlasBaseURL == "" {
-		atlasBaseURL := p.GetString(keyAtlasBaseURL)
-		if FlagAtlasBaseURL == "" {
+		atlasBaseURL := p.AtlasBaseURL()
+		if atlasBaseURL == "" {
 			atlasBaseURL = defaultAtlasBaseURL
 		}
 		p.Flags.AtlasBaseURL = atlasBaseURL
@@ -189,6 +189,10 @@ const (
 	keyTelemetryMode    = "telemetry_mode"
 	keyLastVersionCheck = "last_version_check"
 )
+
+func (p Profile) TelemetryMode() telemetry.Mode {
+	return telemetry.Mode(p.GetString(keyTelemetryMode))
+}
 
 // Credentials gets the CLI profile credentials
 func (p Profile) Credentials() Credentials {

--- a/internal/cli/user/profile_ext_test.go
+++ b/internal/cli/user/profile_ext_test.go
@@ -1,0 +1,57 @@
+package user_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/10gen/realm-cli/internal/cli/user"
+	u "github.com/10gen/realm-cli/internal/utils/test"
+	"github.com/10gen/realm-cli/internal/utils/test/assert"
+)
+
+func TestProfile(t *testing.T) {
+	tmpDir, teardownTmpDir, tmpDirErr := u.NewTempDir("home")
+	assert.Nil(t, tmpDirErr)
+	defer teardownTmpDir()
+
+	_, teardownHomeDir := u.SetupHomeDir(tmpDir)
+	defer teardownHomeDir()
+
+	profile, profileErr := user.NewDefaultProfile()
+	assert.Nil(t, profileErr)
+
+	t.Run("Should initialize as an empty, default profile", func(t *testing.T) {
+		assert.Equal(t, user.DefaultProfile, profile.Name)
+		assert.Equal(t, tmpDir+"/.config/realm-cli", profile.Dir())
+	})
+
+	t.Run("Should load a config that does not exist without error", func(t *testing.T) {
+		assert.Nil(t, profile.Load())
+	})
+
+	t.Run("Should set config values properly", func(t *testing.T) {
+		profile.SetString("a", "ayyy")
+		profile.SetString("b", "be")
+
+		assert.Equal(t, profile.GetString("a"), "ayyy")
+		assert.Equal(t, profile.GetString("b"), "be")
+	})
+
+	t.Run("Should save a config properly", func(t *testing.T) {
+		assert.Nil(t, profile.Save())
+
+		config, err := ioutil.ReadFile(profile.Path())
+		assert.Nil(t, err)
+		assert.True(t, strings.Contains(string(config), `default:
+  a: ayyy
+  b: be
+`), "config must contain the expected contents")
+	})
+
+	t.Run("Should provide a path the the hosting asset cache file", func(t *testing.T) {
+		cachePath := fmt.Sprintf("%s/%s/%s.json", profile.Dir(), user.HostingAssetCacheDir, profile.Name)
+		assert.Equal(t, cachePath, profile.HostingAssetCachePath())
+	})
+}


### PR DESCRIPTION
its a messy diff, but basically:

* `git mv internal/cli/user/profile_test.go internal/cli/user/profile_ext_test.go`
* entirely new test file: `internal/cli/user/profile_test.go`