### PR TITLE
REALMC-11032: Enable package.json to be uploaded from app root dir

### DIFF
--- a/internal/cloud/realm/dependencies.go
+++ b/internal/cloud/realm/dependencies.go
@@ -182,7 +182,7 @@ func (c *client) DiffDependencies(groupID, appID, uploadPath string) (Dependenci
 		},
 	)
 	if err != nil {
-		return DependenciesDiff{}, err
+		return DependenciesDiff{}, fmt.Errorf("unable to upload dependencies from %s\n%w", uploadPath, err)
 	}
 	if res.StatusCode != http.StatusOK {
 		return DependenciesDiff{}, api.ErrUnexpectedStatusCode{"diff dependencies", res.StatusCode}

--- a/internal/local/dependencies_test.go
+++ b/internal/local/dependencies_test.go
@@ -109,31 +109,31 @@ func TestDependenciesFindPackageJSON(t *testing.T) {
 	wd, wdErr := os.Getwd()
 	assert.Nil(t, wdErr)
 
-	testRoot := filepath.Join(wd, "testdata/dependencies")
+	testRootDir := filepath.Join(wd, "testdata/dependencies")
 
 	t.Run("should return an empty object when run outside a project directory", func(t *testing.T) {
-		deps, err := FindPackageJSON(testRoot)
+		deps, err := FindPackageJSON(testRootDir)
 		assert.Nil(t, err)
 		assert.Equal(t, Dependencies{}, deps)
 	})
 
 	t.Run("should return an error when a project has no package.json file", func(t *testing.T) {
-		dir := filepath.Join(testRoot, "empty")
+		dir := filepath.Join(testRootDir, "empty")
 
 		_, err := FindPackageJSON(dir)
 		assert.NotNil(t, err)
 		assert.Equal(t,
 			err.Error(),
-			fmt.Sprintf("package.json not found at '%s/functions'", dir),
+			fmt.Sprintf("package.json not found at %s/functions or %s", dir, dir),
 		)
 	})
 
 	t.Run("should find a package.json", func(t *testing.T) {
-		absPath, err := filepath.Abs(filepath.Join(testRoot, "json"))
+		absPath, err := filepath.Abs(filepath.Join(testRootDir, "json"))
 		assert.Nil(t, err)
 
 		t.Run("with an absolute path", func(t *testing.T) {
-			deps, err := FindPackageJSON(filepath.Join(testRoot, "json"))
+			deps, err := FindPackageJSON(filepath.Join(testRootDir, "json"))
 			assert.Nil(t, err)
 			assert.Equal(t, Dependencies{
 				filepath.Join(absPath, "functions"),
@@ -148,6 +148,18 @@ func TestDependenciesFindPackageJSON(t *testing.T) {
 			assert.Equal(t, Dependencies{
 				filepath.Join(absPath, "functions"),
 				filepath.Join(absPath, "functions", "package.json"),
+				false,
+			}, deps)
+		})
+
+		t.Run("when the package.json is in the app structure root", func(t *testing.T) {
+			absPathWithRootPackage, err := filepath.Abs(filepath.Join(testRootDir, "root_json"))
+			assert.Nil(t, err)
+			deps, err := FindPackageJSON(filepath.Join(testRootDir, "root_json"))
+			assert.Nil(t, err)
+			assert.Equal(t, Dependencies{
+				absPathWithRootPackage,
+				filepath.Join(absPathWithRootPackage, "package.json"),
 				false,
 			}, deps)
 		})

--- a/internal/local/testdata/dependencies/root_json/functions/ignore.txt
+++ b/internal/local/testdata/dependencies/root_json/functions/ignore.txt
@@ -1,0 +1,1 @@
+This file should be ignored. Its only purpose is to commit the functions dir

--- a/internal/local/testdata/dependencies/root_json/package.json
+++ b/internal/local/testdata/dependencies/root_json/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "axios": "0.21.1",
+    "hello-world-npm": "1.0.0"
+  }
+}

--- a/internal/local/testdata/dependencies/root_json/realm_config.json
+++ b/internal/local/testdata/dependencies/root_json/realm_config.json
@@ -1,0 +1,4 @@
+{
+  "config_version": 20210101,
+  "name": "dependencies-tar"
+}


### PR DESCRIPTION
- I tested these changes locally with a `package.json` in the root dir as well as in the functions dir. The functionality works as expected.
- [drive-by] add additional info on which dependencies path failed to upload