### PR TITLE
REALMC 9512

### DIFF
--- a/internal/commands/app/create_inputs.go
+++ b/internal/commands/app/create_inputs.go
@@ -154,7 +154,7 @@ func (i *createInputs) resolveLocalPath(ui terminal.UI, wd string) (string, erro
 }
 
 func (i *createInputs) resolveClusters(ui terminal.UI, client atlas.Client, groupID string) ([]dataSourceCluster, []string, error) {
-	if i.Template != "" {
+	if i.Template.String() != "" {
 		clusters, err := client.Clusters(groupID)
 		if err != nil {
 			return nil, nil, err
@@ -259,7 +259,7 @@ func (i *createInputs) resolveClusters(ui terminal.UI, client atlas.Client, grou
 }
 
 func (i *createInputs) resolveDatalakes(ui terminal.UI, client atlas.Client, groupID string) ([]dataSourceDatalake, []string, error) {
-	if i.Template != "" && len(i.Datalakes) > 0 {
+	if i.Template.String() != "" && len(i.Datalakes) > 0 {
 		return nil, nil, errors.New("cannot create a template app with data lakes")
 	}
 
@@ -321,8 +321,8 @@ func (i createInputs) args(omitDryRun bool) []flags.Arg {
 	if i.LocalPath != "" {
 		args = append(args, flags.Arg{flagLocalPathCreate, i.LocalPath})
 	}
-	if i.Template != "" {
-		args = append(args, flags.Arg{flagTemplate, i.Template})
+	if i.Template.String() != "" {
+		args = append(args, flags.Arg{flagTemplate, i.Template.String()})
 	}
 	if i.Location != flagLocationDefault {
 		args = append(args, flags.Arg{flagLocation, i.Location.String()})

--- a/internal/commands/app/new_app_inputs.go
+++ b/internal/commands/app/new_app_inputs.go
@@ -6,6 +6,7 @@ import (
 	"github.com/10gen/realm-cli/internal/cli"
 	"github.com/10gen/realm-cli/internal/cloud/realm"
 	"github.com/10gen/realm-cli/internal/terminal"
+	"github.com/10gen/realm-cli/internal/utils/flags"
 
 	"github.com/AlecAivazis/survey/v2"
 )
@@ -22,7 +23,7 @@ type newAppInputs struct {
 	DeploymentModel realm.DeploymentModel
 	Location        realm.Location
 	Environment     realm.Environment
-	Template        string
+	Template        flags.OptionalString
 	ConfigVersion   realm.AppConfigVersion
 }
 
@@ -39,7 +40,7 @@ func (i *newAppInputs) resolveRemoteApp(ui terminal.UI, rc realm.Client) (realm.
 }
 
 func (i *newAppInputs) resolveTemplateID(ui terminal.UI, client realm.Client) error {
-	if i.Template == "" && ui.AutoConfirm() {
+	if i.Template.String() == "" && ui.AutoConfirm() {
 		return nil
 	}
 
@@ -50,7 +51,7 @@ func (i *newAppInputs) resolveTemplateID(ui terminal.UI, client realm.Client) er
 
 	// do not disrupt application creation flow if templates are not
 	// available and user is not specifying a template
-	if i.Template == "" && len(templates) == 0 {
+	if i.Template.String() == "" && len(templates) == 0 {
 		return nil
 	}
 
@@ -58,10 +59,10 @@ func (i *newAppInputs) resolveTemplateID(ui terminal.UI, client realm.Client) er
 		return fmt.Errorf("unable to find template '%s'", i.Template)
 	}
 
-	if i.Template != "" {
+	if i.Template.String() != "" {
 		for _, template := range templates {
-			if template.ID == i.Template {
-				i.Template = template.ID
+			if template.ID == i.Template.String() {
+				i.Template = flags.NewSetOptionalString(template.ID)
 				return nil
 			}
 		}
@@ -89,7 +90,7 @@ func (i *newAppInputs) resolveTemplateID(ui terminal.UI, client realm.Client) er
 		return err
 	}
 
-	i.Template = templateIDs[selectedIndex]
+	i.Template = flags.NewSetOptionalString(templateIDs[selectedIndex])
 
 	return nil
 }

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -55,7 +55,7 @@ var (
 				CommandMeta: app.CommandMetaInit,
 			},
 			{
-				Command:     &app.CommandCreate{},
+				Command:     app.NewCommandCreate(),
 				CommandMeta: app.CommandMetaCreate,
 			},
 			{

--- a/internal/utils/flags/flags.go
+++ b/internal/utils/flags/flags.go
@@ -125,6 +125,25 @@ func (f CustomFlag) Register(fs *pflag.FlagSet) {
 	}
 }
 
+// OptionalStringFlag is a flag that has a default value when no args are supplied but
+type OptionalStringFlag struct {
+	Meta
+	Value OptionalString
+}
+
+// Register registers the optional string flag with the provided flag set
+func (f OptionalStringFlag) Register(fs *pflag.FlagSet) {
+	if f.Shorthand == "" {
+		fs.Var(&f.Value, f.Name, f.Usage.String())
+	} else {
+		fs.VarP(&f.Value, f.Name, f.Shorthand, f.Usage.String())
+	}
+
+	if f.Hidden {
+		MarkHidden(fs, f.Name)
+	}
+}
+
 // StringSetOptions are the options available when creating a new string set flag.
 // The DefaultValue and AllowedValues fields of these options (found in Meta.Usage)
 // are ignored and instead are derived from the initially provided values and

--- a/internal/utils/flags/flags_test.go
+++ b/internal/utils/flags/flags_test.go
@@ -1,0 +1,57 @@
+package flags
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+
+	"github.com/10gen/realm-cli/internal/utils/test/assert"
+)
+
+func TestOptionalStringFlag_Register(t *testing.T) {
+	t.Run("should set user-defined value when flag is passed a value", func(t *testing.T) {
+		flag := newOptStringFlag("test1", "defaultvalue")
+		pflag.Var(&flag.Value, flag.Name , flag.Usage.String())
+		pflag.Set(flag.Name, "test-string-value")
+		pflag.Parse()
+
+		f := pflag.Lookup(flag.Name)
+		assert.NotNil(t, f)
+
+		val, ok := f.Value.(*OptionalString)
+		assert.Equal(t, true, ok)
+
+		assert.Equal(t, true, val.IsSet)
+		assert.Equal(t, "test-string-value", val.Value)
+	})
+
+	t.Run("should set default value when flag is not passed a value", func(t *testing.T) {
+		flag := newOptStringFlag("test2", "defaultvalue")
+		pflag.Var(&flag.Value, flag.Name , flag.Usage.String())
+		pflag.Set(flag.Name, "")
+		pflag.Parse()
+
+		f := pflag.Lookup(flag.Name)
+		assert.NotNil(t, f)
+
+		val, ok := f.Value.(*OptionalString)
+		assert.Equal(t, true, ok)
+
+		assert.Equal(t, false, val.IsSet)
+		assert.Equal(t, "defaultvalue", val.Value)
+	})
+}
+
+func newOptStringFlag(name, defaultValue string) OptionalStringFlag {
+	return OptionalStringFlag{
+		Meta:  Meta{
+			Name:      name,
+			Usage:     Usage{
+				Description:   "test template flag",
+			},
+		},
+		Value: OptionalString{
+			DefaultValue: defaultValue,
+		},
+	}
+}

--- a/internal/utils/flags/optional.go
+++ b/internal/utils/flags/optional.go
@@ -1,0 +1,34 @@
+package flags
+
+// OptionalString is a value that can either be set with a user-defined value or unset and have a default value
+type OptionalString struct {
+	IsSet        bool
+	Value        string
+	DefaultValue string
+}
+
+// String returns the string representation of an optional string
+func (o OptionalString) String() string {
+	if o.IsSet {
+		return o.Value
+	}
+	return o.DefaultValue
+}
+
+// Set determines how to set the value of an optional string
+func (o *OptionalString) Set(s string) error {
+	if s == "" {
+		o.Value = o.DefaultValue
+	} else {
+		o.IsSet = true
+		o.Value = s
+	}
+
+	return nil
+}
+
+func (o OptionalString) Type() string {
+	return "OptionalString"
+}
+
+

--- a/internal/utils/flags/optional.go
+++ b/internal/utils/flags/optional.go
@@ -7,6 +7,15 @@ type OptionalString struct {
 	DefaultValue string
 }
 
+// NewSetOptionalString returns an optional string struct that is assumed to have been set with the passed-in argument
+// value
+func NewSetOptionalString(val string) OptionalString {
+	return OptionalString{
+		IsSet: true,
+		Value: "val",
+	}
+}
+
 // String returns the string representation of an optional string
 func (o OptionalString) String() string {
 	if o.IsSet {
@@ -30,5 +39,3 @@ func (o *OptionalString) Set(s string) error {
 func (o OptionalString) Type() string {
 	return "OptionalString"
 }
-
-

--- a/internal/utils/flags/optional_test.go
+++ b/internal/utils/flags/optional_test.go
@@ -1,0 +1,31 @@
+package flags
+
+import (
+	"testing"
+
+	"github.com/10gen/realm-cli/internal/utils/test/assert"
+)
+
+func TestOptionalStringSet(t *testing.T) {
+	defaultValue := "default"
+	opt := OptionalString{
+		DefaultValue: defaultValue,
+	}
+	for _, tc := range []struct {
+		description string
+		input       string
+		expectedIsSet bool
+		expectedValue string
+	}{
+		{"no input", "", false, defaultValue},
+		{"string input", "hello-world", true, "hello-world"},
+		{"string number input", "12", true, "12"},
+	} {
+		t.Run("should parse "+tc.description, func(t *testing.T) {
+			assert.Nil(t, opt.Set(tc.input))
+
+			assert.Equal(t, tc.expectedIsSet, opt.IsSet)
+			assert.Equal(t, tc.expectedValue, opt.Value)
+		})
+	}
+}


### PR DESCRIPTION
## Description

So this is still in the WIP / POC stage

The issue at the moment is that we need to figure out if it's possible to not call `flag.Set()` if the user did not supply the flag that we're concerned with.

I've tried to find references of `flag.Set` within our codebase and it seems like it's only being called from within the pflag lib. This probably means that we either need to maintain our own fork of `pflag` (highly yikes) or we stick to `NoOptDefVal`

As a manual test, I've implemented the `app create --template` flag with this new `OptionalStringFlag` and I'm finding that it behaves similarly as if we used the `StringFlag` with a `DefaultValue: "<prompt-templates>"`.

in other words:

when user calls `realm-cli app create` => `cmd.input.Template.String() = <prompt-template>`

and when user calls `realm-cli app create --template` => error: 2021/07/30 16:28:33 flag needs an argument: --template

![image](https://user-images.githubusercontent.com/15252988/127708560-704880e5-f2bb-481e-8397-a1b48f5050fb.png)
 