### PR TITLE
REALMC-8824: Ensure command factory closes properly before exiting cli

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"log"
+	"os"
 
 	"github.com/10gen/realm-cli/internal/cli"
 	"github.com/10gen/realm-cli/internal/commands"
@@ -23,9 +25,12 @@ func Run() {
 		SilenceUsage:  true,
 	}
 
-	factory := cli.NewCommandFactory()
+	factory, err := cli.NewCommandFactory()
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	cobra.OnInitialize(factory.Setup)
-	defer factory.Close()
 
 	cmd.Flags().SortFlags = false // ensures CLI help text displays global flags unsorted
 	factory.SetGlobalFlags(cmd.PersistentFlags())
@@ -42,5 +47,5 @@ func Run() {
 	cmd.AddCommand(factory.Build(commands.Function))
 	cmd.AddCommand(factory.Build(commands.Schema))
 
-	factory.Run(cmd)
+	os.Exit(factory.Run(cmd))
 }

--- a/internal/terminal/ui.go
+++ b/internal/terminal/ui.go
@@ -90,7 +90,7 @@ func (ui *ui) Print(logs ...Log) {
 		}
 
 		if _, err := fmt.Fprintln(writer, output); err != nil {
-			log.Fatal(output) // log the original failure
+			log.Print(output) // log the original output
 		}
 	}
 }


### PR DESCRIPTION
i'll switch `*CommandFactory.Run` to return `error` if you still don't like this, I just wanted one last chance to defend the semantics of this code (why return `err` if you shouldn't do anything with it, as its already been consumed/reported?)