### PR TITLE
REALMC-11637: Bump version to 2.3.4

### DIFF
--- a/.evg.yml
+++ b/.evg.yml
@@ -424,7 +424,6 @@ buildvariants:
     realm_server_url: "http://localhost:9090"
     yarn_url: "https://s3.amazonaws.com/stitch-artifacts/yarn/latest.tar.gz"
     node_version: 12.16.2
-    cli_version: 2.3.1
   tasks:
   - name: test_unit
   - name: test_with_cloud

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongodb-realm-cli",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "The MongoDB Realm Command Line Interface",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Including one drive-by fix to remove the unused `cli_version` field from our `.evg.yml` file here