### PR TITLE
REALMC-10362: Update CLI to import schemas separate from rules

### DIFF
--- a/internal/local/data.go
+++ b/internal/local/data.go
@@ -63,6 +63,7 @@ const (
 	NameIncomingWebhooks = "incoming_webhooks"
 	NameRules            = "rules"
 	NameSchema           = "schema"
+	NameSchemas          = "schemas"
 	NameServices         = "services"
 	NameRelationships    = "relationships"
 

--- a/internal/local/testdata/data_sources/data_sources/mongodb-atlas/foo/onlyRulesColl/rules.json
+++ b/internal/local/testdata/data_sources/data_sources/mongodb-atlas/foo/onlyRulesColl/rules.json
@@ -1,0 +1,4 @@
+{
+  "database": "foo",
+  "collection": "onlyRulesColl"
+}

--- a/internal/local/testdata/data_sources/data_sources/mongodb-atlas/foo/onlySchemasColl/relationships.json
+++ b/internal/local/testdata/data_sources/data_sources/mongodb-atlas/foo/onlySchemasColl/relationships.json
@@ -1,0 +1,12 @@
+{
+  "name": {
+    "ref": "#/relationship/mongodb-atlas/foo/onlySchemasColl",
+    "foreign_key": "country",
+    "is_list": false
+  },
+  "country": {
+    "ref": "#/relationship/mongodb-atlas/foo/onlySchemasColl",
+    "foreign_key": "name",
+    "is_list": false
+  }
+}

--- a/internal/local/testdata/data_sources/data_sources/mongodb-atlas/foo/onlySchemasColl/schema.json
+++ b/internal/local/testdata/data_sources/data_sources/mongodb-atlas/foo/onlySchemasColl/schema.json
@@ -1,0 +1,11 @@
+{
+  "title": "soloSchema",
+  "properties": {
+    "name": {
+      "bsonType": "string"
+    },
+    "country": {
+      "bsonType": "string"
+    }
+  }
+}


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/REALMC-10362

Essentially doing a similar thing to [this PR](https://github.com/10gen/baas/pull/5848). After this PR, pushing, pulling, and diffing an app should work in cases where:
* a collection folder (`data_sources/<data_source>/<database>/<collection>`) contains solely a `rules.json` file
* a collection folder contains solely a pair of `schema.json` and `relationships.json` files
This change was necessary because, as part of Schema Separation, an app is allowed to have a rule without an associated schema and vice versa