### PR TITLE
REALMC-11391: Support local-userpass auth provider type for login

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,3 +138,90 @@ c, err := expect.NewConsole(expect.WithStdout(out))
 assert.Nil(t, err)
 defer c.Close()
 ```
+
+## Undocumented Features and Flags
+
+### Global Flags
+
+#### Using `--realm-url` and `--atlas-url`
+
+At some point, you may wish to configure which Realm and Atlas servers the CLI is connecting to.  By default, these URLs point to the Production instances of Realm and Atlas, which should be sufficient for most use cases.
+
+However, you can set `--realm-url` and `--atlas-url` to any URLs you know a respective server instance is running at.  If you are configuring one, chances are you'll want to configure both of these.
+
+### Pseudo-Global Flags
+
+#### Using `--project`
+
+At some point, you may wish to target a specific "project id" (a.k.a. "group id") when performing any sort of app lookup.  By default, the project id is derived from the list of projects available to the logged in user, which should be sufficient for most use cases (but may force a prompt for a project selection, thus breaking typical CI/CD setups).  The impact of this setting effects only the prompts presented by the CLI (and the data found within them) to allow the user to select a project (and ultimately an app) to work with.
+
+However, you can set `--project` to any known project id.  Most commands which interact with a specific app support the use of `--project`:
+
+* `accesslist create`
+* `accesslist delete`
+* `accesslist list`
+* `accesslist update`
+* `app create`
+* `app delete`
+* `app describe`
+* `app diff`
+* `app init`
+* `apps list`
+* `function run`
+* `logs list`
+* `pull`
+* `push`
+* `schema models`
+* `secrets create`
+* `secret delete`
+* `secrets list`
+* `secret update`
+* `user create`
+* `user delete`
+* `user disable`
+* `user enable`
+* `users list`
+* `user revoke`
+
+#### Using `--config-version`
+
+At some point, you may wish to target a specific "config version" of an app.  By default, the config version chosen is the latest and most up-to-date, which should be sufficient for most use cases.
+
+However, you can set `--config-version` to any previously supported config version.  The supported values can be found at `internal/cloud/realm/realm.go`.  The following commands support the use of `--config-version`:
+
+* `app create`
+* `app init`
+* `pull`/`export`
+
+#### Using `--product`
+
+At some point, you may wish to target a specific "product type" when performing any sort of app lookup.  By default, the product types queried for include `"standard"` and `"atlas"`, which should be sufficient for most use cases.  The impact of this setting effects only the prompts presented by the CLI (and the data found within them) to allow the user to select an app to work with.
+
+However, you can set `--product` to any known app product type.  Most commands which interact with a specific app support the use of `--product`:
+
+* `accesslist create`
+* `accesslist delete`
+* `accesslist list`
+* `accesslist update`
+* `app describe`
+* `apps list`
+* `function run`
+* `logs list`
+* `schema models`
+* `secrets create`
+* `secret delete`
+* `secrets list`
+* `secret update`
+* `user create`
+* `user delete`
+* `user disable`
+* `user enable`
+* `users list`
+
+### Login Flags
+
+The `login` command supports multiple ways of authenticating with Realm.  By default, the CLI will authenticate against MongoDB Cloud Atlas using a programmatic API Key, which should be sufficient (and even recommended) for most use cases.
+
+However, you can set `--auth-type` to any other supported authentication type.  The supported values can be found at `internal/commands/login/inputs.go`.
+
+If you are using the `"local"` auth type, you will also need to specify both `--username` and `--password`.  If you do not specify these as flags, the CLI will prompt you for these inputs.  The username and password must correspond to a `local-userpass` user known to exist on the Realm server the CLI is configured to talk to.

--- a/internal/cli/user/auth.go
+++ b/internal/cli/user/auth.go
@@ -14,14 +14,12 @@ type Session struct {
 type Credentials struct {
 	PublicAPIKey  string
 	PrivateAPIKey string
+	Username      string
+	Password      string
 }
 
 // RedactedPrivateAPIKey returns the user's private API key with sensitive information redacted
 func (creds Credentials) RedactedPrivateAPIKey() string {
-	redact := func(s string) string {
-		return strings.Repeat("*", len(s))
-	}
-
 	parts := strings.Split(creds.PrivateAPIKey, "-")
 	switch len(parts) {
 	case 0:
@@ -39,4 +37,13 @@ func (creds Credentials) RedactedPrivateAPIKey() string {
 
 		return strings.Join(out, "-")
 	}
+}
+
+// RedactedPassword returns the user's password with sensitive information redacted
+func (creds Credentials) RedactedPassword() string {
+	return redact(creds.Password)
+}
+
+func redact(s string) string {
+	return strings.Repeat("*", len(s))
 }

--- a/internal/cli/user/profile.go
+++ b/internal/cli/user/profile.go
@@ -182,6 +182,8 @@ func (p Profile) Path() string {
 const (
 	keyPublicAPIKey  = "public_api_key"
 	keyPrivateAPIKey = "private_api_key"
+	keyUsername      = "username"
+	keyPassword      = "password"
 	keyAccessToken   = "access_token"
 	keyRefreshToken  = "refresh_token"
 
@@ -199,8 +201,10 @@ func (p Profile) TelemetryMode() telemetry.Mode {
 // Credentials gets the CLI profile credentials
 func (p Profile) Credentials() Credentials {
 	return Credentials{
-		p.GetString(keyPublicAPIKey),
-		p.GetString(keyPrivateAPIKey),
+		PublicAPIKey:  p.GetString(keyPublicAPIKey),
+		PrivateAPIKey: p.GetString(keyPrivateAPIKey),
+		Username:      p.GetString(keyUsername),
+		Password:      p.GetString(keyPassword),
 	}
 }
 
@@ -208,12 +212,16 @@ func (p Profile) Credentials() Credentials {
 func (p Profile) SetCredentials(creds Credentials) {
 	p.SetString(keyPublicAPIKey, creds.PublicAPIKey)
 	p.SetString(keyPrivateAPIKey, creds.PrivateAPIKey)
+	p.SetString(keyUsername, creds.Username)
+	p.SetString(keyPassword, creds.Password)
 }
 
 // ClearCredentials clears the CLI profile credentials
 func (p Profile) ClearCredentials() {
 	p.Clear(keyPublicAPIKey)
 	p.Clear(keyPrivateAPIKey)
+	p.Clear(keyUsername)
+	p.Clear(keyPassword)
 }
 
 // Session gets the CLI profile session

--- a/internal/cloud/atlas/clusters_test.go
+++ b/internal/cloud/atlas/clusters_test.go
@@ -24,7 +24,7 @@ func TestClusters(t *testing.T) {
 		},
 		{
 			description: "with a client with bad credentials",
-			client:      atlas.NewAuthClient(u.AtlasServerURL(), user.Credentials{"username", "password"}),
+			client:      atlas.NewAuthClient(u.AtlasServerURL(), user.Credentials{PublicAPIKey: "username", PrivateAPIKey: "password"}),
 			expectedErr: atlas.ErrUnauthorized{"You are not authorized for this resource."},
 		},
 	} {

--- a/internal/cloud/atlas/data_lakes_test.go
+++ b/internal/cloud/atlas/data_lakes_test.go
@@ -24,7 +24,7 @@ func TestDatalakes(t *testing.T) {
 		},
 		{
 			description: "with a client with bad credentials",
-			client:      atlas.NewAuthClient(u.AtlasServerURL(), user.Credentials{"username", "password"}),
+			client:      atlas.NewAuthClient(u.AtlasServerURL(), user.Credentials{PublicAPIKey: "username", PrivateAPIKey: "password"}),
 			expectedErr: atlas.ErrUnauthorized{"You are not authorized for this resource."},
 		},
 	} {

--- a/internal/cloud/atlas/groups_test.go
+++ b/internal/cloud/atlas/groups_test.go
@@ -24,7 +24,7 @@ func TestAtlasGroups(t *testing.T) {
 		},
 		{
 			description: "With a client with bad credentials",
-			client:      atlas.NewAuthClient(u.AtlasServerURL(), user.Credentials{"username", "password"}),
+			client:      atlas.NewAuthClient(u.AtlasServerURL(), user.Credentials{PublicAPIKey: "username", PrivateAPIKey: "password"}),
 			expectedErr: atlas.ErrUnauthorized{"You are not authorized for this resource."},
 		},
 	} {
@@ -44,5 +44,8 @@ func TestAtlasGroups(t *testing.T) {
 }
 
 func newAuthClient(t *testing.T) atlas.Client {
-	return atlas.NewAuthClient(u.AtlasServerURL(), user.Credentials{u.CloudUsername(), u.CloudAPIKey()})
+	return atlas.NewAuthClient(u.AtlasServerURL(), user.Credentials{
+		PublicAPIKey:  u.CloudUsername(),
+		PrivateAPIKey: u.CloudAPIKey(),
+	})
 }

--- a/internal/cloud/atlas/status_test.go
+++ b/internal/cloud/atlas/status_test.go
@@ -3,7 +3,6 @@ package atlas_test
 import (
 	"testing"
 
-	"github.com/10gen/realm-cli/internal/cli/user"
 	"github.com/10gen/realm-cli/internal/cloud/atlas"
 	u "github.com/10gen/realm-cli/internal/utils/test"
 	"github.com/10gen/realm-cli/internal/utils/test/assert"
@@ -11,7 +10,8 @@ import (
 
 func TestAtlasStatus(t *testing.T) {
 	u.SkipUnlessAtlasServerRunning(t)
-	client := atlas.NewAuthClient(u.AtlasServerURL(), user.Credentials{u.CloudUsername(), u.CloudAPIKey()})
+
+	client := newAuthClient(t)
 
 	t.Run("Should return no error if the server is running", func(t *testing.T) {
 		err := client.Status()

--- a/internal/cloud/realm/auth.go
+++ b/internal/cloud/realm/auth.go
@@ -13,7 +13,10 @@ const (
 	authenticatePathPattern = adminAPI + "/auth/providers/%s/login"
 	authProfilePath         = adminAPI + "/auth/profile"
 	authSessionPath         = adminAPI + "/auth/session"
+)
 
+// set of supported auth types
+const (
 	AuthTypeCloud = "mongodb-cloud"
 	AuthTypeLocal = "local-userpass"
 )

--- a/internal/cloud/realm/client.go
+++ b/internal/cloud/realm/client.go
@@ -22,7 +22,7 @@ const (
 // Client is a Realm client
 type Client interface {
 	AuthProfile() (AuthProfile, error)
-	Authenticate(publicAPIKey, privateAPIKey string) (Session, error)
+	Authenticate(authType string, credentials user.Credentials) (Session, error)
 
 	Export(groupID, appID string, req ExportRequest) (string, *zip.Reader, error)
 	ExportDependencies(groupID, appID string) (string, io.ReadCloser, error)

--- a/internal/commands/login/command_test.go
+++ b/internal/commands/login/command_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestLoginHandler(t *testing.T) {
-	t.Run("with no existing credentials handler should save new credentials", func(t *testing.T) {
+	t.Run("with no existing cloud credentials handler should save new credentials", func(t *testing.T) {
 		tmpDir, teardownTmpDir, tmpDirErr := u.NewTempDir("home")
 		assert.Nil(t, tmpDirErr)
 		defer teardownTmpDir()
@@ -32,7 +32,7 @@ func TestLoginHandler(t *testing.T) {
 		assert.True(t, os.IsNotExist(statErr), "profile must not exist")
 
 		realmClient := mock.RealmClient{}
-		realmClient.AuthenticateFn = func(publicAPIKey, privateAPIKey string) (realm.Session, error) {
+		realmClient.AuthenticateFn = func(authType string, creds user.Credentials) (realm.Session, error) {
 			return realm.Session{
 				AccessToken:  "accessToken",
 				RefreshToken: "refreshToken",
@@ -40,6 +40,7 @@ func TestLoginHandler(t *testing.T) {
 		}
 
 		cmd := &Command{inputs{
+			AuthType:      authTypeCloud,
 			PublicAPIKey:  "publicAPIKey",
 			PrivateAPIKey: "privateAPIKey",
 		}}
@@ -48,7 +49,7 @@ func TestLoginHandler(t *testing.T) {
 
 		assert.Nil(t, cmd.Handler(profile, ui, cli.Clients{Realm: realmClient}))
 
-		expectedUser := user.Credentials{"publicAPIKey", "privateAPIKey"}
+		expectedUser := user.Credentials{PublicAPIKey: "publicAPIKey", PrivateAPIKey: "privateAPIKey"}
 		expectedSession := user.Session{"accessToken", "refreshToken"}
 
 		assert.Equal(t, expectedUser, profile.Credentials())
@@ -57,7 +58,48 @@ func TestLoginHandler(t *testing.T) {
 		ensureProfileContents(t, profile, expectedUser, expectedSession)
 	})
 
-	t.Run("with existing credentials", func(t *testing.T) {
+	t.Run("with no existing local credentials handler should save new credentials", func(t *testing.T) {
+		tmpDir, teardownTmpDir, tmpDirErr := u.NewTempDir("home")
+		assert.Nil(t, tmpDirErr)
+		defer teardownTmpDir()
+
+		_, teardownHomeDir := u.SetupHomeDir(tmpDir)
+		defer teardownHomeDir()
+
+		profile := mock.NewProfile(t)
+
+		_, statErr := os.Stat(profile.Path())
+		assert.NotNil(t, statErr)
+		assert.True(t, os.IsNotExist(statErr), "profile must not exist")
+
+		realmClient := mock.RealmClient{}
+		realmClient.AuthenticateFn = func(authType string, creds user.Credentials) (realm.Session, error) {
+			return realm.Session{
+				AccessToken:  "accessToken",
+				RefreshToken: "refreshToken",
+			}, nil
+		}
+
+		cmd := &Command{inputs{
+			AuthType: authTypeLocal,
+			Username: "username",
+			Password: "password",
+		}}
+
+		_, ui := mock.NewUI()
+
+		assert.Nil(t, cmd.Handler(profile, ui, cli.Clients{Realm: realmClient}))
+
+		expectedUser := user.Credentials{Username: "username", Password: "password"}
+		expectedSession := user.Session{"accessToken", "refreshToken"}
+
+		assert.Equal(t, expectedUser, profile.Credentials())
+		assert.Equal(t, expectedSession, profile.Session())
+
+		ensureProfileContents(t, profile, expectedUser, expectedSession)
+	})
+
+	t.Run("with existing cloud credentials", func(t *testing.T) {
 		setup := func(t *testing.T) (*user.Profile, realm.Client, func()) {
 			tmpDir, teardownTmpDir, tmpDirErr := u.NewTempDir("home")
 			assert.Nil(t, tmpDirErr)
@@ -66,12 +108,12 @@ func TestLoginHandler(t *testing.T) {
 
 			profile := mock.NewProfile(t)
 
-			profile.SetCredentials(user.Credentials{"existingUser", "existing-password"})
+			profile.SetCredentials(user.Credentials{PublicAPIKey: "existingUser", PrivateAPIKey: "existing-password"})
 			profile.SetSession(user.Session{"existingAccessToken", "existingRefreshToken"})
 			assert.Nil(t, profile.Save())
 
 			realmClient := mock.RealmClient{}
-			realmClient.AuthenticateFn = func(publicAPIKey, privateAPIKey string) (realm.Session, error) {
+			realmClient.AuthenticateFn = func(authType string, creds user.Credentials) (realm.Session, error) {
 				return realm.Session{
 					AccessToken:  "newAccessToken",
 					RefreshToken: "newRefreshToken",
@@ -89,6 +131,7 @@ func TestLoginHandler(t *testing.T) {
 			defer teardown()
 
 			cmd := &Command{inputs{
+				AuthType:      authTypeCloud,
 				PublicAPIKey:  "existingUser",
 				PrivateAPIKey: "existing-password",
 			}}
@@ -97,7 +140,7 @@ func TestLoginHandler(t *testing.T) {
 
 			assert.Nil(t, cmd.Handler(profile, ui, cli.Clients{Realm: realmClient}))
 
-			expectedUser := user.Credentials{"existingUser", "existing-password"}
+			expectedUser := user.Credentials{PublicAPIKey: "existingUser", PrivateAPIKey: "existing-password"}
 			expectedSession := user.Session{"newAccessToken", "newRefreshToken"}
 
 			assert.Equal(t, expectedUser, profile.Credentials())
@@ -116,13 +159,13 @@ func TestLoginHandler(t *testing.T) {
 				{
 					description:     "And do nothing if the user does not want to proceed",
 					confirmAnswer:   "n",
-					expectedUser:    user.Credentials{"existingUser", "existing-password"},
+					expectedUser:    user.Credentials{PublicAPIKey: "existingUser", PrivateAPIKey: "existing-password"},
 					expectedSession: user.Session{"existingAccessToken", "existingRefreshToken"},
 				},
 				{
 					description:     "And save a new session if the user does want to proceed",
 					confirmAnswer:   "y",
-					expectedUser:    user.Credentials{"newUser", "new-password"},
+					expectedUser:    user.Credentials{PublicAPIKey: "newUser", PrivateAPIKey: "new-password"},
 					expectedSession: user.Session{"newAccessToken", "newRefreshToken"},
 				},
 			} {
@@ -132,6 +175,7 @@ func TestLoginHandler(t *testing.T) {
 
 					cmd := &Command{
 						inputs: inputs{
+							AuthType:      authTypeCloud,
 							PublicAPIKey:  "newUser",
 							PrivateAPIKey: "new-password",
 						},
@@ -161,6 +205,113 @@ func TestLoginHandler(t *testing.T) {
 			}
 		})
 	})
+
+	t.Run("with existing local credentials", func(t *testing.T) {
+		setup := func(t *testing.T) (*user.Profile, realm.Client, func()) {
+			tmpDir, teardownTmpDir, tmpDirErr := u.NewTempDir("home")
+			assert.Nil(t, tmpDirErr)
+
+			_, teardownHomeDir := u.SetupHomeDir(tmpDir)
+
+			profile := mock.NewProfile(t)
+
+			profile.SetCredentials(user.Credentials{Username: "existingUser", Password: "existing-password"})
+			profile.SetSession(user.Session{"existingAccessToken", "existingRefreshToken"})
+			assert.Nil(t, profile.Save())
+
+			realmClient := mock.RealmClient{}
+			realmClient.AuthenticateFn = func(authType string, creds user.Credentials) (realm.Session, error) {
+				return realm.Session{
+					AccessToken:  "newAccessToken",
+					RefreshToken: "newRefreshToken",
+				}, nil
+			}
+
+			return profile, realmClient, func() {
+				teardownHomeDir()
+				teardownTmpDir()
+			}
+		}
+
+		t.Run("that match the attempted login credentials handler should refresh the existing session", func(t *testing.T) {
+			profile, realmClient, teardown := setup(t)
+			defer teardown()
+
+			cmd := &Command{inputs{
+				AuthType: authTypeLocal,
+				Username: "existingUser",
+				Password: "existing-password",
+			}}
+
+			_, ui := mock.NewUI()
+
+			assert.Nil(t, cmd.Handler(profile, ui, cli.Clients{Realm: realmClient}))
+
+			expectedUser := user.Credentials{Username: "existingUser", Password: "existing-password"}
+			expectedSession := user.Session{"newAccessToken", "newRefreshToken"}
+
+			assert.Equal(t, expectedUser, profile.Credentials())
+			assert.Equal(t, expectedSession, profile.Session())
+
+			ensureProfileContents(t, profile, expectedUser, expectedSession)
+		})
+
+		t.Run("that do not match the attempted login credentials should prompt the user to continue", func(t *testing.T) {
+			for _, tc := range []struct {
+				description     string
+				confirmAnswer   string
+				expectedUser    user.Credentials
+				expectedSession user.Session
+			}{
+				{
+					description:     "And do nothing if the user does not want to proceed",
+					confirmAnswer:   "n",
+					expectedUser:    user.Credentials{Username: "existingUser", Password: "existing-password"},
+					expectedSession: user.Session{"existingAccessToken", "existingRefreshToken"},
+				},
+				{
+					description:     "And save a new session if the user does want to proceed",
+					confirmAnswer:   "y",
+					expectedUser:    user.Credentials{Username: "newUser", Password: "new-password"},
+					expectedSession: user.Session{"newAccessToken", "newRefreshToken"},
+				},
+			} {
+				t.Run(tc.description, func(t *testing.T) {
+					profile, realmClient, teardown := setup(t)
+					defer teardown()
+
+					cmd := &Command{
+						inputs: inputs{
+							AuthType: authTypeLocal,
+							Username: "newUser",
+							Password: "new-password",
+						},
+					}
+
+					_, console, _, ui, consoleErr := mock.NewVT10XConsole()
+					assert.Nil(t, consoleErr)
+
+					doneCh := make(chan (struct{}))
+					go func() {
+						defer close(doneCh)
+						console.ExpectString("This action will terminate the existing session for user: existingUser (*****************), would you like to proceed?")
+						console.SendLine(tc.confirmAnswer)
+						console.ExpectEOF()
+					}()
+
+					err := cmd.Handler(profile, ui, cli.Clients{Realm: realmClient})
+					assert.Nil(t, err)
+
+					assert.Nil(t, console.Tty().Close())
+					<-doneCh
+
+					assert.Equal(t, tc.expectedUser, profile.Credentials())
+					assert.Equal(t, tc.expectedSession, profile.Session())
+					ensureProfileContents(t, profile, tc.expectedUser, tc.expectedSession)
+				})
+			}
+		})
+	})
 }
 
 func TestLoginFeedback(t *testing.T) {
@@ -171,7 +322,7 @@ func TestLoginFeedback(t *testing.T) {
 		out := new(bytes.Buffer)
 		ui := mock.NewUIWithOptions(mock.UIOptions{AutoConfirm: true}, out)
 
-		cmd := &Command{}
+		cmd := &Command{inputs: inputs{AuthType: authTypeCloud}}
 
 		err := cmd.Handler(tc.profile, ui, cli.Clients{Realm: tc.realmClient})
 		assert.Nil(t, err)
@@ -183,12 +334,33 @@ func TestLoginFeedback(t *testing.T) {
 func ensureProfileContents(t *testing.T, profile *user.Profile, user user.Credentials, session user.Session) {
 	contents, err := ioutil.ReadFile(profile.Path())
 	assert.Nil(t, err)
+
+	// yaml represents empty strings as `""`, so formatting that here
+	publicAPIKey := user.PublicAPIKey
+	if publicAPIKey == "" {
+		publicAPIKey = `""`
+	}
+	privateAPIKey := user.PrivateAPIKey
+	if privateAPIKey == "" {
+		privateAPIKey = `""`
+	}
+	username := user.Username
+	if username == "" {
+		username = `""`
+	}
+	password := user.Password
+	if password == "" {
+		password = `""`
+	}
+
 	assert.True(t, strings.Contains(string(contents), fmt.Sprintf(`%s:
   access_token: %s
+  password: %s
   private_api_key: %s
   public_api_key: %s
   refresh_token: %s
-`, profile.Name, session.AccessToken, user.PrivateAPIKey, user.PublicAPIKey, session.RefreshToken)), "profile must contain the expected contents")
+  username: %s
+`, profile.Name, session.AccessToken, password, privateAPIKey, publicAPIKey, session.RefreshToken, username)), "profile must contain the expected contents")
 }
 
 type testContext struct {
@@ -207,12 +379,12 @@ func setup(t *testing.T) testContext {
 
 	profile := mock.NewProfile(t)
 
-	profile.SetCredentials(user.Credentials{"existingUser", "existing-password"})
+	profile.SetCredentials(user.Credentials{PublicAPIKey: "existingUser", PrivateAPIKey: "existing-password"})
 	profile.SetSession(user.Session{"existingAccessToken", "existingRefreshToken"})
 	assert.Nil(t, profile.Save())
 
 	realmClient := mock.RealmClient{}
-	realmClient.AuthenticateFn = func(publicAPIKey, privateAPIKey string) (realm.Session, error) {
+	realmClient.AuthenticateFn = func(authType string, creds user.Credentials) (realm.Session, error) {
 		return realm.Session{
 			AccessToken:  "newAccessToken",
 			RefreshToken: "newRefreshToken",

--- a/internal/commands/login/inputs.go
+++ b/internal/commands/login/inputs.go
@@ -1,7 +1,11 @@
 package login
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/10gen/realm-cli/internal/cli/user"
+	"github.com/10gen/realm-cli/internal/cloud/realm"
 	"github.com/10gen/realm-cli/internal/terminal"
 	"github.com/AlecAivazis/survey/v2"
 )
@@ -9,37 +13,37 @@ import (
 const (
 	inputFieldPublicAPIKey  = "publicAPIKey"
 	inputFieldPrivateAPIKey = "privateAPIKey"
+
+	inputFieldUsername = "username"
+	inputFieldPassword = "password"
+
+	authTypeCloud = "cloud"
+	authTypeLocal = "local"
 )
 
 type inputs struct {
+	AuthType      string
 	PublicAPIKey  string
 	PrivateAPIKey string
+	Username      string
+	Password      string
 }
 
 func (i *inputs) Resolve(profile *user.Profile, ui terminal.UI) error {
-	user := profile.Credentials()
+	u := profile.Credentials()
+
 	var questions []*survey.Question
 
-	if i.PublicAPIKey == "" {
-		if user.PublicAPIKey == "" {
-			questions = append(questions, &survey.Question{
-				Name:   inputFieldPublicAPIKey,
-				Prompt: &survey.Input{Message: "Public API Key", Default: user.PublicAPIKey},
-			})
-		} else {
-			i.PublicAPIKey = user.PublicAPIKey
-		}
-	}
-
-	if i.PrivateAPIKey == "" {
-		if user.PrivateAPIKey == "" {
-			questions = append(questions, &survey.Question{
-				Name:   inputFieldPrivateAPIKey,
-				Prompt: &survey.Password{Message: "Private API Key"},
-			})
-		} else {
-			i.PrivateAPIKey = user.PrivateAPIKey
-		}
+	switch i.AuthType {
+	case authTypeCloud:
+		questions = i.resolveCloudCredentials(u)
+	case authTypeLocal:
+		questions = i.resolveLocalCredentials(u)
+	default:
+		return fmt.Errorf(
+			"unsupported login type, use one of [%s] instead",
+			strings.Join([]string{authTypeCloud, authTypeLocal}, ", "),
+		)
 	}
 
 	if len(questions) > 0 {
@@ -48,4 +52,70 @@ func (i *inputs) Resolve(profile *user.Profile, ui terminal.UI) error {
 		}
 	}
 	return nil
+}
+
+func (i *inputs) resolveCloudCredentials(u user.Credentials) []*survey.Question {
+	var questions []*survey.Question
+
+	if i.PublicAPIKey == "" {
+		if u.PublicAPIKey == "" {
+			questions = append(questions, &survey.Question{
+				Name:   inputFieldPublicAPIKey,
+				Prompt: &survey.Input{Message: "Public API Key", Default: u.PublicAPIKey},
+			})
+		} else {
+			i.PublicAPIKey = u.PublicAPIKey
+		}
+	}
+
+	if i.PrivateAPIKey == "" {
+		if u.PrivateAPIKey == "" {
+			questions = append(questions, &survey.Question{
+				Name:   inputFieldPrivateAPIKey,
+				Prompt: &survey.Password{Message: "Private API Key"},
+			})
+		} else {
+			i.PrivateAPIKey = u.PrivateAPIKey
+		}
+	}
+
+	return questions
+}
+
+func (i *inputs) resolveLocalCredentials(u user.Credentials) []*survey.Question {
+	var questions []*survey.Question
+
+	if i.Username == "" {
+		if u.Username == "" {
+			questions = append(questions, &survey.Question{
+				Name:   inputFieldUsername,
+				Prompt: &survey.Input{Message: "Username", Default: u.Username},
+			})
+		} else {
+			i.Username = u.Username
+		}
+	}
+
+	if i.Password == "" {
+		if u.Password == "" {
+			questions = append(questions, &survey.Question{
+				Name:   inputFieldPassword,
+				Prompt: &survey.Password{Message: "Password"},
+			})
+		} else {
+			i.Password = u.Password
+		}
+	}
+
+	return questions
+}
+
+func realmAuthType(authType string) string {
+	switch authType {
+	case authTypeCloud:
+		return realm.AuthTypeCloud
+	case authTypeLocal:
+		return realm.AuthTypeLocal
+	}
+	return ""
 }

--- a/internal/commands/login/inputs_test.go
+++ b/internal/commands/login/inputs_test.go
@@ -72,9 +72,7 @@ func TestLoginInputs(t *testing.T) {
 				PrivateAPIKey: "password",
 			},
 			prepareProfile: func(p *user.Profile) {},
-			procedure: func(c *expect.Console) {
-				// c.ExpectEOF()
-			},
+			procedure:      func(c *expect.Console) {},
 			test: func(t *testing.T, i inputs) {
 				assert.Equal(t, "username", i.PublicAPIKey)
 				assert.Equal(t, "password", i.PrivateAPIKey)
@@ -149,9 +147,7 @@ func TestLoginInputs(t *testing.T) {
 				Password: "password",
 			},
 			prepareProfile: func(p *user.Profile) {},
-			procedure: func(c *expect.Console) {
-				// c.ExpectEOF()
-			},
+			procedure:      func(c *expect.Console) {},
 			test: func(t *testing.T, i inputs) {
 				assert.Equal(t, "username", i.Username)
 				assert.Equal(t, "password", i.Password)

--- a/internal/commands/login/inputs_test.go
+++ b/internal/commands/login/inputs_test.go
@@ -18,8 +18,9 @@ func TestLoginInputs(t *testing.T) {
 		test           func(t *testing.T, i inputs)
 	}{
 		{
-			description: "Should prompt for public api key when not provided",
+			description: "Should prompt for public api key when not provided for cloud type",
 			inputs: inputs{
+				AuthType:      authTypeCloud,
 				PrivateAPIKey: "password",
 			},
 			prepareProfile: func(p *user.Profile) {},
@@ -32,8 +33,9 @@ func TestLoginInputs(t *testing.T) {
 			},
 		},
 		{
-			description: "Should prompt for private api key when not provided",
+			description: "Should prompt for private api key when not provided for cloud type",
 			inputs: inputs{
+				AuthType:     authTypeCloud,
 				PublicAPIKey: "username",
 			},
 			prepareProfile: func(p *user.Profile) {},
@@ -47,7 +49,8 @@ func TestLoginInputs(t *testing.T) {
 			},
 		},
 		{
-			description:    "Should prompt for both api keys when not provided",
+			description:    "Should prompt for both api keys when not provided for cloud type",
+			inputs:         inputs{AuthType: authTypeCloud},
 			prepareProfile: func(p *user.Profile) {},
 			procedure: func(c *expect.Console) {
 				c.ExpectString("API Key")
@@ -62,8 +65,9 @@ func TestLoginInputs(t *testing.T) {
 			},
 		},
 		{
-			description: "Should not prompt for inputs when flags provide the data",
+			description: "Should not prompt for inputs when flags provide the data for cloud type",
 			inputs: inputs{
+				AuthType:      authTypeCloud,
 				PublicAPIKey:  "username",
 				PrivateAPIKey: "password",
 			},
@@ -77,9 +81,10 @@ func TestLoginInputs(t *testing.T) {
 			},
 		},
 		{
-			description: "Should not prompt for inputs when profile provides the data",
+			description: "Should not prompt for inputs when profile provides the data for cloud type",
+			inputs:      inputs{AuthType: authTypeCloud},
 			prepareProfile: func(p *user.Profile) {
-				p.SetCredentials(user.Credentials{"username", "password"})
+				p.SetCredentials(user.Credentials{PublicAPIKey: "username", PrivateAPIKey: "password"})
 			},
 			procedure: func(c *expect.Console) {
 				c.ExpectEOF()
@@ -87,6 +92,83 @@ func TestLoginInputs(t *testing.T) {
 			test: func(t *testing.T, i inputs) {
 				assert.Equal(t, "username", i.PublicAPIKey)
 				assert.Equal(t, "password", i.PrivateAPIKey)
+			},
+		},
+		{
+			description: "Should prompt for username when not provided for local type",
+			inputs: inputs{
+				AuthType: authTypeLocal,
+				Password: "password",
+			},
+			prepareProfile: func(p *user.Profile) {},
+			procedure: func(c *expect.Console) {
+				c.ExpectString("Username")
+				c.SendLine("username")
+			},
+			test: func(t *testing.T, i inputs) {
+				assert.Equal(t, "username", i.Username)
+			},
+		},
+		{
+			description: "Should prompt for password when not provided for local type",
+			inputs: inputs{
+				AuthType: authTypeLocal,
+				Username: "username",
+			},
+			prepareProfile: func(p *user.Profile) {},
+			procedure: func(c *expect.Console) {
+				c.ExpectString("Password")
+				c.SendLine("password")
+				c.ExpectEOF()
+			},
+			test: func(t *testing.T, i inputs) {
+				assert.Equal(t, "password", i.Password)
+			},
+		},
+		{
+			description:    "Should prompt for both username and password when not provided for local type",
+			inputs:         inputs{AuthType: authTypeLocal},
+			prepareProfile: func(p *user.Profile) {},
+			procedure: func(c *expect.Console) {
+				c.ExpectString("Username")
+				c.SendLine("username")
+				c.ExpectString("Password")
+				c.SendLine("password")
+				c.ExpectEOF()
+			},
+			test: func(t *testing.T, i inputs) {
+				assert.Equal(t, "username", i.Username)
+				assert.Equal(t, "password", i.Password)
+			},
+		},
+		{
+			description: "Should not prompt for inputs when flags provide the data for local type",
+			inputs: inputs{
+				AuthType: authTypeLocal,
+				Username: "username",
+				Password: "password",
+			},
+			prepareProfile: func(p *user.Profile) {},
+			procedure: func(c *expect.Console) {
+				// c.ExpectEOF()
+			},
+			test: func(t *testing.T, i inputs) {
+				assert.Equal(t, "username", i.Username)
+				assert.Equal(t, "password", i.Password)
+			},
+		},
+		{
+			description: "Should not prompt for inputs when profile provides the data for local type",
+			inputs:      inputs{AuthType: authTypeLocal},
+			prepareProfile: func(p *user.Profile) {
+				p.SetCredentials(user.Credentials{Username: "username", Password: "password"})
+			},
+			procedure: func(c *expect.Console) {
+				c.ExpectEOF()
+			},
+			test: func(t *testing.T, i inputs) {
+				assert.Equal(t, "username", i.Username)
+				assert.Equal(t, "password", i.Password)
 			},
 		},
 	} {

--- a/internal/commands/logout/command_test.go
+++ b/internal/commands/logout/command_test.go
@@ -24,22 +24,33 @@ func TestLogoutHandler(t *testing.T) {
 
 		profile := mock.NewProfile(t)
 
-		profile.SetCredentials(user.Credentials{"username", "password"})
-		profile.SetSession(user.Session{"accessToken", "refreshToken"})
+		existingCreds := user.Credentials{
+			PublicAPIKey:  "publicAPIKey",
+			PrivateAPIKey: "privateAPIKey",
+			Username:      "username",
+			Password:      "password",
+		}
+
+		existingSess := user.Session{"accessToken", "refreshToken"}
+
+		profile.SetCredentials(existingCreds)
+		profile.SetSession(existingSess)
 		assert.Nil(t, profile.Save())
 
 		creds := profile.Credentials()
 		session := profile.Session()
-		assert.Equal(t, user.Credentials{"username", "password"}, creds)
-		assert.Equal(t, user.Session{"accessToken", "refreshToken"}, session)
+		assert.Equal(t, existingCreds, creds)
+		assert.Equal(t, existingSess, session)
 
 		out, err := ioutil.ReadFile(profile.Path())
 		assert.Nil(t, err)
 		assert.True(t, strings.Contains(string(out), fmt.Sprintf(`%s:
   access_token: accessToken
-  private_api_key: password
-  public_api_key: username
+  password: password
+  private_api_key: privateAPIKey
+  public_api_key: publicAPIKey
   refresh_token: refreshToken
+  username: username
 `, profile.Name)), "profile must contain the expected contents")
 
 		_, ui := mock.NewUI()
@@ -55,9 +66,11 @@ func TestLogoutHandler(t *testing.T) {
 		assert.Nil(t, err)
 		assert.True(t, strings.Contains(string(out), fmt.Sprintf(`%s:
   access_token: ""
+  password: ""
   private_api_key: ""
   public_api_key: ""
   refresh_token: ""
+  username: ""
 `, profile.Name)), "profile must contain the expected contents")
 	})
 }

--- a/internal/commands/whoami/command.go
+++ b/internal/commands/whoami/command.go
@@ -25,19 +25,31 @@ type Command struct{}
 
 // Handler is the command handler
 func (cmd *Command) Handler(profile *user.Profile, ui terminal.UI, clients cli.Clients) error {
-	user := profile.Credentials()
-	session := profile.Session()
+	u := profile.Credentials()
+	sess := profile.Session()
 
-	if user.PrivateAPIKey == "" {
+	if u.PrivateAPIKey == "" && u.Password == "" {
 		ui.Print(terminal.NewTextLog("No user is currently logged in"))
 		return nil
 	}
 
-	if session.AccessToken == "" {
-		ui.Print(terminal.NewTextLog("The user, %s, is not currently logged in", user.PublicAPIKey))
+	userDisplay := u.PublicAPIKey
+	if userDisplay == "" {
+		userDisplay = u.Username
+	}
+
+	if sess.AccessToken == "" {
+		ui.Print(terminal.NewTextLog("The user, %s, is not currently logged in", userDisplay))
 		return nil
 	}
 
-	ui.Print(terminal.NewTextLog("Currently logged in user: %s (%s)", user.PublicAPIKey, user.RedactedPrivateAPIKey()))
+	var userSecret string
+	if u.PublicAPIKey == "" {
+		userSecret = u.RedactedPassword()
+	} else {
+		userSecret = u.RedactedPrivateAPIKey()
+	}
+
+	ui.Print(terminal.NewTextLog("Currently logged in user: %s (%s)", userDisplay, userSecret))
 	return nil
 }

--- a/internal/commands/whoami/command_test.go
+++ b/internal/commands/whoami/command_test.go
@@ -23,22 +23,41 @@ func TestWhoamiFeedback(t *testing.T) {
 				},
 			},
 			{
-				description: "with a user that has no active session",
+				description: "with a user that has no active session with cloud credentials",
 				setup: func(t *testing.T, profile *user.Profile) {
-					profile.SetCredentials(user.Credentials{"username", "my-super-secret-key"})
+					profile.SetCredentials(user.Credentials{PublicAPIKey: "apiKey", PrivateAPIKey: "my-super-secret-key"})
+				},
+				test: func(t *testing.T, output string) {
+					assert.Equal(t, "The user, apiKey, is not currently logged in\n", output)
+				},
+			},
+			{
+				description: "with a user fully logged in with cloud credentials",
+				setup: func(t *testing.T, profile *user.Profile) {
+					profile.SetCredentials(user.Credentials{PublicAPIKey: "apiKey", PrivateAPIKey: "my-super-secret-key"})
+					profile.SetSession(user.Session{"accessToken", "refreshToken"})
+				},
+				test: func(t *testing.T, output string) {
+					assert.Equal(t, "Currently logged in user: apiKey (**-*****-******-key)\n", output)
+				},
+			},
+			{
+				description: "with a user that has no active session with local credentials",
+				setup: func(t *testing.T, profile *user.Profile) {
+					profile.SetCredentials(user.Credentials{Username: "username", Password: "my-super-secret-pwd"})
 				},
 				test: func(t *testing.T, output string) {
 					assert.Equal(t, "The user, username, is not currently logged in\n", output)
 				},
 			},
 			{
-				description: "with a user fully logged in",
+				description: "with a user fully logged in with local credentials",
 				setup: func(t *testing.T, profile *user.Profile) {
-					profile.SetCredentials(user.Credentials{"username", "my-super-secret-key"})
+					profile.SetCredentials(user.Credentials{Username: "username", Password: "my-super-secret-pwd"})
 					profile.SetSession(user.Session{"accessToken", "refreshToken"})
 				},
 				test: func(t *testing.T, output string) {
-					assert.Equal(t, "Currently logged in user: username (**-*****-******-key)\n", output)
+					assert.Equal(t, "Currently logged in user: username (*******************)\n", output)
 				},
 			},
 		} {

--- a/internal/utils/test/mock/realm_client.go
+++ b/internal/utils/test/mock/realm_client.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"io"
 
+	"github.com/10gen/realm-cli/internal/cli/user"
 	"github.com/10gen/realm-cli/internal/cloud/realm"
 )
 
@@ -11,7 +12,7 @@ import (
 type RealmClient struct {
 	realm.Client
 
-	AuthenticateFn func(publicAPIKey, privateAPIKey string) (realm.Session, error)
+	AuthenticateFn func(authType string, creds user.Credentials) (realm.Session, error)
 	AuthProfileFn  func() (realm.AuthProfile, error)
 
 	DiffFn   func(groupID, appID string, appData interface{}) ([]string, error)
@@ -79,11 +80,11 @@ type RealmClient struct {
 // Authenticate calls the mocked Authenticate implementation if provided,
 // otherwise the call falls back to the underlying realm.Client implementation.
 // NOTE: this may panic if the underlying realm.Client is left undefined
-func (rc RealmClient) Authenticate(publicAPIKey, privateAPIKey string) (realm.Session, error) {
+func (rc RealmClient) Authenticate(authType string, creds user.Credentials) (realm.Session, error) {
 	if rc.AuthenticateFn != nil {
-		return rc.AuthenticateFn(publicAPIKey, privateAPIKey)
+		return rc.AuthenticateFn(authType, creds)
 	}
-	return rc.Client.Authenticate(publicAPIKey, privateAPIKey)
+	return rc.Client.Authenticate(authType, creds)
 }
 
 // AuthProfile calls the mocked AuthProfile implementation if provided,

--- a/internal/utils/test/test.go
+++ b/internal/utils/test/test.go
@@ -137,7 +137,10 @@ var SkipUnlessAtlasServerRunning = func() func(t *testing.T) {
 			MustSkipf(t, "Atlas server not running at %s", AtlasServerURL())
 			return
 		}
-		client := atlas.NewAuthClient(AtlasServerURL(), user.Credentials{CloudUsername(), CloudAPIKey()})
+		client := atlas.NewAuthClient(AtlasServerURL(), user.Credentials{
+			PublicAPIKey:  CloudUsername(),
+			PrivateAPIKey: CloudAPIKey(),
+		})
 		if err := client.Status(); err != nil {
 			atlasServerNotRunning = true
 			MustSkipf(t, "Atlas server not running at %s", AtlasServerURL())


### PR DESCRIPTION
Mentioned this in the JIRA, but this functionality was technically missed when going from `v1` to `v2`, see: https://github.com/10gen/realm-cli/blob/support/1.3.x/auth/auth.go

Not sure how far we should go to support these use cases of "self-contained Realm instances" when testing in CI/CD environments, but Nikola reached out asking me about this so it's safe to say we have at least one real use-case for all of this