### PR TITLE
REALMC-12080: Change name of executable in outdated version warning to realm-cli

### DIFF
--- a/.evg.yml
+++ b/.evg.yml
@@ -281,18 +281,18 @@ tasks:
             export GOOS=linux
             export OSARCH=linux-amd64
             echo "Building realm-cli for $GOOS on $GOARCH"
-            REPLACE_VARS="-ldflags \"-X github.com/10gen/realm-cli/internal/cli.Version=$VERSION -X github.com/10gen/realm-cli/internal/cli.osArch=$OSARCH -X github.com/10gen/realm-cli/internal/telemetry.segmentWriteKey=$SEGMENT_WRITE_KEY\""
+            REPLACE_VARS="-ldflags \"-X github.com/10gen/realm-cli/internal/cli.Version=$VERSION -X github.com/10gen/realm-cli/internal/cli.OSArch=$OSARCH -X github.com/10gen/realm-cli/internal/telemetry.segmentWriteKey=$SEGMENT_WRITE_KEY\""
             eval go build $REPLACE_VARS -o realm-cli-linux-amd64 main.go
 
             export GOOS=darwin
             export OSARCH=macos-amd64
-            REPLACE_VARS="-ldflags \"-X github.com/10gen/realm-cli/internal/cli.Version=$VERSION -X github.com/10gen/realm-cli/internal/cli.osArch=$OSARCH -X github.com/10gen/realm-cli/internal/telemetry.segmentWriteKey=$SEGMENT_WRITE_KEY\""
+            REPLACE_VARS="-ldflags \"-X github.com/10gen/realm-cli/internal/cli.Version=$VERSION -X github.com/10gen/realm-cli/internal/cli.OSArch=$OSARCH -X github.com/10gen/realm-cli/internal/telemetry.segmentWriteKey=$SEGMENT_WRITE_KEY\""
             echo "Building realm-cli for $GOOS on $GOARCH"
             eval go build $REPLACE_VARS -o realm-cli-macos-amd64 main.go
 
             export GOOS=windows
             export OSARCH=windows-amd64
-            REPLACE_VARS="-ldflags \"-X github.com/10gen/realm-cli/internal/cli.Version=$VERSION -X github.com/10gen/realm-cli/internal/cli.osArch=$OSARCH -X github.com/10gen/realm-cli/internal/telemetry.segmentWriteKey=$SEGMENT_WRITE_KEY\""
+            REPLACE_VARS="-ldflags \"-X github.com/10gen/realm-cli/internal/cli.Version=$VERSION -X github.com/10gen/realm-cli/internal/cli.OSArch=$OSARCH -X github.com/10gen/realm-cli/internal/telemetry.segmentWriteKey=$SEGMENT_WRITE_KEY\""
             echo "Building realm-cli for $GOOS on $GOARCH"
             eval go build $REPLACE_VARS -o realm-cli-windows-amd64 main.go
       - command: s3.put

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ go build -ldflags "-X github.com/10gen/realm-cli/internal/cli.Version=0.0.0-loca
 
 This will create a CLI build that will print `0.0.0-local` when `--version` is invoked.  Other configurable build options include:
 
-* `-X github.com/10gen/realm-cli/internal/cli.osArch=macos-amd64`
+* `-X github.com/10gen/realm-cli/internal/cli.OSArch=macos-amd64`
 * `-X github.com/10gen/realm-cli/internal/telemetry.segmentWriteKey=${segment_write_key}`
 
 > NOTE: `${segment_write_key}` is a dynamic value you would need to replace with something valid.  If it is left blank, then events will simply not be sent to Segment.

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -220,7 +220,7 @@ func TestCLIVersionCheck(t *testing.T) {
 		{osArch: "macos-amd64"},
 		{"windows-amd64", ".exe"},
 	} {
-		t.Run(fmt.Sprintf("should display instrutions for installing latest cli when version is outdated for %s os", tc.osArch), func(t *testing.T) {
+		t.Run(fmt.Sprintf("should display instructions for installing latest cli when version is outdated for %s os", tc.osArch), func(t *testing.T) {
 			out := new(bytes.Buffer)
 
 			console, err := expect.NewConsole(expect.WithStdout(out))

--- a/internal/cli/command_factory.go
+++ b/internal/cli/command_factory.go
@@ -255,7 +255,7 @@ func (factory *CommandFactory) checkForNewVersion(client VersionManifestClient) 
 		terminal.NewFollowupLog(
 			"To install",
 			fmt.Sprintf("npm install -g mongodb-%s@v%s", Name, v.Semver),
-			fmt.Sprintf("curl -o ./mongodb-%s %s && chmod +x ./mongodb-%s", Name, v.URL, Name),
+			fmt.Sprintf("curl -o ./%s %s && chmod +x ./%s", Name, v.URL, Name),
 		),
 	)
 

--- a/internal/cli/command_factory_test.go
+++ b/internal/cli/command_factory_test.go
@@ -166,6 +166,6 @@ func (client mockVersionClient) Get(_ string) (*http.Response, error) {
 		Body: ioutil.NopCloser(strings.NewReader(fmt.Sprintf(`{
   "version": %q,
   "info": { %q: { "url": %q } }
-}`, version, osArch, url))),
+}`, version, OSArch, url))),
 	}, nil
 }

--- a/internal/cli/command_factory_test.go
+++ b/internal/cli/command_factory_test.go
@@ -106,7 +106,7 @@ func TestCommandFactoryVersionCheck(t *testing.T) {
 Note: This is the only time this alert will display today
 To install
   npm install -g mongodb-realm-cli@v0.1.0
-  curl -o ./mongodb-realm-cli http://somewhere.com && chmod +x ./mongodb-realm-cli
+  curl -o ./realm-cli http://somewhere.com && chmod +x ./realm-cli
 `, out.String())
 
 		assert.True(t, lastVersionCheck.Before(profile.LastVersionCheck()), "version check time should be updated")

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -17,8 +17,8 @@ var (
 	// Version represents the CLI version
 	Version = "0.0.0" // value will be injected at build-time
 
-	// osArch represents the CLI os architecture; used for locating the correct CLI URL
-	osArch string // value will be injected at build-time
+	// OSArch represents the CLI os architecture; used for locating the correct CLI URL
+	OSArch string // value will be injected at build-time
 )
 
 const (
@@ -70,9 +70,9 @@ func checkVersion(client VersionManifestClient) (buildInfo, error) {
 		return buildInfo{}, nil // version is up-to-date
 	}
 
-	osInfo, ok := manifest.Info[osArch]
+	osInfo, ok := manifest.Info[OSArch]
 	if !ok {
-		return buildInfo{}, fmt.Errorf("unrecognized CLI OS build: %s", osArch)
+		return buildInfo{}, fmt.Errorf("unrecognized CLI OS build: %s", OSArch)
 	}
 
 	return buildInfo{versionNext.String(), osInfo.URL}, nil

--- a/internal/cli/version_test.go
+++ b/internal/cli/version_test.go
@@ -13,9 +13,9 @@ import (
 )
 
 func TestVersionCheck(t *testing.T) {
-	origOSArch := osArch
-	osArch = "macos-amd64"
-	defer func() { osArch = origOSArch }()
+	origOSArch := OSArch
+	OSArch = "macos-amd64"
+	defer func() { OSArch = origOSArch }()
 
 	for _, tc := range []struct {
 		description     string
@@ -35,7 +35,7 @@ func TestVersionCheck(t *testing.T) {
 		},
 	} {
 		t.Run(tc.description, func(t *testing.T) {
-			client := testClient{http.StatusOK, tc.nextVersion, osArch, "http://whatever.com/test"}
+			client := testClient{http.StatusOK, tc.nextVersion, OSArch, "http://whatever.com/test"}
 
 			v, err := checkVersion(client)
 			assert.Nil(t, err)
@@ -80,7 +80,7 @@ func TestVersionCheck(t *testing.T) {
 		client := testClient{statusCode: http.StatusOK, version: "0.1.0", osArch: "some-other-arch"}
 
 		_, err := checkVersion(client)
-		assert.Equal(t, fmt.Errorf("unrecognized CLI OS build: %s", osArch), err)
+		assert.Equal(t, fmt.Errorf("unrecognized CLI OS build: %s", OSArch), err)
 	})
 }
 


### PR DESCRIPTION
Noticed this when testing out `npx` this morning:

```cmd
% npx mongodb-realm-cli whoami
New version (v2.3.5) of CLI available: https://s3.amazonaws.com/realm-clis/realm_cli_rhel70_c61061f62167023c81195fd09ba42bd5cdfade6e_22_03_02_20_09_42/macos-amd64/realm-cli
Note: This is the only time this alert will display today
To install
  npm install -g mongodb-realm-cli@v2.3.5
  curl -o ./mongodb-realm-cli https://s3.amazonaws.com/realm-clis/realm_cli_rhel70_c61061f62167023c81195fd09ba42bd5cdfade6e_22_03_02_20_09_42/macos-amd64/realm-cli && chmod +x ./mongodb-realm-cli
Currently logged in user: aoicacni (********-****-****-****-3e0f6e5e9dca)
```

I'm changing the `curl` output to reference the executable name `realm-cli`, rather than the (more verbose) npm package name `mongodb-realm-cli`... which would then align more with how we currently show UI snippets for sample commands

Also added a rather complex test to verify all this... I'm all ears if you think there may be simpler ways to go about this!