### PR TITLE
REALMC-9460: Prevent template app creation prompt from occurring automatically

### DIFF
--- a/internal/cloud/realm/client.go
+++ b/internal/cloud/realm/client.go
@@ -73,9 +73,9 @@ type Client interface {
 
 	SchemaModels(groupID, appID, language string) ([]SchemaModel, error)
 
-	AllTemplates() ([]Template, error)
+	AllTemplates() (Templates, error)
 	ClientTemplate(groupID, appID, templateID string) (*zip.Reader, bool, error)
-	CompatibleTemplates(groupID, appID string) ([]Template, error)
+	CompatibleTemplates(groupID, appID string) (Templates, error)
 
 	AllowedIPs(groupID, appID string) ([]AllowedIP, error)
 	AllowedIPCreate(groupID, appID, address, comment string, useCurrent bool) (AllowedIP, error)

--- a/internal/cloud/realm/templates.go
+++ b/internal/cloud/realm/templates.go
@@ -11,6 +11,19 @@ import (
 	"github.com/10gen/realm-cli/internal/utils/api"
 )
 
+// AllowedTemplates is an array of templates that we know to work. We need to update this in the event we add more
+// templates in the future.
+// This array is used to display the allowed values in the --help menu of the templates flag
+var AllowedTemplates = []string{
+	"web.graphql.todo",
+	"web.mql.todo",
+	"triggers",
+	"ios.swift.todo",
+	"android.kotlin.todo",
+	"react-native.todo",
+	"xamarin.todo",
+}
+
 // Template represents an available Realm app template
 type Template struct {
 	ID   string `json:"id"`

--- a/internal/cloud/realm/templates.go
+++ b/internal/cloud/realm/templates.go
@@ -11,8 +11,7 @@ import (
 	"github.com/10gen/realm-cli/internal/utils/api"
 )
 
-// AllowedTemplates is an array of templates that we know to work. We need to update this in the event we add more
-// templates in the future.
+// AllowedTemplates is an array of templates that we support. We should update this slice whenever we add new templates.
 // This array is used to display the allowed values in the --help menu of the templates flag
 var AllowedTemplates = []string{
 	"web.graphql.todo",

--- a/internal/cloud/realm/templates.go
+++ b/internal/cloud/realm/templates.go
@@ -17,6 +17,7 @@ type Template struct {
 	Name string `json:"name"`
 }
 
+// Templates is a slice of Template structs
 type Templates []Template
 
 // MapByID converts an array of templates into a map whose keys are the template ids and values are the template

--- a/internal/cloud/realm/templates.go
+++ b/internal/cloud/realm/templates.go
@@ -11,7 +11,7 @@ import (
 	"github.com/10gen/realm-cli/internal/utils/api"
 )
 
-// AllowedTemplates is an array of templates that we support. We should update this slice whenever we add new templates.
+// AllowedTemplates is an array of supported templates.
 // This array is used to display the allowed values in the --help menu of the templates flag
 var AllowedTemplates = []string{
 	"web.graphql.todo",

--- a/internal/cloud/realm/templates.go
+++ b/internal/cloud/realm/templates.go
@@ -17,13 +17,24 @@ type Template struct {
 	Name string `json:"name"`
 }
 
+type Templates []Template
+
+// MapByID converts an array of templates into a map whose keys are the template ids and values are the template
+func (templates Templates) MapByID() map[string]Template {
+	out := make(map[string]Template, len(templates))
+	for _, t := range templates {
+		out[t.ID] = t
+	}
+	return out
+}
+
 const (
 	allTemplatesPath               = adminAPI + "/templates"
 	clientTemplatePathPattern      = appPathPattern + "/templates/%s/client"
 	compatibleTemplatesPathPattern = appPathPattern + "/templates"
 )
 
-func (c *client) AllTemplates() ([]Template, error) {
+func (c *client) AllTemplates() (Templates, error) {
 	res, resErr := c.do(
 		http.MethodGet,
 		allTemplatesPath,
@@ -37,7 +48,7 @@ func (c *client) AllTemplates() ([]Template, error) {
 	}
 	defer res.Body.Close()
 
-	var templates []Template
+	var templates Templates
 	if err := json.NewDecoder(res.Body).Decode(&templates); err != nil {
 		return nil, err
 	}
@@ -71,7 +82,7 @@ func (c *client) ClientTemplate(groupID, appID, templateID string) (*zip.Reader,
 	return zipPkg, true, nil
 }
 
-func (c *client) CompatibleTemplates(groupID, appID string) ([]Template, error) {
+func (c *client) CompatibleTemplates(groupID, appID string) (Templates, error) {
 	res, resErr := c.do(http.MethodGet, fmt.Sprintf(compatibleTemplatesPathPattern, groupID, appID), api.RequestOptions{})
 	if resErr != nil {
 		return nil, resErr
@@ -85,7 +96,7 @@ func (c *client) CompatibleTemplates(groupID, appID string) ([]Template, error) 
 	}
 	defer res.Body.Close()
 
-	var templates []Template
+	var templates Templates
 	if err := json.NewDecoder(res.Body).Decode(&templates); err != nil {
 		return nil, err
 	}

--- a/internal/cloud/realm/templates.go
+++ b/internal/cloud/realm/templates.go
@@ -12,7 +12,6 @@ import (
 )
 
 // AllowedTemplates is an array of supported templates.
-// This array is used to display the allowed values in the --help menu of the templates flag
 var AllowedTemplates = []string{
 	"web.graphql.todo",
 	"web.mql.todo",

--- a/internal/commands/app/create.go
+++ b/internal/commands/app/create.go
@@ -20,6 +20,10 @@ import (
 	"github.com/briandowns/spinner"
 )
 
+var (
+	noArgsDefaultValueTemplate = "<prompt-templates>"
+)
+
 // CommandMetaCreate is the command meta for the `app create` command
 var CommandMetaCreate = cli.CommandMeta{
 	Use:         "create",
@@ -97,7 +101,8 @@ func (cmd *CommandCreate) Flags() []flags.Flag {
 			},
 		},
 		flags.StringFlag{
-			Value: &cmd.inputs.Template,
+			Value:              &cmd.inputs.Template,
+			NoArgsDefaultValue: &noArgsDefaultValueTemplate,
 			Meta: flags.Meta{
 				Name: flagTemplate,
 				Usage: flags.Usage{
@@ -201,10 +206,10 @@ func (cmd *CommandCreate) Handler(profile *user.Profile, ui terminal.UI, clients
 		}
 	}
 
-	if cmd.inputs.Template != "" {
-		return cmd.handleCreateTemplateApp(profile, ui, clients, groupID, rootDir, dsClusters, dsDatalakes)
+	if cmd.inputs.Template == "" {
+		return cmd.handleCreateApp(profile, ui, clients, groupID, rootDir, appRemote, dsClusters, dsDatalakes)
 	}
-	return cmd.handleCreateApp(profile, ui, clients, groupID, rootDir, appRemote, dsClusters, dsDatalakes)
+	return cmd.handleCreateTemplateApp(profile, ui, clients, groupID, rootDir, dsClusters, dsDatalakes)
 }
 
 func (cmd CommandCreate) handleCreateApp(

--- a/internal/commands/app/create.go
+++ b/internal/commands/app/create.go
@@ -20,10 +20,6 @@ import (
 	"github.com/briandowns/spinner"
 )
 
-var (
-	noArgsDefaultValueTemplate = "<prompt-templates>"
-)
-
 // CommandMetaCreate is the command meta for the `app create` command
 var CommandMetaCreate = cli.CommandMeta{
 	Use:         "create",
@@ -101,13 +97,12 @@ func (cmd *CommandCreate) Flags() []flags.Flag {
 			},
 		},
 		flags.StringFlag{
-			Value:              &cmd.inputs.Template,
-			NoArgsDefaultValue: &noArgsDefaultValueTemplate,
+			Value: &cmd.inputs.Template,
 			Meta: flags.Meta{
 				Name: flagTemplate,
 				Usage: flags.Usage{
 					Description: "Create your Realm app from an available template",
-					Note:        "Manually specifying a template id must be done with a '='. ie: --template=web.graphql.todo",
+					Note:        "Valid templates: web.graphql.todo, web.mql.todo, triggers, ios.swift.todo, android.kotlin.todo, react-native.todo, xamarin.todo",
 				},
 			},
 		},
@@ -169,7 +164,7 @@ func (cmd *CommandCreate) Handler(profile *user.Profile, ui terminal.UI, clients
 		return err
 	}
 
-	if err := cmd.inputs.resolveTemplateID(ui, clients.Realm); err != nil {
+	if err := cmd.inputs.resolveTemplateID(clients.Realm); err != nil {
 		return err
 	}
 

--- a/internal/commands/app/create.go
+++ b/internal/commands/app/create.go
@@ -164,7 +164,7 @@ func (cmd *CommandCreate) Handler(profile *user.Profile, ui terminal.UI, clients
 		return err
 	}
 
-	if err = cmd.inputs.resolveTemplateID(ui, clients.Realm); err != nil {
+	if err := cmd.inputs.resolveTemplateID(ui, clients.Realm); err != nil {
 		return err
 	}
 

--- a/internal/commands/app/create.go
+++ b/internal/commands/app/create.go
@@ -63,6 +63,7 @@ func (cmd *CommandCreate) Flags() []flags.Flag {
 				Name: flagCluster,
 				Usage: flags.Usage{
 					Description: "Link Atlas cluster(s) to your Realm app",
+					Note:        "Only one cluster can be linked during app creation if creating a template app",
 				},
 			},
 		},
@@ -72,6 +73,7 @@ func (cmd *CommandCreate) Flags() []flags.Flag {
 				Name: flagClusterServiceName,
 				Usage: flags.Usage{
 					Description: "Specify the Realm app Service name to reference your Atlas cluster",
+					Note:        "Service names will be overwritten when creating a template app",
 				},
 			},
 		},
@@ -81,6 +83,7 @@ func (cmd *CommandCreate) Flags() []flags.Flag {
 				Name: flagDatalake,
 				Usage: flags.Usage{
 					Description: "Link Atlas data lake(s) to your Realm app",
+					Note:        "Data lakes cannot be used to create template apps",
 				},
 			},
 		},
@@ -99,6 +102,7 @@ func (cmd *CommandCreate) Flags() []flags.Flag {
 				Name: flagTemplate,
 				Usage: flags.Usage{
 					Description: "Create your Realm app from an available template",
+					Note:        "A cluster must be supplied in order to create a template app",
 				},
 			},
 		},

--- a/internal/commands/app/create.go
+++ b/internal/commands/app/create.go
@@ -101,8 +101,8 @@ func (cmd *CommandCreate) Flags() []flags.Flag {
 			Meta: flags.Meta{
 				Name: flagTemplate,
 				Usage: flags.Usage{
-					Description: "Create your Realm app from an available template",
-					Note:        "Valid templates: web.graphql.todo, web.mql.todo, triggers, ios.swift.todo, android.kotlin.todo, react-native.todo, xamarin.todo",
+					Description:   "Create your Realm app from an available template",
+					AllowedValues: realm.AllowedTemplates,
 				},
 			},
 		},

--- a/internal/commands/app/create.go
+++ b/internal/commands/app/create.go
@@ -107,7 +107,7 @@ func (cmd *CommandCreate) Flags() []flags.Flag {
 				Name: flagTemplate,
 				Usage: flags.Usage{
 					Description: "Create your Realm app from an available template",
-					Note:        "A cluster must be supplied in order to create a template app",
+					Note:        "Manually specifying a template id must be done with a '='. ie: --template=web.graphql.todo",
 				},
 			},
 		},

--- a/internal/commands/app/create_inputs.go
+++ b/internal/commands/app/create_inputs.go
@@ -99,7 +99,7 @@ func (i *createInputs) resolveName(ui terminal.UI, client realm.Client, groupID,
 }
 
 func (i *createInputs) resolveLocalPath(ui terminal.UI, wd string) (string, error) {
-	//check if we are in an app directory already
+	// Check if current working directory is the app directory
 	_, appOK, err := local.FindApp(wd)
 	if err != nil {
 		return "", err
@@ -174,7 +174,14 @@ func (i *createInputs) resolveClusters(ui terminal.UI, client atlas.Client, grou
 
 		var clusterName string
 		if len(i.Clusters) == 1 {
-			clusterName = i.Clusters[0]
+			for _, c := range clusters {
+				if c.Name == i.Clusters[0] {
+					clusterName = i.Clusters[0]
+				}
+			}
+			if clusterName == "" {
+				return nil, nil, fmt.Errorf("could not find atlas cluster '%s'", i.Clusters[0])
+			}
 		} else {
 			clusterOptions := make([]string, 0, len(clusters))
 			for _, c := range clusters {

--- a/internal/commands/app/create_inputs.go
+++ b/internal/commands/app/create_inputs.go
@@ -177,6 +177,7 @@ func (i *createInputs) resolveClusters(ui terminal.UI, client atlas.Client, grou
 			for _, c := range clusters {
 				if c.Name == i.Clusters[0] {
 					clusterName = i.Clusters[0]
+					break
 				}
 			}
 			if clusterName == "" {

--- a/internal/commands/app/create_inputs.go
+++ b/internal/commands/app/create_inputs.go
@@ -329,7 +329,11 @@ func (i createInputs) args(omitDryRun bool) []flags.Arg {
 		args = append(args, flags.Arg{flagLocalPathCreate, i.LocalPath})
 	}
 	if i.Template != "" {
-		args = append(args, flags.Arg{flagTemplate, i.Template})
+		if i.Template == noArgsDefaultValueTemplate {
+			args = append(args, flags.Arg{Name: flagTemplate})
+		} else {
+			args = append(args, flags.Arg{flagTemplate, i.Template})
+		}
 	}
 	if i.Location != flagLocationDefault {
 		args = append(args, flags.Arg{flagLocation, i.Location.String()})

--- a/internal/commands/app/create_inputs.go
+++ b/internal/commands/app/create_inputs.go
@@ -99,7 +99,7 @@ func (i *createInputs) resolveName(ui terminal.UI, client realm.Client, groupID,
 }
 
 func (i *createInputs) resolveLocalPath(ui terminal.UI, wd string) (string, error) {
-	// Check if current working directory is the app directory
+	// Check if current working directory is an app directory
 	_, appOK, err := local.FindApp(wd)
 	if err != nil {
 		return "", err
@@ -180,7 +180,7 @@ func (i *createInputs) resolveClusters(ui terminal.UI, client atlas.Client, grou
 				}
 			}
 			if clusterName == "" {
-				return nil, nil, fmt.Errorf("could not find atlas cluster '%s'", i.Clusters[0])
+				return nil, nil, fmt.Errorf("could not find Atlas cluster '%s'", i.Clusters[0])
 			}
 		} else if len(clusters) == 1 {
 			clusterName = clusters[0].Name

--- a/internal/commands/app/create_inputs.go
+++ b/internal/commands/app/create_inputs.go
@@ -154,7 +154,7 @@ func (i *createInputs) resolveLocalPath(ui terminal.UI, wd string) (string, erro
 }
 
 func (i *createInputs) resolveClusters(ui terminal.UI, client atlas.Client, groupID string) ([]dataSourceCluster, []string, error) {
-	if i.Template != "" {
+	if i.Template != "" && i.Template != noArgsDefaultValueTemplate {
 		clusters, err := client.Clusters(groupID)
 		if err != nil {
 			return nil, nil, err
@@ -182,6 +182,8 @@ func (i *createInputs) resolveClusters(ui terminal.UI, client atlas.Client, grou
 			if clusterName == "" {
 				return nil, nil, fmt.Errorf("could not find atlas cluster '%s'", i.Clusters[0])
 			}
+		} else if len(clusters) == 1 {
+			clusterName = clusters[0].Name
 		} else {
 			clusterOptions := make([]string, 0, len(clusters))
 			for _, c := range clusters {

--- a/internal/commands/app/create_inputs.go
+++ b/internal/commands/app/create_inputs.go
@@ -154,7 +154,7 @@ func (i *createInputs) resolveLocalPath(ui terminal.UI, wd string) (string, erro
 }
 
 func (i *createInputs) resolveClusters(ui terminal.UI, client atlas.Client, groupID string) ([]dataSourceCluster, []string, error) {
-	if i.Template != "" && i.Template != noArgsDefaultValueTemplate {
+	if i.Template != "" {
 		clusters, err := client.Clusters(groupID)
 		if err != nil {
 			return nil, nil, err
@@ -331,11 +331,7 @@ func (i createInputs) args(omitDryRun bool) []flags.Arg {
 		args = append(args, flags.Arg{flagLocalPathCreate, i.LocalPath})
 	}
 	if i.Template != "" {
-		if i.Template == noArgsDefaultValueTemplate {
-			args = append(args, flags.Arg{Name: flagTemplate})
-		} else {
-			args = append(args, flags.Arg{flagTemplate, i.Template})
-		}
+		args = append(args, flags.Arg{flagTemplate, i.Template})
 	}
 	if i.Location != flagLocationDefault {
 		args = append(args, flags.Arg{flagLocation, i.Location.String()})

--- a/internal/commands/app/create_inputs_test.go
+++ b/internal/commands/app/create_inputs_test.go
@@ -767,7 +767,7 @@ func TestAppCreateInputsResolveCluster(t *testing.T) {
 			}
 
 			_, _, err := inputs.resolveClusters(ui, ac, "123")
-			assert.Equal(t, errors.New("could not find atlas cluster 'nonExistentCluster'"), err)
+			assert.Equal(t, errors.New("could not find Atlas cluster 'nonExistentCluster'"), err)
 		})
 
 		t.Run("should resolve a single data source when cluster name is passed in", func(t *testing.T) {

--- a/internal/commands/app/create_inputs_test.go
+++ b/internal/commands/app/create_inputs_test.go
@@ -795,6 +795,27 @@ func TestAppCreateInputsResolveCluster(t *testing.T) {
 		assert.Equal(t, 1, len(clusters))
 		assert.Equal(t, "mongodb-atlas", clusters[0].Name)
 	})
+
+	t.Run("should error when provided cluster name does not exist", func(t *testing.T) {
+		_, ui := mock.NewUI()
+		clusterNames := []string{"nonExistentCluster"}
+
+		ac := mock.AtlasClient{}
+		ac.ClustersFn = func(groupID string) ([]atlas.Cluster, error) {
+			return []atlas.Cluster{
+				{ID: "456", Name: "Cluster0"},
+			}, nil
+		}
+		inputs := createInputs{
+			newAppInputs: newAppInputs{
+				Template: "ios.template.todo",
+			},
+			Clusters: clusterNames,
+		}
+
+		_, _, err := inputs.resolveClusters(ui, ac, "123")
+		assert.Equal(t, errors.New("could not find atlas cluster 'nonExistentCluster'"), err)
+	})
 }
 
 func TestAppCreateInputsResolveDatalake(t *testing.T) {

--- a/internal/commands/app/create_test.go
+++ b/internal/commands/app/create_test.go
@@ -339,6 +339,7 @@ Check out your app: cd ./test-app && realm-cli app describe
 
 		defaultBackendZipPkg, err := zip.OpenReader("testdata/project.zip")
 		assert.Nil(t, err)
+		defer defaultBackendZipPkg.Close()
 
 		realmClient := mock.RealmClient{
 			FindAppsFn: func(filter realm.AppFilter) ([]realm.App, error) {
@@ -389,7 +390,7 @@ Check out your app: cd ./test-app && realm-cli app describe
 		var containsRealmConfig bool
 		var containsTemplateDirChild bool
 		for _, fi := range backendFileInfo {
-			if strings.Contains(fi.Name(), local.NameRealmConfig) {
+			if fi.Name() == fmt.Sprintf("%s.json", local.NameRealmConfig) {
 				containsRealmConfig = true
 			}
 			if fi.Name() == local.BackendPath || fi.Name() == local.FrontendPath {
@@ -545,6 +546,7 @@ Check out your app: cd ./remote-app && realm-cli app describe
 
 		backendZipPkg, err := zip.OpenReader("testdata/project.zip")
 		assert.Nil(t, err)
+		defer backendZipPkg.Close()
 
 		templateID := "palm-pilot.bitcoin-miner"
 		client := mock.RealmClient{
@@ -578,6 +580,8 @@ Check out your app: cd ./remote-app && realm-cli app describe
 
 		frontendZipPkg, err := zip.OpenReader("testdata/react-native.zip")
 		assert.Nil(t, err)
+		defer frontendZipPkg.Close()
+
 		client.ClientTemplateFn = func(groupID, appID, templateID string) (*zip.Reader, bool, error) {
 			return &frontendZipPkg.Reader, true, err
 		}

--- a/internal/commands/app/create_test.go
+++ b/internal/commands/app/create_test.go
@@ -1325,6 +1325,22 @@ func TestAppCreateCommandDisplay(t *testing.T) {
 		)
 	})
 
+	t.Run("should create a command with --template flag that has no args", func(t *testing.T) {
+		cmd := &CommandCreate{
+			inputs: createInputs{
+				newAppInputs: newAppInputs{
+					Template:        noArgsDefaultValueTemplate,
+					Location:        realm.LocationIreland,
+					DeploymentModel: realm.DeploymentModelLocal,
+				},
+			},
+		}
+		assert.Equal(t,
+			cli.Name+" app create --template --location IE --deployment-model LOCAL",
+			cmd.display(false),
+		)
+	})
+
 	t.Run("should create a command with multiple input clusters and data lakes", func(t *testing.T) {
 		cmd := &CommandCreate{
 			inputs: createInputs{

--- a/internal/commands/app/create_test.go
+++ b/internal/commands/app/create_test.go
@@ -382,27 +382,16 @@ Check out your app: cd ./test-app && realm-cli app describe
 		_, err = local.LoadApp(filepath.Join(profile.WorkingDirectory, cmd.inputs.Name))
 		assert.Nil(t, err)
 
-		backendFileInfo, err := ioutil.ReadDir(filepath.Join(profile.WorkingDirectory, cmd.inputs.Name))
-		assert.Nil(t, err)
-
 		// we expect for the command to have created a default app. we will assert that realm_config.json exists and that
 		// backend/ and frontend/ do not exist in the directory.
-		var containsRealmConfig bool
-		var containsTemplateDirChild bool
-		for _, fi := range backendFileInfo {
-			if fi.Name() == fmt.Sprintf("%s.json", local.NameRealmConfig) {
-				containsRealmConfig = true
-			}
-			if fi.Name() == local.BackendPath || fi.Name() == local.FrontendPath {
-				containsTemplateDirChild = true
-			}
-		}
+		_, err = os.Stat(filepath.Join(profile.WorkingDirectory, cmd.inputs.Name, "realm_config.json"))
+		assert.False(t, os.IsNotExist(err), "expected realm_config.json to exist")
 
-		assert.True(t, containsRealmConfig, "expected resulting directory to contain realm_config.json")
-		assert.False(t, containsTemplateDirChild, "expected resulting directory not to contain %s/ or %s/",
-			local.BackendPath,
-			local.FrontendPath,
-		)
+		_, err = os.Stat(filepath.Join(profile.WorkingDirectory, cmd.inputs.Name, local.BackendPath))
+		assert.True(t, os.IsNotExist(err), "expected for backend path to not exist")
+
+		_, err = os.Stat(filepath.Join(profile.WorkingDirectory, cmd.inputs.Name, local.FrontendPath))
+		assert.True(t, os.IsNotExist(err), "expected for frontend path to not exist")
 	})
 
 	t.Run("should create a new app with a structure based on the specified remote app", func(t *testing.T) {

--- a/internal/commands/app/new_app_inputs.go
+++ b/internal/commands/app/new_app_inputs.go
@@ -6,8 +6,6 @@ import (
 	"github.com/10gen/realm-cli/internal/cli"
 	"github.com/10gen/realm-cli/internal/cloud/realm"
 	"github.com/10gen/realm-cli/internal/terminal"
-
-	"github.com/AlecAivazis/survey/v2"
 )
 
 const (
@@ -40,13 +38,11 @@ func (i *newAppInputs) resolveRemoteApp(ui terminal.UI, rc realm.Client) (realm.
 
 // resolveTemplateID is responsible for resolving a template id from a user cli request.
 // a user can use the --template flag in 1 of the following ways:
-// 1. --template: This will populate the current value of i.Template to be `noArgsDefaultValueTemplate`. This tells us
-//    that the user wants to create a template and wants to be prompted for the template id
-// 2. --template=<template-id>: This populates the value of i.Template to be <template-id>. This skips the template id
-//    prompt and checks whether the supplied template id exists.
-// 3. no flag defined: This populates the value of i.Template to be "". This tells us to skip the template-app-related
-//    parts of app creation
-func (i *newAppInputs) resolveTemplateID(ui terminal.UI, client realm.Client) error {
+// 1. --template=<template-id>: This populates the value of i.Template to be <template-id> and attempts to create a
+//    template with id = <template-id>
+// 2. no flag defined: This populates the value of i.Template to be "". This tells us to skip the template-app-related
+//    parts of app creation and create a default app
+func (i *newAppInputs) resolveTemplateID(client realm.Client) error {
 	if i.Template == "" {
 		return nil
 	}
@@ -59,7 +55,7 @@ func (i *newAppInputs) resolveTemplateID(ui terminal.UI, client realm.Client) er
 		return fmt.Errorf("unable to find template '%s'", i.Template)
 	}
 
-	if i.Template != noArgsDefaultValueTemplate {
+	if i.Template != "" {
 		for _, template := range templates {
 			if template.ID == i.Template {
 				i.Template = template.ID
@@ -69,26 +65,5 @@ func (i *newAppInputs) resolveTemplateID(ui terminal.UI, client realm.Client) er
 
 		return fmt.Errorf("template '%s' not found", i.Template)
 	}
-
-	options := make([]string, 0, len(templates)+1)
-	templateIDs := make([]string, 0, len(templates)+1)
-	for _, template := range templates {
-		options = append(options, fmt.Sprintf("[%s]: %s", template.ID, template.Name))
-		templateIDs = append(templateIDs, template.ID)
-	}
-
-	var selectedIndex int
-	if err := ui.AskOne(
-		&selectedIndex,
-		&survey.Select{
-			Message: "Please select a template from the available options",
-			Options: options,
-		},
-	); err != nil {
-		return err
-	}
-
-	i.Template = templateIDs[selectedIndex]
-
 	return nil
 }

--- a/internal/commands/app/new_app_inputs.go
+++ b/internal/commands/app/new_app_inputs.go
@@ -37,11 +37,8 @@ func (i *newAppInputs) resolveRemoteApp(ui terminal.UI, rc realm.Client) (realm.
 }
 
 // resolveTemplateID is responsible for resolving a template id from a user cli request.
-// a user can use the --template flag in 1 of the following ways:
-// 1. --template=<template-id>: This populates the value of i.Template to be <template-id> and attempts to create a
-//    template with id = <template-id>
-// 2. no flag defined: This populates the value of i.Template to be "". This tells us to skip the template-app-related
-//    parts of app creation and create a default app
+// If the --template flag is not set, the CLI will create a default app without any template,
+// otherwise the CLI will attempt to create an app based on the specified template
 func (i *newAppInputs) resolveTemplateID(client realm.Client) error {
 	if i.Template == "" {
 		return nil

--- a/internal/commands/app/new_app_inputs.go
+++ b/internal/commands/app/new_app_inputs.go
@@ -47,7 +47,6 @@ func (i *newAppInputs) resolveRemoteApp(ui terminal.UI, rc realm.Client) (realm.
 // 3. no flag defined: This populates the value of i.Template to be "". This tells us to skip the template-app-related
 //    parts of app creation
 func (i *newAppInputs) resolveTemplateID(ui terminal.UI, client realm.Client) error {
-	ui.Print(terminal.NewTextLog("Current Template: %s", i.Template))
 	if i.Template == "" {
 		return nil
 	}

--- a/internal/commands/app/new_app_inputs.go
+++ b/internal/commands/app/new_app_inputs.go
@@ -41,7 +41,7 @@ func (i *newAppInputs) resolveRemoteApp(ui terminal.UI, rc realm.Client) (realm.
 // resolveTemplateID is responsible for resolving a template id from a user cli request.
 // a user can use the --template flag in 1 of the following ways:
 // 1. --template: This will populate the current value of i.Template to be `noArgsDefaultValueTemplate`. This tells us
-//    that the user wants to create a template but wants to be prompted for the template id
+//    that the user wants to create a template and wants to be prompted for the template id
 // 2. --template=<template-id>: This populates the value of i.Template to be <template-id>. This skips the template id
 //    prompt and checks whether the supplied template id exists.
 // 3. no flag defined: This populates the value of i.Template to be "". This tells us to skip the template-app-related

--- a/internal/commands/app/new_app_inputs.go
+++ b/internal/commands/app/new_app_inputs.go
@@ -55,15 +55,11 @@ func (i *newAppInputs) resolveTemplateID(client realm.Client) error {
 		return fmt.Errorf("unable to find template '%s'", i.Template)
 	}
 
-	if i.Template != "" {
-		for _, template := range templates {
-			if template.ID == i.Template {
-				i.Template = template.ID
-				return nil
-			}
+	// Check if supplied template id is a valid template
+	for _, template := range templates {
+		if template.ID == i.Template {
+			return nil
 		}
-
-		return fmt.Errorf("template '%s' not found", i.Template)
 	}
-	return nil
+	return fmt.Errorf("template '%s' not found", i.Template)
 }

--- a/internal/commands/pull/command.go
+++ b/internal/commands/pull/command.go
@@ -90,7 +90,8 @@ func (cmd *Command) Flags() []flags.Flag {
 				Name:      "template",
 				Shorthand: "t",
 				Usage: flags.Usage{
-					Description:   "Specify the frontend Template ID(s) to export. Specified templates must be compatible with the remote app",
+					Description:   "Specify the frontend Template ID(s) to export.",
+					Note:          "Specified templates must be compatible with the remote app",
 					AllowedValues: realm.AllowedTemplates,
 				},
 			},

--- a/internal/commands/pull/command.go
+++ b/internal/commands/pull/command.go
@@ -84,13 +84,13 @@ func (cmd *Command) Flags() []flags.Flag {
 				},
 			},
 		},
-		flags.StringFlag{
-			Value: &cmd.inputs.TemplateID,
+		flags.StringSliceFlag{
+			Value: &cmd.inputs.TemplateIDs,
 			Meta: flags.Meta{
 				Name:      "template",
 				Shorthand: "t",
 				Usage: flags.Usage{
-					Description: "Specify the Template ID that is used for this Realm app",
+					Description: "Specify the IDs of the template frontend to export",
 				},
 			},
 		},
@@ -113,7 +113,7 @@ func (cmd *Command) Handler(profile *user.Profile, ui terminal.UI, clients cli.C
 
 	var clientTemplates []clientTemplate
 	if app.TemplateID != "" {
-		clientTemplates, err = cmd.inputs.resolveClientTemplates(ui, clients.Realm, app.GroupID, app.ID)
+		clientTemplates, err = cmd.inputs.resolveClientTemplates(clients.Realm, app.GroupID, app.ID)
 		if err != nil {
 			return err
 		}

--- a/internal/commands/pull/command.go
+++ b/internal/commands/pull/command.go
@@ -90,7 +90,8 @@ func (cmd *Command) Flags() []flags.Flag {
 				Name:      "template",
 				Shorthand: "t",
 				Usage: flags.Usage{
-					Description: "Specify the IDs of the template frontend to export",
+					Description: "Specify the IDs of the template frontend to export. Specified templates must be compatible with the remote app",
+					Note:        "Options include: web.graphql.todo, web.mql.todo, triggers, ios.swift.todo, android.kotlin.todo, react-native.todo, xamarin.todo",
 				},
 			},
 		},

--- a/internal/commands/pull/command.go
+++ b/internal/commands/pull/command.go
@@ -90,8 +90,8 @@ func (cmd *Command) Flags() []flags.Flag {
 				Name:      "template",
 				Shorthand: "t",
 				Usage: flags.Usage{
-					Description: "Specify the IDs of the template frontend to export. Specified templates must be compatible with the remote app",
-					Note:        "Options include: web.graphql.todo, web.mql.todo, triggers, ios.swift.todo, android.kotlin.todo, react-native.todo, xamarin.todo",
+					Description:   "Specify the frontend Template ID(s) to export. Specified templates must be compatible with the remote app",
+					AllowedValues: realm.AllowedTemplates,
 				},
 			},
 		},

--- a/internal/commands/pull/command_test.go
+++ b/internal/commands/pull/command_test.go
@@ -117,7 +117,7 @@ Contents would have been written to: app
 				return nil, true, nil
 			}
 
-			cmd := &Command{inputs{Project: "elsewhere", DryRun: true, LocalPath: "app", TemplateID: "some-template-id"}}
+			cmd := &Command{inputs{Project: "elsewhere", DryRun: true, LocalPath: "app", TemplateIDs: []string{"some-template-id"}}}
 
 			assert.Nil(t, cmd.Handler(profile, ui, cli.Clients{Realm: realmClient}))
 			backendDestination := filepath.Join(profile.WorkingDirectory, "app", local.BackendPath)
@@ -442,7 +442,7 @@ Successfully pulled app down: app
 
 			_, ui := mock.NewUI()
 
-			cmd := &Command{inputs{Project: "some_project", LocalPath: "app", TemplateID: templateID}}
+			cmd := &Command{inputs{Project: "some_project", LocalPath: "app", TemplateIDs: []string{templateID}}}
 			assert.Nil(t, cmd.Handler(profile, ui, cli.Clients{Realm: realmClient}))
 
 			destination := filepath.Join(profile.WorkingDirectory, "app", local.FrontendPath, templateID)
@@ -527,7 +527,7 @@ Successfully pulled app down: app
 			out := new(bytes.Buffer)
 			ui := mock.NewUIWithOptions(mock.UIOptions{AutoConfirm: true}, out)
 
-			cmd := &Command{inputs{Project: "elsewhere", LocalPath: "app", TemplateID: "some-template-id"}}
+			cmd := &Command{inputs{Project: "elsewhere", LocalPath: "app", TemplateIDs: []string{"some-template-id"}}}
 
 			err := cmd.Handler(profile, ui, cli.Clients{Realm: realmClient})
 			assert.Equal(t, errors.New("some kind of error"), err)
@@ -544,7 +544,7 @@ Successfully pulled app down: app
 			out := new(bytes.Buffer)
 			ui := mock.NewUIWithOptions(mock.UIOptions{AutoConfirm: true}, out)
 
-			cmd := &Command{inputs{Project: "elsewhere", LocalPath: "app", TemplateID: "some-template-id"}}
+			cmd := &Command{inputs{Project: "elsewhere", LocalPath: "app", TemplateIDs: []string{"some-template-id"}}}
 
 			err := cmd.Handler(profile, ui, cli.Clients{Realm: realmClient})
 			assert.Equal(t, errors.New("template 'some-template-id' is not compatible with this app"), err)

--- a/internal/commands/pull/command_test.go
+++ b/internal/commands/pull/command_test.go
@@ -474,9 +474,7 @@ Successfully pulled app down: app
 			profile, teardown := mock.NewProfileFromTmpDir(t, "profile_name")
 			defer teardown()
 
-			console, _, ui, err := mock.NewVT10XConsoleWithOptions(mock.UIOptions{AutoConfirm: true})
-			assert.Nil(t, err)
-			defer console.Close()
+			_, ui := mock.NewUI()
 
 			cmd := &Command{input}
 			assert.Nil(t, cmd.Handler(profile, ui, cli.Clients{Realm: realmClient}))

--- a/internal/commands/pull/command_test.go
+++ b/internal/commands/pull/command_test.go
@@ -456,7 +456,7 @@ Successfully pulled app down: app
 		})
 
 		t.Run("should export all selected compatible templates if no template id is passed in and the app is made with a template and auto confirm is not set", func(t *testing.T) {
-			input := inputs{Project: "some_project", LocalPath: "app"}
+			input := inputs{Project: "some_project", LocalPath: "app", TemplateIDs: []string{"template_1", "template_2"}}
 
 			realmClient.CompatibleTemplatesFn = func(groupID, appID string) ([]realm.Template, error) {
 				return []realm.Template{{ID: "template_1", Name: "Template 1"}, {ID: "template_2", Name: "Template 2"}}, nil
@@ -477,18 +477,6 @@ Successfully pulled app down: app
 			console, _, ui, err := mock.NewVT10XConsoleWithOptions(mock.UIOptions{AutoConfirm: true})
 			assert.Nil(t, err)
 			defer console.Close()
-
-			doneCh := make(chan struct{})
-			go func() {
-				defer close(doneCh)
-				console.ExpectString("Which template(s) would you like to export this app with")
-				console.Send("Template 1")
-				console.Send(" ")
-				console.Send("Template 2")
-				console.Send(" ")
-				console.SendLine("")
-				console.ExpectEOF()
-			}()
 
 			cmd := &Command{input}
 			assert.Nil(t, cmd.Handler(profile, ui, cli.Clients{Realm: realmClient}))
@@ -547,7 +535,7 @@ Successfully pulled app down: app
 			cmd := &Command{inputs{Project: "elsewhere", LocalPath: "app", TemplateIDs: []string{"some-template-id"}}}
 
 			err := cmd.Handler(profile, ui, cli.Clients{Realm: realmClient})
-			assert.Equal(t, errors.New("template 'some-template-id' is not compatible with this app"), err)
+			assert.Equal(t, errors.New("frontend template 'some-template-id' is not compatible with this app"), err)
 		})
 
 		t.Run("should return nothing and continue exporting the app if the app is not made with a template", func(t *testing.T) {

--- a/internal/commands/pull/inputs_test.go
+++ b/internal/commands/pull/inputs_test.go
@@ -184,7 +184,7 @@ func TestPullTemplatesResolve(t *testing.T) {
 
 		input := inputs{}
 		out, err := input.resolveClientTemplates(realmClient, "some-group-id", "some-app-id")
-		assert.Equal(t, nil, err)
+		assert.Nil(t, err)
 		assert.Equal(t, 0, len(out))
 	})
 

--- a/internal/commands/pull/inputs_test.go
+++ b/internal/commands/pull/inputs_test.go
@@ -179,6 +179,15 @@ func TestPullTemplatesResolve(t *testing.T) {
 	assert.Nil(t, err)
 	defer templateZipPkg2.Close()
 
+	t.Run("should not do anything if no template id is passed in", func(t *testing.T) {
+		var realmClient mock.RealmClient
+
+		input := inputs{}
+		out, err := input.resolveClientTemplates(realmClient, "some-group-id", "some-app-id")
+		assert.Equal(t, nil, err)
+		assert.Equal(t, 0, len(out))
+	})
+
 	t.Run("should not do anything if fetching for compatible templates errors", func(t *testing.T) {
 		var realmClient mock.RealmClient
 
@@ -186,9 +195,8 @@ func TestPullTemplatesResolve(t *testing.T) {
 			return nil, errors.New("something went wrong")
 		}
 
-		_, ui := mock.NewUI()
-		input := inputs{}
-		_, err := input.resolveClientTemplates(ui, realmClient, "some-group-id", "some-app-id")
+		input := inputs{TemplateIDs: []string{"test-template-id"}}
+		_, err := input.resolveClientTemplates(realmClient, "some-group-id", "some-app-id")
 		assert.Equal(t, errors.New("something went wrong"), err)
 	})
 
@@ -202,9 +210,8 @@ func TestPullTemplatesResolve(t *testing.T) {
 			realmClient.ClientTemplateFn = func(groupID, appID, templateID string) (*zip.Reader, bool, error) {
 				return nil, false, errors.New("something went wrong with client")
 			}
-			_, ui := mock.NewUI()
-			input := inputs{TemplateID: "some-template-id"}
-			_, err := input.resolveClientTemplates(ui, realmClient, "some-group-id", "some-app-id")
+			input := inputs{TemplateIDs: []string{"some-template-id"}}
+			_, err := input.resolveClientTemplates(realmClient, "some-group-id", "some-app-id")
 			assert.Equal(t, errors.New("something went wrong with client"), err)
 		})
 
@@ -215,10 +222,9 @@ func TestPullTemplatesResolve(t *testing.T) {
 				return []realm.Template{{ID: "some-template-id", Name: "some template name"}}, nil
 			}
 
-			_, ui := mock.NewUI()
-			input := inputs{TemplateID: "wrong-template-id"}
-			_, err := input.resolveClientTemplates(ui, realmClient, "some-group-id", "some-app-id")
-			assert.Equal(t, errors.New("template 'wrong-template-id' is not compatible with this app"), err)
+			input := inputs{TemplateIDs: []string{"wrong-template-id"}}
+			_, err := input.resolveClientTemplates(realmClient, "some-group-id", "some-app-id")
+			assert.Equal(t, errors.New("frontend template 'wrong-template-id' is not compatible with this app"), err)
 		})
 	})
 
@@ -230,8 +236,7 @@ func TestPullTemplatesResolve(t *testing.T) {
 			realmClient.CompatibleTemplatesFn = func(groupID, appID string) ([]realm.Template, error) {
 				return nil, nil
 			}
-			_, ui := mock.NewUI()
-			result, err := input.resolveClientTemplates(ui, realmClient, "some-group-id", "some-app-id")
+			result, err := input.resolveClientTemplates(realmClient, "some-group-id", "some-app-id")
 			assert.Nil(t, err)
 			assert.Equal(t, 0, len(result))
 
@@ -243,19 +248,7 @@ func TestPullTemplatesResolve(t *testing.T) {
 				return []realm.Template{{ID: "some-template-id", Name: "some name"}}, nil
 			}
 
-			_, console, _, ui, err := mock.NewVT10XConsole()
-			assert.Nil(t, err)
-			defer console.Close()
-
-			doneCh := make(chan struct{})
-			go func() {
-				defer close(doneCh)
-				console.ExpectString("Would you like to export with a client template?")
-				console.SendLine("n")
-				console.ExpectEOF()
-			}()
-
-			result, err := input.resolveClientTemplates(ui, realmClient, "some-group-id", "some-group-app")
+			result, err := input.resolveClientTemplates(realmClient, "some-group-id", "some-group-app")
 			assert.Nil(t, err)
 			assert.Equal(t, 0, len(result))
 		})

--- a/internal/utils/flags/flags.go
+++ b/internal/utils/flags/flags.go
@@ -179,8 +179,9 @@ func NewStringSetFlag(values *[]string, opts StringSetOptions) CustomFlag {
 // StringFlag is a string flag
 type StringFlag struct {
 	Meta
-	Value        *string
-	DefaultValue string
+	Value              *string
+	DefaultValue       string
+	NoArgsDefaultValue *string
 }
 
 // Register registers the string flag with the provided flag set
@@ -189,6 +190,13 @@ func (f StringFlag) Register(fs *pflag.FlagSet) {
 		fs.StringVar(f.Value, f.Name, f.DefaultValue, f.Usage.String())
 	} else {
 		fs.StringVarP(f.Value, f.Name, f.Shorthand, f.DefaultValue, f.Usage.String())
+	}
+
+	// If NoArgsDefaultValue is defined, set a default value when flag is defined with no args
+	if f.NoArgsDefaultValue != nil {
+		if flag := fs.Lookup(f.Name); flag != nil {
+			flag.NoOptDefVal = *f.NoArgsDefaultValue
+		}
 	}
 
 	if f.Hidden {

--- a/internal/utils/flags/flags.go
+++ b/internal/utils/flags/flags.go
@@ -57,6 +57,10 @@ func (u Usage) String() string {
 
 	parts = append(parts, u.Description)
 
+	if u.Note != "" {
+		parts = append(parts, fmt.Sprintf("(Note: %s)", u.Note))
+	}
+
 	if u.DefaultValue != "" || len(u.AllowedValues) > 0 {
 		valueParts := make([]string, 0, 3)
 
@@ -73,10 +77,6 @@ func (u Usage) String() string {
 		}
 
 		parts = append(parts, fmt.Sprintf("(%s)", strings.Join(valueParts, "; ")))
-	}
-
-	if u.Note != "" {
-		parts = append(parts, fmt.Sprintf("(Note: %s)", u.Note))
 	}
 
 	if u.DocsLink != "" {

--- a/internal/utils/flags/flags.go
+++ b/internal/utils/flags/flags.go
@@ -179,8 +179,8 @@ func NewStringSetFlag(values *[]string, opts StringSetOptions) CustomFlag {
 // StringFlag is a string flag
 type StringFlag struct {
 	Meta
-	Value              *string
-	DefaultValue       string
+	Value        *string
+	DefaultValue string
 }
 
 // Register registers the string flag with the provided flag set

--- a/internal/utils/flags/flags.go
+++ b/internal/utils/flags/flags.go
@@ -181,7 +181,6 @@ type StringFlag struct {
 	Meta
 	Value              *string
 	DefaultValue       string
-	NoArgsDefaultValue *string
 }
 
 // Register registers the string flag with the provided flag set
@@ -190,13 +189,6 @@ func (f StringFlag) Register(fs *pflag.FlagSet) {
 		fs.StringVar(f.Value, f.Name, f.DefaultValue, f.Usage.String())
 	} else {
 		fs.StringVarP(f.Value, f.Name, f.Shorthand, f.DefaultValue, f.Usage.String())
-	}
-
-	// If NoArgsDefaultValue is defined, set a default value when flag is defined with no args
-	if f.NoArgsDefaultValue != nil {
-		if flag := fs.Lookup(f.Name); flag != nil {
-			flag.NoOptDefVal = *f.NoArgsDefaultValue
-		}
 	}
 
 	if f.Hidden {

--- a/internal/utils/test/mock/realm_client.go
+++ b/internal/utils/test/mock/realm_client.go
@@ -478,7 +478,7 @@ func (rc RealmClient) SchemaModels(groupID, appID, language string) ([]realm.Sch
 // AllTemplates calls the mocked AllTemplates implementation if provided,
 // otherwise the call falls back to the underlying realm.Client implementation.
 // NOTE: this may panic if the underlying realm.Client is left undefined
-func (rc RealmClient) AllTemplates() ([]realm.Template, error) {
+func (rc RealmClient) AllTemplates() (realm.Templates, error) {
 	if rc.AllTemplatesFn != nil {
 		return rc.AllTemplatesFn()
 	}
@@ -498,7 +498,7 @@ func (rc RealmClient) ClientTemplate(groupID, appID, templateID string) (*zip.Re
 // CompatibleTemplates calls the mocked CompatibleTemplates implementation if provided,
 // otherwise the call falls back to the underlying realm.Client implementation.
 // NOTE: this may panic if the underlying realm.Client is left undefined
-func (rc RealmClient) CompatibleTemplates(groupID, appID string) ([]realm.Template, error) {
+func (rc RealmClient) CompatibleTemplates(groupID, appID string) (realm.Templates, error) {
 	if rc.CompatibleTemplatesFn != nil {
 		return rc.CompatibleTemplatesFn(groupID, appID)
 	}


### PR DESCRIPTION
## Description

In this PR, I've reworked how the template app creation works within the realm-cli.

We decided offline that we will start out without making a prompt for template ids and instead add the available template ids   to the help menu. We will update the help menu as we add more templates and rethink how we want to prompt for template ids once we find a good solution to REALMC-9512.

~First off, I've updated the --template flag to have a default value when it is declared but is not supplied any arguments.~

~This allows us to distinguish between the following commands:~

~1. `realm-cli app create --template=<template-id>`~

~2. `realm-cli app create --template`~

~3. `realm-cli app create`~

~1 does not prompt the user for a template because it's already supplied~
~2 prompts the user for a template~
~3 does not prompt the user for template because we assume that users do not always want to create a template app.~

~## Updated Help menu~

![image](https://user-images.githubusercontent.com/15252988/127373658-551213db-8016-4e18-a741-153e951de810.png)

~`<prompt-templates>` is a special value used to distinguish whether we should prompt the user. This is probably going to be the point of contention in this PR since we don't really have this behavior anywhere else in the CLI. I'm happy to try and work this out and iron out the details if this is not acceptable.~