### PR TITLE
Revert "REALMC-11543: Use nil map in test data source's schema and relationships"

### DIFF
--- a/internal/cloud/realm/import_export_test.go
+++ b/internal/cloud/realm/import_export_test.go
@@ -14,10 +14,6 @@ import (
 	"github.com/10gen/realm-cli/internal/utils/test/assert"
 )
 
-var (
-	nilMap map[string]interface{}
-)
-
 func TestRealmImportExportRoundTrip(t *testing.T) {
 	u.SkipUnlessRealmServerRunning(t)
 
@@ -322,8 +318,8 @@ func appDataV2(app realm.App) local.AppDataV2 {
 				Rules: []map[string]interface{}{{
 					"database":      "db",
 					"collection":    "coll",
-					"schema":        nilMap,
-					"relationships": nilMap,
+					"schema":        map[string]interface{}{},
+					"relationships": map[string]interface{}{},
 				}},
 			},
 		},


### PR DESCRIPTION
Reverts 10gen/realm-cli#245