### PR TITLE
REALMC-10889: Add truthy PreventAuth flag to refreshAuth request options

### DIFF
--- a/internal/cli/command_factory.go
+++ b/internal/cli/command_factory.go
@@ -123,7 +123,7 @@ func (factory *CommandFactory) Build(command CommandDefinition) *cobra.Command {
 			)
 
 			err := command.Command.Handler(factory.profile, factory.ui, Clients{
-				Realm:        realm.NewAuthClient(factory.profile.RealmBaseURL(), factory.profile), // TODO(REALMC-8185): make this accept factory.profile.Session()
+				Realm:        realm.NewAuthClient(factory.profile.RealmBaseURL(), factory.profile),
 				Atlas:        atlas.NewAuthClient(factory.profile.AtlasBaseURL(), factory.profile.Credentials()),
 				HostingAsset: http.DefaultClient,
 			})

--- a/internal/cloud/realm/auth.go
+++ b/internal/cloud/realm/auth.go
@@ -144,6 +144,7 @@ func (c *client) refreshAuth() error {
 	session := c.profile.Session()
 	session.AccessToken = s.AccessToken
 	c.profile.SetSession(session)
+	
 	return c.profile.Save()
 }
 

--- a/internal/cloud/realm/auth.go
+++ b/internal/cloud/realm/auth.go
@@ -144,7 +144,7 @@ func (c *client) refreshAuth() error {
 	session := c.profile.Session()
 	session.AccessToken = s.AccessToken
 	c.profile.SetSession(session)
-	
+
 	return c.profile.Save()
 }
 

--- a/internal/cloud/realm/auth.go
+++ b/internal/cloud/realm/auth.go
@@ -126,7 +126,7 @@ func (c *client) refreshAuth() error {
 	res, resErr := c.do(
 		http.MethodPost,
 		authSessionPath,
-		api.RequestOptions{RefreshAuth: true},
+		api.RequestOptions{RefreshAuth: true, PreventRefresh: true},
 	)
 	if resErr != nil {
 		return resErr

--- a/internal/cloud/realm/auth.go
+++ b/internal/cloud/realm/auth.go
@@ -144,7 +144,6 @@ func (c *client) refreshAuth() error {
 	session := c.profile.Session()
 	session.AccessToken = s.AccessToken
 	c.profile.SetSession(session)
-
 	return c.profile.Save()
 }
 

--- a/internal/cloud/realm/client.go
+++ b/internal/cloud/realm/client.go
@@ -145,7 +145,7 @@ func (c *client) do(method, path string, options api.RequestOptions) (*http.Resp
 	if resErr != nil {
 		return nil, resErr
 	}
-	
+
 	if res.StatusCode >= 200 && res.StatusCode <= 299 {
 		return res, nil
 	}

--- a/internal/cloud/realm/client.go
+++ b/internal/cloud/realm/client.go
@@ -145,7 +145,6 @@ func (c *client) do(method, path string, options api.RequestOptions) (*http.Resp
 	if resErr != nil {
 		return nil, resErr
 	}
-
 	if res.StatusCode >= 200 && res.StatusCode <= 299 {
 		return res, nil
 	}

--- a/internal/cloud/realm/client.go
+++ b/internal/cloud/realm/client.go
@@ -145,6 +145,7 @@ func (c *client) do(method, path string, options api.RequestOptions) (*http.Resp
 	if resErr != nil {
 		return nil, resErr
 	}
+	
 	if res.StatusCode >= 200 && res.StatusCode <= 299 {
 		return res, nil
 	}


### PR DESCRIPTION
[bug fix]: fixes auth loop bug that occurs when running cli commands that require client authentication (e.g. apps list, or apps create). JIRA ticket [here](https://jira.mongodb.org/browse/REALMC-10889)

Note: Currently returns only "invalid session", but a Suggestion bug is being addressed on [11700](https://github.com/10gen/realm-cli/pull/251)