### PR TITLE
REALMC-11209: Specify patch/minor/major as arg into version bump script

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -17,7 +17,23 @@ Make sure to also consider the following minor changes:
 * did you add any command flag?
 * did you fix a bug or improve any existing behavior?
 
-## Publishing a version
+## Release Process
+
+The CLI release process is automated now such that we will publish new builds when the `package.json` file is committed to `master` with a new `"version"`.
+
+### Managing the JIRA release
+
+Head over to the [JIRA release board](https://jira.mongodb.org/projects/REALMC?selectedItem=com.atlassian.jira.jira-projects-plugin%3Arelease-page&status=released-unreleased) and find the `cli-next` version.  Here you'll find all of the tickets ready to be released with this next version.
+
+By going through all of the tickets to be released, determine the next CLI version's bump type: patch, minor, or major.
+
+At this point, you can edit the `cli-next` release in JIRA to have a more appropriate name (e.g. `cli-2.3.1`).
+
+Once the steps below are complete, you can come back here to officially "release" this version.  You should also add a new `cli-next` version.
+
+### Publishing a version
+
+First determine the next CLI version to publish.  
 
 1. Create a JIRA ticket for the corresponding release (e.g. "Release CLI <version>") and create a branch:
 ```bash
@@ -26,23 +42,14 @@ git checkout -b REALMC-XXXXX
 
 > NOTE: The branch name is significant here, as the version bump script assumes it to be the JIRA ticket associated with the CLI release.
 
-2. Update the CLI version field in `.evg.yml` to the next desired version (make sure to consult the Semantic Versioning summary above):
-  ```yaml
-  buildvariants:
-    ...
-    expansions:
-      ...
-      cli_version: <next_version>
-  ```
+2. Update the CLI version by running the `bump_version.bash` script (make sure to consult the Semantic Versioning summary above):
+```bash
+./contrib/bump_version.bash <patch|minor|major>
+```
 
-3. Run the `bump_version.bash` script to update the CLI's `package.json` and commit the changes:
-  ```bash
-  ./contrib/bump_version.bash
-  ```
+3. Push to your fork and create a PR
+```bash
+git push origin HEAD
+```
 
-4. Push to your fork and create a PR
-  ```bash
-  git push origin HEAD
-  ```
-
-5. After merging your PR, wait for Evergreen to complete the `release_tag` task on `master`.  At that point, the new CLI should be available through `npm` and `s3` updated accordingly.
+4. After merging your PR, wait for Evergreen to complete the `release_tag` task on `master`.  At that point, the new CLI should be available through `npm` and `s3` updated accordingly.

--- a/contrib/bump_version.bash
+++ b/contrib/bump_version.bash
@@ -6,13 +6,19 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $DIR
 cd ..
 
-NEXT_VERSION=`cat .evg.yml | grep cli_version: | awk '{ print $2 }' | tail -n 1`
+BUMP_TYPE=$1
+if [ "$BUMP_TYPE" != "patch" ] && [ "$BUMP_TYPE" != "minor" ] && [ "$BUMP_TYPE" != "major" ]; then
+	echo $"Usage: $0 <patch|minor|major>"
+	exit 1
+fi
 
 LAST_VERSION=`node -e 'console.log(require("./package.json").version)'`
 
-echo "Bumping CLI v$LAST_VERSION to v$NEXT_VERSION"
+echo "Bumping CLI v$LAST_VERSION to"
 
-npm version $NEXT_VERSION --no-git-tag-version
+npm version $BUMP_TYPE --no-git-tag-version
+
+NEXT_VERSION=`node -e 'console.log(require("./package.json").version)'`
 
 JIRA_TICKET=`git branch --show-current`
 


### PR DESCRIPTION
I think we're finally squared away with all of this now...

Output from the version bump script now:
```cmd
√ ~/go/src/github.com/10gen/realm-cli % ./contrib/bump_version.bash patch                                                                                                                                                          (REALMC-11209)realm-cli
Bumping CLI v2.3.1 to
v2.3.2
[REALMC-11209 de512ae9] REALMC-11209: Bump version to 2.3.2
 1 file changed, 1 insertion(+), 1 deletion(-)
commit de512ae96a62c72dbb18325f61d78edb352a68d0 (HEAD -> REALMC-11209)
Author: Nick Makes <nick@makes.life>
Date:   Wed Dec 15 14:51:02 2021 -0500

    REALMC-11209: Bump version to 2.3.2

diff --git a/package.json b/package.json
index bda1cc4a..0ccca899 100644
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongodb-realm-cli",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "The MongoDB Realm Command Line Interface",
   "repository": {
     "type": "git",
```