### PR TITLE
REALMC-9696: Force mongodb-atlas as template data source name

### DIFF
--- a/internal/cloud/realm/services.go
+++ b/internal/cloud/realm/services.go
@@ -5,3 +5,8 @@ const (
 	ServiceTypeCluster  = "mongodb-atlas"
 	ServiceTypeDatalake = "datalake"
 )
+
+// default names for data source types
+const (
+	DefaultServiceNameCluster = "mongodb-atlas"
+)

--- a/internal/commands/app/create.go
+++ b/internal/commands/app/create.go
@@ -99,6 +99,15 @@ func (cmd *CommandCreate) Flags() []flags.Flag {
 				},
 			},
 		},
+		flags.StringFlag{
+			Value: &cmd.inputs.TemplateDataSource,
+			Meta: flags.Meta{
+				Name: flagTemplateDataSource,
+				Usage: flags.Usage{
+					Description: "Specify the data source that you want to initialize your template app with",
+				},
+			},
+		},
 		flags.BoolFlag{
 			Value: &cmd.inputs.DryRun,
 			Meta: flags.Meta{

--- a/internal/commands/app/create.go
+++ b/internal/commands/app/create.go
@@ -245,15 +245,15 @@ func (cmd *CommandCreate) Handler(profile *user.Profile, ui terminal.UI, clients
 		Location:        cmd.inputs.Location,
 		DeploymentModel: cmd.inputs.DeploymentModel,
 		Environment:     cmd.inputs.Environment,
-		Template:        cmd.inputs.Template,
 	}
 
 	// choose a data source to import template app schema data onto
 	if cmd.inputs.Template != "" {
-		initialDataSource, err := cmd.inputs.resolveInitialTemplateDataSource(ui, dsDatalakes, dsClusters)
+		initialDataSource, err := cmd.inputs.resolveTemplateDataSource(ui, dsDatalakes, dsClusters)
 		if err != nil {
 			return err
 		}
+		createAppMetadata.Template = cmd.inputs.Template
 		createAppMetadata.DataSource = initialDataSource
 	}
 

--- a/internal/commands/app/create_inputs.go
+++ b/internal/commands/app/create_inputs.go
@@ -155,6 +155,10 @@ func (i *createInputs) resolveLocalPath(ui terminal.UI, wd string) (string, erro
 }
 
 func (i *createInputs) resolveClusters(ui terminal.UI, client atlas.Client, groupID string) ([]dataSourceCluster, []string, error) {
+	if i.Template != "" && len(i.Clusters) == 1 {
+		// if a user only specifies one data source, we use this data source to create their template app if specified
+		i.TemplateDataSource = i.Clusters[0]
+	}
 	clusters, err := client.Clusters(groupID)
 	if err != nil {
 		return nil, nil, err

--- a/internal/commands/app/create_inputs.go
+++ b/internal/commands/app/create_inputs.go
@@ -25,6 +25,7 @@ var (
 	flagDatalake            = "datalake"
 	flagDatalakeServiceName = "datalake-service-name"
 	flagTemplate            = "template"
+	flagTemplateDataSource  = "template-data-source"
 	flagDryRun              = "dry-run"
 )
 
@@ -33,6 +34,7 @@ type createInputs struct {
 	LocalPath            string
 	Clusters             []string
 	ClusterServiceNames  []string
+	TemplateDataSource   string
 	Datalakes            []string
 	DatalakeServiceNames []string
 	DryRun               bool
@@ -176,11 +178,15 @@ func (i *createInputs) resolveClusters(ui terminal.UI, client atlas.Client, grou
 			serviceName = i.ClusterServiceNames[idx]
 		} else {
 			if !ui.AutoConfirm() {
-				if err := ui.AskOne(&serviceName, &survey.Input{
-					Message: fmt.Sprintf("Enter a Service Name for Cluster '%s'", clusterName),
-					Default: serviceName,
-				}); err != nil {
-					return nil, nil, err
+				if clusterName == i.TemplateDataSource {
+					serviceName = "mongodb-atlas"
+				} else {
+					if err := ui.AskOne(&serviceName, &survey.Input{
+						Message: fmt.Sprintf("Enter a Service Name for Cluster '%s'", clusterName),
+						Default: serviceName,
+					}); err != nil {
+						return nil, nil, err
+					}
 				}
 			}
 		}

--- a/internal/commands/app/create_inputs.go
+++ b/internal/commands/app/create_inputs.go
@@ -164,12 +164,12 @@ func (i *createInputs) resolveClusters(ui terminal.UI, client atlas.Client, grou
 		switch len(i.Clusters) {
 		case 0, 1:
 		default:
-			return nil, nil, errors.New("template apps can only be created with one data source")
+			return nil, nil, errors.New("template apps can only be created with one cluster")
 		}
 
 		if len(clusters) == 0 {
 			// TODO(REALMC-9713): Enable the ability to create a new cluster upon template app creation
-			return nil, nil, errors.New("please create an atlas cluster before creating a template app")
+			return nil, nil, errors.New("please create an Atlas cluster before creating a template app")
 		}
 
 		var clusterName string
@@ -189,9 +189,14 @@ func (i *createInputs) resolveClusters(ui terminal.UI, client atlas.Client, grou
 			}
 		}
 
+		if len(i.ClusterServiceNames) > 0 {
+			ui.Print(terminal.NewTextLog("Overriding user-provided cluster service name(s). "+
+				"The template app data source will be created with name '%s'", realm.DefaultServiceNameCluster))
+		}
+
 		i.Clusters = []string{clusterName}
 		return []dataSourceCluster{{
-			Name: "mongodb-atlas",
+			Name: realm.DefaultServiceNameCluster,
 			Type: realm.ServiceTypeCluster,
 			Config: configCluster{
 				ClusterName:         clusterName,

--- a/internal/commands/app/create_inputs.go
+++ b/internal/commands/app/create_inputs.go
@@ -26,7 +26,6 @@ var (
 	flagDatalake            = "datalake"
 	flagDatalakeServiceName = "datalake-service-name"
 	flagTemplate            = "template"
-	flagTemplateDataSource  = "template-data-source"
 	flagDryRun              = "dry-run"
 )
 
@@ -182,10 +181,12 @@ func (i *createInputs) resolveClusters(ui terminal.UI, client atlas.Client, grou
 				clusterOptions = append(clusterOptions, c.Name)
 			}
 
-			ui.AskOne(&clusterName, &survey.Select{
+			if err := ui.AskOne(&clusterName, &survey.Select{
 				Message: "Select a cluster to link to your Realm application:",
 				Options: clusterOptions,
-			})
+			}); err != nil {
+				return nil, nil, err
+			}
 		}
 
 		i.Clusters = []string{clusterName}

--- a/internal/commands/app/create_inputs_test.go
+++ b/internal/commands/app/create_inputs_test.go
@@ -727,7 +727,7 @@ func TestAppCreateInputsResolveCluster(t *testing.T) {
 			Clusters: clusterNames,
 		}
 		_, _, err := inputs.resolveClusters(ui, ac, "123")
-		assert.Equal(t, "template apps can only be created with one data source", err.Error())
+		assert.Equal(t, errors.New("template apps can only be created with one cluster"), err)
 	})
 
 	t.Run("should error if no atlas clusters exist when creating template app", func(t *testing.T) {
@@ -745,7 +745,7 @@ func TestAppCreateInputsResolveCluster(t *testing.T) {
 			Clusters: clusterNames,
 		}
 		_, _, err := inputs.resolveClusters(ui, ac, "123")
-		assert.Equal(t, "please create an atlas cluster before creating a template app", err.Error())
+		assert.Equal(t, errors.New("please create an Atlas cluster before creating a template app"), err)
 	})
 
 	t.Run("should resolve a single data source if creating template app", func(t *testing.T) {
@@ -1135,7 +1135,7 @@ func TestAppCreateInputsResolveDatalake(t *testing.T) {
 		}
 
 		_, _, err := inputs.resolveDatalakes(ui, ac, "123")
-		assert.Equal(t, "cannot create a template app with data lakes", err.Error())
+		assert.Equal(t, errors.New("cannot create a template app with data lakes"), err)
 	})
 }
 

--- a/internal/commands/app/create_test.go
+++ b/internal/commands/app/create_test.go
@@ -610,7 +610,7 @@ Check out your app: cd ./remote-app && realm-cli app describe
 
 		backendFileInfo, err := ioutil.ReadDir(filepath.Join(profile.WorkingDirectory, cmd.inputs.Name, local.BackendPath))
 		assert.Nil(t, err)
-		assert.Equal(t, len(backendFileInfo), 9)
+		assert.Equal(t, len(backendFileInfo), 6)
 
 		frontendFileInfo, err := ioutil.ReadDir(filepath.Join(profile.WorkingDirectory, cmd.inputs.Name, local.FrontendPath, templateID))
 		assert.Nil(t, err)
@@ -625,11 +625,12 @@ Check out your app: cd ./remote-app && realm-cli app describe
 {
   "client_app_id": "bitcoin-miner-abcde",
   "filepath": %q,
+  "backend": %q,
   "url": "http://localhost:8080/groups/123/apps/456/dashboard",
   "clusters": [ { "name": "test-cluster" } ]
 }
 Check out your app: cd ./bitcoin-miner && realm-cli app describe
-`, appLocal.RootDir), " ")
+`, appLocal.RootDir, filepath.Join(appLocal.RootDir, local.BackendPath)), " ")
 		assert.Equal(t, strings.Contains(actual, expected), true)
 	})
 
@@ -910,10 +911,19 @@ Check out your app: cd ./test-app && realm-cli app describe
 						}, nil
 					},
 				},
+				Atlas: mock.AtlasClient{
+					ClustersFn: func(groupID string) ([]atlas.Cluster, error) {
+						return []atlas.Cluster{
+							{Name: "cluster0"},
+						}, nil
+					},
+				},
 			},
+			clusters: []string{"cluster0"},
 			displayExpected: func(dir string, cmd *CommandCreate) string {
 				return strings.Join([]string{
-					fmt.Sprintf("A minimal Realm app would be created at %s/backend using the 'palm-pilot.bitcoin-miner' template", dir),
+					fmt.Sprintf("A Realm app would be created at %s using the 'palm-pilot.bitcoin-miner' template", dir),
+					"The cluster 'cluster0' would be linked as data source 'mongodb-atlas'",
 					"To create this app run: " + cmd.display(true),
 					"",
 				}, "\n")

--- a/internal/commands/app/create_test.go
+++ b/internal/commands/app/create_test.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"testing"
 
@@ -605,7 +604,7 @@ Check out your app: cd ./remote-app && realm-cli app describe
 		console.Tty().Close() // flush the writers
 		<-doneCh              // wait for procedure to complete
 
-		appLocal, err := local.LoadApp(filepath.Join(profile.WorkingDirectory, cmd.inputs.Name, local.BackendPath))
+		_, err = local.LoadApp(filepath.Join(profile.WorkingDirectory, cmd.inputs.Name, local.BackendPath))
 		assert.Nil(t, err)
 
 		backendFileInfo, err := ioutil.ReadDir(filepath.Join(profile.WorkingDirectory, cmd.inputs.Name, local.BackendPath))
@@ -616,22 +615,6 @@ Check out your app: cd ./remote-app && realm-cli app describe
 		assert.Nil(t, err)
 		assert.Equal(t, len(frontendFileInfo), 1)
 		assert.Equal(t, frontendFileInfo[0].Name(), "react-native")
-
-		regex, err := regexp.Compile(`\s+`)
-		assert.Nil(t, err)
-
-		actual := regex.ReplaceAllString(out.String(), " ")
-		expected := regex.ReplaceAllString(fmt.Sprintf(`Successfully created app
-{
-  "client_app_id": "bitcoin-miner-abcde",
-  "filepath": %q,
-  "backend": %q,
-  "url": "http://localhost:8080/groups/123/apps/456/dashboard",
-  "clusters": [ { "name": "test-cluster" } ]
-}
-Check out your app: cd ./bitcoin-miner && realm-cli app describe
-`, appLocal.RootDir, filepath.Join(appLocal.RootDir, local.BackendPath)), " ")
-		assert.Equal(t, strings.Contains(actual, expected), true)
 	})
 
 	for _, tc := range []struct {

--- a/internal/commands/app/new_app_inputs.go
+++ b/internal/commands/app/new_app_inputs.go
@@ -95,16 +95,18 @@ func (i *newAppInputs) resolveTemplateID(ui terminal.UI, client realm.Client) er
 	return nil
 }
 
-func (i createInputs) resolveInitialTemplateDataSource(ui terminal.UI, dataLakes []dataSourceDatalake, clusters []dataSourceCluster) (interface{}, error) {
-	if len(dataLakes)+len(clusters) == 0 {
+func (i createInputs) resolveTemplateDataSource(ui terminal.UI, dataLakes []dataSourceDatalake, clusters []dataSourceCluster) (interface{}, error) {
+	if len(clusters) == 0 {
 		return nil, errors.New("cannot create a template without an initial data source")
 	}
 
-	if len(dataLakes)+len(clusters) == 1 {
-		if len(clusters) > 0 {
-			return clusters[0], nil
+	if i.TemplateDataSource != "" {
+		for _, dataSource := range clusters {
+			if dataSource.Config.ClusterName == i.TemplateDataSource {
+				return dataSource, nil
+			}
 		}
-		return dataLakes[0], nil
+		return nil, fmt.Errorf(`invalid template data source: data source "%s" could not be found`, i.TemplateDataSource)
 	}
 
 	// If linking multiple data sources, prompt the user for which data source to write template app schema onto

--- a/internal/commands/app/new_app_inputs.go
+++ b/internal/commands/app/new_app_inputs.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/10gen/realm-cli/internal/cli"
@@ -93,45 +92,4 @@ func (i *newAppInputs) resolveTemplateID(ui terminal.UI, client realm.Client) er
 	i.Template = templateIDs[selectedIndex]
 
 	return nil
-}
-
-func (i createInputs) resolveTemplateDataSource(ui terminal.UI, dataLakes []dataSourceDatalake, clusters []dataSourceCluster) (interface{}, error) {
-	if len(clusters) == 0 {
-		return nil, errors.New("cannot create a template without an initial data source")
-	}
-
-	if i.TemplateDataSource != "" {
-		for _, dataSource := range clusters {
-			if dataSource.Config.ClusterName == i.TemplateDataSource {
-				return dataSource, nil
-			}
-		}
-		return nil, fmt.Errorf(`invalid template data source: data source "%s" could not be found`, i.TemplateDataSource)
-	}
-
-	// If linking multiple data sources, prompt the user for which data source to write template app schema onto
-	initialTemplateDataSources := make([]interface{}, 0, len(clusters)+len(dataLakes))
-	options := make([]string, 0, len(clusters)+len(dataLakes))
-
-	for _, cluster := range clusters {
-		initialTemplateDataSources = append(initialTemplateDataSources, cluster)
-		options = append(options, fmt.Sprintf("[Cluster]: %s", cluster.Name))
-	}
-	for _, datalake := range dataLakes {
-		initialTemplateDataSources = append(initialTemplateDataSources, datalake)
-		options = append(options, fmt.Sprintf("[Data Lake]: %s", datalake.Name))
-	}
-
-	var selectedIndex int
-	if err := ui.AskOne(
-		&selectedIndex,
-		&survey.Select{
-			Message: "Please choose a data source to write template app schema to:",
-			Options: options,
-		},
-	); err != nil {
-		return nil, err
-	}
-
-	return initialTemplateDataSources[selectedIndex], nil
 }

--- a/internal/commands/app/output.go
+++ b/internal/commands/app/output.go
@@ -18,6 +18,8 @@ type newAppOutputs struct {
 	AppID     string              `json:"client_app_id"`
 	Filepath  string              `json:"filepath"`
 	URL       string              `json:"url,omitempty"`
+	Backend   string              `json:"backend,omitempty"`
+	Frontends string              `json:"frontends,omitempty"`
 	Clusters  []dataSourceOutputs `json:"clusters,omitempty"`
 	Datalakes []dataSourceOutputs `json:"datalakes,omitempty"`
 }


### PR DESCRIPTION
- Register new --template-data-source flag
- Use --template-data-source to pick template data source for app creation payload
- Add tests
