### PR TITLE
remove repeated word in help text

### DIFF
--- a/internal/commands/pull/inputs.go
+++ b/internal/commands/pull/inputs.go
@@ -21,7 +21,7 @@ const (
 
 	flagIncludeDependencies      = "include-dependencies"
 	flagIncludeDependenciesShort = "d"
-	flagIncludeDependenciesUsage = "include to to export Realm app dependencies changes as well"
+	flagIncludeDependenciesUsage = "include to export Realm app dependencies changes as well"
 
 	flagIncludeHosting      = "include-hosting"
 	flagIncludeHostingShort = "s"


### PR DESCRIPTION
Help for pull command --include-dependencies has a repeated `to`: `include to to export...`