### PR TITLE
REALMC-9749: Remove -h shorthand flag conflict

### DIFF
--- a/internal/commands/app/diff.go
+++ b/internal/commands/app/diff.go
@@ -73,7 +73,7 @@ func (cmd *CommandDiff) Flags() []flags.Flag {
 			Value: &cmd.inputs.IncludeHosting,
 			Meta: flags.Meta{
 				Name:      "include-hosting",
-				Shorthand: "h",
+				Shorthand: "s",
 				Usage: flags.Usage{
 					Description: "Include Realm app hosting files in the diff",
 				},

--- a/internal/commands/pull/command.go
+++ b/internal/commands/pull/command.go
@@ -68,7 +68,7 @@ func (cmd *Command) Flags() []flags.Flag {
 			Value: &cmd.inputs.IncludeHosting,
 			Meta: flags.Meta{
 				Name:      "include-hosting",
-				Shorthand: "h",
+				Shorthand: "s",
 				Usage: flags.Usage{
 					Description: "Export and include Realm app hosting files",
 				},

--- a/internal/commands/push/command.go
+++ b/internal/commands/push/command.go
@@ -68,7 +68,7 @@ func (cmd *Command) Flags() []flags.Flag {
 			Value: &cmd.inputs.IncludeHosting,
 			Meta: flags.Meta{
 				Name:      flagIncludeHosting,
-				Shorthand: "h",
+				Shorthand: "s",
 				Usage: flags.Usage{
 					Description: "Import and include Realm app hosting files",
 				},


### PR DESCRIPTION
This PR removes this error:

`panic: unable to redefine 'h' shorthand in "pull" flagset: it's already used for "include-hosting" flag`

This is caused by having the --include-hosting flag use the `-h` shorthand flag which conflicts with the -h for the `--help` command

