### PR TITLE
REALMC-9391: Add initial data source to app create body

### DIFF
--- a/internal/cloud/realm/app.go
+++ b/internal/cloud/realm/app.go
@@ -18,10 +18,11 @@ const (
 
 // AppMeta is Realm application metadata
 type AppMeta struct {
-	Location        Location        `json:"location,omitempty"`
-	DeploymentModel DeploymentModel `json:"deployment_model,omitempty"`
-	Environment     Environment     `json:"environment,omitempty"`
-	Template        string          `json:"template_id,omitempty"`
+	Location          Location        `json:"location,omitempty"`
+	DeploymentModel   DeploymentModel `json:"deployment_model,omitempty"`
+	Environment       Environment     `json:"environment,omitempty"`
+	Template          string          `json:"template_id,omitempty"`
+	InitialDataSource interface{}     `json:"link_data_source_data,omitempty"`
 }
 
 // App is a Realm application

--- a/internal/cloud/realm/app.go
+++ b/internal/cloud/realm/app.go
@@ -18,11 +18,11 @@ const (
 
 // AppMeta is Realm application metadata
 type AppMeta struct {
-	Location          Location        `json:"location,omitempty"`
-	DeploymentModel   DeploymentModel `json:"deployment_model,omitempty"`
-	Environment       Environment     `json:"environment,omitempty"`
-	Template          string          `json:"template_id,omitempty"`
-	InitialDataSource interface{}     `json:"link_data_source_data,omitempty"`
+	Location        Location        `json:"location,omitempty"`
+	DeploymentModel DeploymentModel `json:"deployment_model,omitempty"`
+	Environment     Environment     `json:"environment,omitempty"`
+	Template        string          `json:"template_id,omitempty"`
+	DataSource      interface{}     `json:"data_source,omitempty"`
 }
 
 // App is a Realm application

--- a/internal/commands/app/create.go
+++ b/internal/commands/app/create.go
@@ -14,7 +14,6 @@ import (
 	"github.com/10gen/realm-cli/internal/terminal"
 	"github.com/10gen/realm-cli/internal/utils/flags"
 
-	"github.com/AlecAivazis/survey/v2"
 	"github.com/briandowns/spinner"
 	"github.com/spf13/pflag"
 )
@@ -184,59 +183,26 @@ func (cmd *CommandCreate) Handler(profile *user.Profile, ui terminal.UI, clients
 		return nil
 	}
 
+	createAppMetadata := realm.AppMeta{
+		Location:        cmd.inputs.Location,
+		DeploymentModel: cmd.inputs.DeploymentModel,
+		Environment:     cmd.inputs.Environment,
+		Template:        cmd.inputs.Template,
+	}
+
 	// choose a data source to import template app schema data onto
-	var initialDataSource interface{}
 	if cmd.inputs.Template != "" {
-		if len(dsClusters)+len(dsDatalakes) == 1 {
-			if len(dsClusters) > 0 {
-				initialDataSource = dsClusters[0]
-			} else {
-				initialDataSource = dsDatalakes[0]
-			}
-		} else {
-			// If linking multiple data sources, prompt the user to ask on which data source to write template app
-			// schema to
-			initialTemplateDataSources := make([]interface{}, 0, len(dsClusters)+len(dsDatalakes))
-			options := make([]string, 0, len(dsClusters)+len(dsDatalakes))
-
-			for _, cluster := range dsClusters {
-				initialTemplateDataSources = append(initialTemplateDataSources, cluster)
-				options = append(options, fmt.Sprintf("[Cluster]: %s", cluster.Name))
-			}
-			for _, datalake := range dsDatalakes {
-				initialTemplateDataSources = append(initialTemplateDataSources, datalake)
-				options = append(options, fmt.Sprintf("[Data Lake]: %s", datalake.Name))
-			}
-
-			var selectedIndex int
-			if err := ui.AskOne(
-				&selectedIndex,
-				&survey.Select{
-					Message: "Please choose a data source to write template app schema to:",
-					Options: options,
-				},
-			); err != nil {
-				return err
-			}
-			initialDataSource = initialTemplateDataSources[selectedIndex]
+		initialDataSource, err := cmd.inputs.resolveInitialTemplateDataSource(ui, dsDatalakes, dsClusters)
+		if err != nil {
+			return err
 		}
-
-		if initialDataSource == nil {
-			ui.Print(terminal.NewTextLog("Cannot create a template app without an initial data source"))
-			return nil
-		}
+		createAppMetadata.DataSource = initialDataSource
 	}
 
 	appRealm, err := clients.Realm.CreateApp(
 		groupID,
 		cmd.inputs.Name,
-		realm.AppMeta{
-			Location:        cmd.inputs.Location,
-			DeploymentModel: cmd.inputs.DeploymentModel,
-			Environment:     cmd.inputs.Environment,
-			Template:        cmd.inputs.Template,
-			DataSource:      initialDataSource,
-		},
+		createAppMetadata,
 	)
 	if err != nil {
 		return err

--- a/internal/commands/app/create_inputs.go
+++ b/internal/commands/app/create_inputs.go
@@ -53,9 +53,10 @@ type createInputs struct {
 }
 
 type dataSourceCluster struct {
-	Name   string        `json:"name"`
-	Type   string        `json:"type"`
-	Config configCluster `json:"config"`
+	Name    string        `json:"name"`
+	Type    string        `json:"type"`
+	Config  configCluster `json:"config"`
+	Version int           `json:"version"`
 }
 
 type configCluster struct {
@@ -65,9 +66,10 @@ type configCluster struct {
 }
 
 type dataSourceDatalake struct {
-	Name   string         `json:"name"`
-	Type   string         `json:"type"`
-	Config configDatalake `json:"config"`
+	Name    string         `json:"name"`
+	Type    string         `json:"type"`
+	Config  configDatalake `json:"config"`
+	Version int            `json:"version"`
 }
 
 type configDatalake struct {
@@ -206,6 +208,7 @@ func (i *createInputs) resolveClusters(ui terminal.UI, client atlas.Client, grou
 					ReadPreference:      "primary",
 					WireProtocolEnabled: false,
 				},
+				Version: 1,
 			})
 	}
 

--- a/internal/commands/app/create_inputs_test.go
+++ b/internal/commands/app/create_inputs_test.go
@@ -399,6 +399,7 @@ func TestAppCreateInputsResolveCluster(t *testing.T) {
 					ReadPreference:      "primary",
 					WireProtocolEnabled: false,
 				},
+				Version: 1,
 			},
 		}, ds)
 		assert.Equal(t, "123", expectedGroupID)
@@ -434,6 +435,7 @@ func TestAppCreateInputsResolveCluster(t *testing.T) {
 					ReadPreference:      "primary",
 					WireProtocolEnabled: false,
 				},
+				Version: 1,
 			},
 			{
 				Name: "another-data-source",
@@ -443,6 +445,7 @@ func TestAppCreateInputsResolveCluster(t *testing.T) {
 					ReadPreference:      "primary",
 					WireProtocolEnabled: false,
 				},
+				Version: 1,
 			},
 		}, ds)
 		assert.Equal(t, "123", expectedGroupID)
@@ -508,6 +511,7 @@ func TestAppCreateInputsResolveCluster(t *testing.T) {
 					ReadPreference:      "primary",
 					WireProtocolEnabled: false,
 				},
+				Version: 1,
 			},
 		}, ds)
 	})
@@ -673,6 +677,7 @@ func TestAppCreateInputsResolveCluster(t *testing.T) {
 							ReadPreference:      "primary",
 							WireProtocolEnabled: false,
 						},
+						Version: 1,
 					},
 					{
 						Name: tc.expectedClusterServiceNames[1],
@@ -682,6 +687,7 @@ func TestAppCreateInputsResolveCluster(t *testing.T) {
 							ReadPreference:      "primary",
 							WireProtocolEnabled: false,
 						},
+						Version: 1,
 					},
 				}, ds)
 			})

--- a/internal/commands/app/create_test.go
+++ b/internal/commands/app/create_test.go
@@ -311,7 +311,7 @@ Check out your app: cd ./test-app && realm-cli app describe
 		}, createdApp)
 	})
 
-	t.Run("when a template is not provided should prompt for template selection", func(t *testing.T) {
+	t.Run("when creating a template app", func(t *testing.T) {
 		profile, teardown := mock.NewProfileFromTmpDir(t, "app_create_test")
 		defer teardown()
 		profile.SetRealmBaseURL("http://localhost:8080")
@@ -391,11 +391,19 @@ Check out your app: cd ./test-app && realm-cli app describe
 		console.Tty().Close() // flush the writers
 		<-doneCh              // wait for procedure to complete
 
-		path := filepath.Join(profile.WorkingDirectory, cmd.inputs.Name, backendPath)
-		appLocal, err := local.LoadApp(path)
-		assert.Nil(t, err)
+		t.Run("should export realm app in backend directory", func(t *testing.T) {
+			path := filepath.Join(profile.WorkingDirectory, cmd.inputs.Name, backendPath)
+			appLocal, err := local.LoadApp(path)
+			assert.Nil(t, err)
 
-		assert.Equal(t, appLocal.RootDir, path)
+			assert.Equal(t, appLocal.RootDir, path)
+		})
+
+		t.Run("should export frontend client to frontend/ folder", func(t *testing.T) {
+			_, err := os.Stat(filepath.Join(profile.WorkingDirectory, cmd.inputs.Name, frontendPath, "palm-pilot.bitcoin-miner"))
+			frontendClientFolderExists := !os.IsNotExist((err))
+			assert.Equal(t, frontendClientFolderExists, true)
+		})
 	})
 
 	t.Run("should create a new app with a structure based on the specified remote app", func(t *testing.T) {

--- a/internal/commands/app/create_test.go
+++ b/internal/commands/app/create_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -311,7 +312,7 @@ Check out your app: cd ./test-app && realm-cli app describe
 		}, createdApp)
 	})
 
-	t.Run("when creating a template app", func(t *testing.T) {
+	t.Run("when a template is not provided should prompt for template selection", func(t *testing.T) {
 		profile, teardown := mock.NewProfileFromTmpDir(t, "app_create_test")
 		defer teardown()
 		profile.SetRealmBaseURL("http://localhost:8080")
@@ -319,6 +320,8 @@ Check out your app: cd ./test-app && realm-cli app describe
 		procedure := func(c *expect.Console) {
 			c.ExpectString("Please select a template from the available options")
 			c.SendLine("palm-pilot.bitcoin-miner")
+			c.ExpectString("Enter a Service Name for Cluster 'test-cluster")
+			c.SendLine("test-cluster")
 			c.ExpectEOF()
 		}
 
@@ -378,32 +381,30 @@ Check out your app: cd ./test-app && realm-cli app describe
 		ac.GroupsFn = func() ([]atlas.Group, error) {
 			return []atlas.Group{{ID: "123"}}, nil
 		}
+		ac.ClustersFn = func(groupID string) ([]atlas.Cluster, error) {
+			return []atlas.Cluster{{Name: "test-cluster"}}, nil
+		}
 
-		cmd := &CommandCreate{createInputs{newAppInputs: newAppInputs{
-			Name:            "template-app",
-			Location:        realm.LocationVirginia,
-			DeploymentModel: realm.DeploymentModelGlobal,
-			ConfigVersion:   realm.DefaultAppConfigVersion,
-		}}}
+		cmd := &CommandCreate{createInputs{
+			newAppInputs: newAppInputs{
+				Name:            "template-app",
+				Location:        realm.LocationVirginia,
+				DeploymentModel: realm.DeploymentModelGlobal,
+				ConfigVersion:   realm.DefaultAppConfigVersion,
+			},
+			Clusters: []string{"test-cluster"},
+		}}
 
 		assert.Nil(t, cmd.Handler(profile, ui, cli.Clients{Realm: rc, Atlas: ac}))
 
 		console.Tty().Close() // flush the writers
 		<-doneCh              // wait for procedure to complete
 
-		t.Run("should export realm app in backend directory", func(t *testing.T) {
-			path := filepath.Join(profile.WorkingDirectory, cmd.inputs.Name, backendPath)
-			appLocal, err := local.LoadApp(path)
-			assert.Nil(t, err)
+		path := filepath.Join(profile.WorkingDirectory, cmd.inputs.Name, backendPath)
+		appLocal, err := local.LoadApp(path)
+		assert.Nil(t, err)
 
-			assert.Equal(t, appLocal.RootDir, path)
-		})
-
-		t.Run("should export frontend client to frontend/ folder", func(t *testing.T) {
-			_, err := os.Stat(filepath.Join(profile.WorkingDirectory, cmd.inputs.Name, frontendPath, "palm-pilot.bitcoin-miner"))
-			frontendClientFolderExists := !os.IsNotExist((err))
-			assert.Equal(t, frontendClientFolderExists, true)
-		})
+		assert.Equal(t, appLocal.RootDir, path)
 	})
 
 	t.Run("should create a new app with a structure based on the specified remote app", func(t *testing.T) {
@@ -518,7 +519,26 @@ Check out your app: cd ./remote-app && realm-cli app describe
 		defer teardown()
 		profile.SetRealmBaseURL("http://localhost:8080")
 
-		out, ui := mock.NewUI()
+		procedure := func(c *expect.Console) {
+			c.ExpectString("Please select a template from the available options")
+			c.SendLine("palm-pilot.bitcoin-miner")
+			c.ExpectString("Enter a Service Name for Cluster 'test-cluster")
+			c.SendLine("test-cluster")
+			c.ExpectEOF()
+		}
+
+		// TODO(REALMC-8264): Mock console in tests does not behave as initially expected
+		out := new(bytes.Buffer)
+		console, _, ui, consoleErr := mock.NewVT10XConsoleWithOptions(mock.UIOptions{AutoConfirm: true}, out)
+		assert.Nil(t, consoleErr)
+		defer console.Close()
+
+		doneCh := make(chan (struct{}))
+		go func() {
+			defer close(doneCh)
+			procedure(console)
+		}()
+
 		testApp := realm.App{
 			ID:          "456",
 			GroupID:     "123",
@@ -529,6 +549,7 @@ Check out your app: cd ./remote-app && realm-cli app describe
 		backendZipPkg, err := zip.OpenReader("testdata/project.zip")
 		assert.Nil(t, err)
 
+		templateID := "palm-pilot.bitcoin-miner"
 		client := mock.RealmClient{
 			FindAppsFn: func(filter realm.AppFilter) ([]realm.App, error) {
 				return []realm.App{}, nil
@@ -551,7 +572,7 @@ Check out your app: cd ./remote-app && realm-cli app describe
 			TemplatesFn: func() ([]realm.Template, error) {
 				return []realm.Template{
 					{
-						ID:   "palm-pilot.bitcoin-miner",
+						ID:   templateID,
 						Name: "Mine bitcoin on your Palm Pilot from the comfort of your home, electricity not included",
 					},
 				}, nil
@@ -564,15 +585,25 @@ Check out your app: cd ./remote-app && realm-cli app describe
 			return &frontendZipPkg.Reader, err
 		}
 
-		cmd := &CommandCreate{createInputs{newAppInputs: newAppInputs{
-			Name:            "bitcoin-miner",
-			Project:         testApp.GroupID,
-			Template:        "palm-pilot.bitcoin-miner",
-			Location:        realm.LocationIreland,
-			DeploymentModel: realm.DeploymentModelGlobal,
-		}}}
+		cmd := &CommandCreate{createInputs{
+			newAppInputs: newAppInputs{
+				Name:            "bitcoin-miner",
+				Project:         testApp.GroupID,
+				Template:        templateID,
+				Location:        realm.LocationIreland,
+				DeploymentModel: realm.DeploymentModelGlobal,
+			},
+			Clusters: []string{"test-cluster"},
+		}}
 
-		assert.Nil(t, cmd.Handler(profile, ui, cli.Clients{Realm: client}))
+		assert.Nil(t, cmd.Handler(profile, ui, cli.Clients{Realm: client, Atlas: mock.AtlasClient{
+			ClustersFn: func(groupID string) ([]atlas.Cluster, error) {
+				return []atlas.Cluster{{Name: "test-cluster"}}, nil
+			},
+		}}))
+
+		console.Tty().Close() // flush the writers
+		<-doneCh              // wait for procedure to complete
 
 		appLocal, err := local.LoadApp(filepath.Join(profile.WorkingDirectory, cmd.inputs.Name, backendPath))
 		assert.Nil(t, err)
@@ -581,19 +612,25 @@ Check out your app: cd ./remote-app && realm-cli app describe
 		assert.Nil(t, err)
 		assert.Equal(t, len(backendFileInfo), 9)
 
-		frontendFileInfo, err := ioutil.ReadDir(filepath.Join(profile.WorkingDirectory, cmd.inputs.Name, frontendPath))
+		frontendFileInfo, err := ioutil.ReadDir(filepath.Join(profile.WorkingDirectory, cmd.inputs.Name, frontendPath, templateID))
 		assert.Nil(t, err)
 		assert.Equal(t, len(frontendFileInfo), 1)
 		assert.Equal(t, frontendFileInfo[0].Name(), "react-native")
 
-		assert.Equal(t, fmt.Sprintf(`Successfully created app
+		regex, err := regexp.Compile(`\s+`)
+		assert.Nil(t, err)
+
+		actual := regex.ReplaceAllString(out.String(), " ")
+		expected := regex.ReplaceAllString(fmt.Sprintf(`Successfully created app
 {
   "client_app_id": "bitcoin-miner-abcde",
   "filepath": %q,
-  "url": "http://localhost:8080/groups/123/apps/456/dashboard"
+  "url": "http://localhost:8080/groups/123/apps/456/dashboard",
+  "clusters": [ { "name": "test-cluster" } ]
 }
 Check out your app: cd ./bitcoin-miner && realm-cli app describe
-`, appLocal.RootDir), out.String())
+`, appLocal.RootDir), " ")
+		assert.Equal(t, strings.Contains(actual, expected), true)
 	})
 
 	for _, tc := range []struct {

--- a/internal/commands/app/new_app_inputs.go
+++ b/internal/commands/app/new_app_inputs.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/10gen/realm-cli/internal/cli"
@@ -116,4 +117,43 @@ func (i *newAppInputs) resolveTemplateID(ui terminal.UI, client realm.Client) er
 	i.Template = templateIDs[selectedIndex]
 
 	return nil
+}
+
+func (i createInputs) resolveInitialTemplateDataSource(ui terminal.UI, dataLakes []dataSourceDatalake, clusters []dataSourceCluster) (interface{}, error) {
+	if len(dataLakes)+len(clusters) == 0 {
+		return nil, errors.New("cannot create a template without an initial data source")
+	}
+
+	if len(dataLakes)+len(clusters) == 1 {
+		if len(clusters) > 0 {
+			return clusters[0], nil
+		}
+		return dataLakes[0], nil
+	}
+
+	// If linking multiple data sources, prompt the user for which data source to write template app schema onto
+	initialTemplateDataSources := make([]interface{}, 0, len(clusters)+len(dataLakes))
+	options := make([]string, 0, len(clusters)+len(dataLakes))
+
+	for _, cluster := range clusters {
+		initialTemplateDataSources = append(initialTemplateDataSources, cluster)
+		options = append(options, fmt.Sprintf("[Cluster]: %s", cluster.Name))
+	}
+	for _, datalake := range dataLakes {
+		initialTemplateDataSources = append(initialTemplateDataSources, datalake)
+		options = append(options, fmt.Sprintf("[Data Lake]: %s", datalake.Name))
+	}
+
+	var selectedIndex int
+	if err := ui.AskOne(
+		&selectedIndex,
+		&survey.Select{
+			Message: "Please choose a data source to write template app schema to:",
+			Options: options,
+		},
+	); err != nil {
+		return nil, err
+	}
+
+	return initialTemplateDataSources[selectedIndex], nil
 }


### PR DESCRIPTION
Since we added a new field for the app creation endpoint in the `baas` PR of this ticket, we need to update the app creation request body that we send to baas from the realm-cli to match what we do in the UI.

This PR handles the above change and it adds a requirement that makes users specify a data source if they want to make a template app.

I believe prompting users for the data source that they want to use if they're requesting a template would be an improvement, but the current log should work for the time being.