### PR TITLE
REALMC-10379: Fix flaky CLI test for TestFindDefaultPath

### DIFF
--- a/internal/commands/app/create_inputs_test.go
+++ b/internal/commands/app/create_inputs_test.go
@@ -1236,7 +1236,7 @@ func TestFindDefaultPath(t *testing.T) {
 
 		//if file options 1-9 are exhausted, use hex
 		defaultPath := findDefaultPath(profile.WorkingDirectory, testAppName)
-		directoryID := strings.Trim(defaultPath, testAppName+"-")
+		directoryID := strings.TrimLeft(defaultPath, testAppName+"-")
 		assert.True(t, primitive.IsValidObjectID(directoryID), fmt.Sprintf("should be primitive object id, but found %s", directoryID))
 	})
 }


### PR DESCRIPTION
Ran a bunch of tests and it seems like if the default path returned on line 1238 ended in one of the letters contained in `test-app`, then that letter was “trimmed” off. 
This explains why the test was flaky: it failed only when the random hex object id ended in ‘a’ or ‘e’. 

ex. 
> If 		==> defaultPath == test-app-61803177ff64466343a31eee
> Then 	==> directoryID == 61803177ff64466343a31 (“all ‘e’s were trimmed)


Similarly for 
> If 		==> defaultPath == test-app-61803177ff64466343a31eea
> Then    ==> directoryID  == 61803177ff64466343a31 (“all ‘e’s  and ‘a’s were trimmed)

But if it ends in ‘c’, then it passes/trims correctly  because ‘c’ is not found in ‘test-app’
> If 		==> defaultPath == test-app-61802fbe11186e2e4fc7970c
> Then 	==> directoryID  == 61802fbe11186e2e4fc7970c

Solution was to use `strings.TrimLeft` instead of `strings.Trim` to ensure only the app name `test-app` gets trimmed.