### PR TITLE
REALMC-11800: Use root directory to create app on nested push command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,13 +9,13 @@ require (
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/briandowns/spinner v1.12.0
 	github.com/edaniels/digest v0.0.0-20170923160545-b81e9c4ee11c
-	github.com/edaniels/golinters v0.0.3
+	github.com/edaniels/golinters v0.0.3 // indirect
 	github.com/fatih/color v1.10.0
-	github.com/golangci/golangci-lint v1.32.2
+	github.com/golangci/golangci-lint v1.32.2 // indirect
 	github.com/google/go-cmp v0.5.2
 	github.com/hinshun/vt10x v0.0.0-20180616224451-1954e6464174
 	github.com/iancoleman/orderedmap v0.1.0
-	github.com/kr/pretty v0.2.1
+	github.com/kr/pretty v0.2.1 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/segmentio/backo-go v0.0.0-20200129164019-23eae7c10bd3 // indirect
 	github.com/spf13/afero v1.1.2

--- a/internal/commands/app/init_inputs_test.go
+++ b/internal/commands/app/init_inputs_test.go
@@ -20,7 +20,7 @@ func TestAppInitInputsResolve(t *testing.T) {
 		defer teardown()
 
 		assert.Nil(t, ioutil.WriteFile(
-			filepath.Join(profile.WorkingDirectory, local.FileConfig.String()),
+			filepath.Join(profile.WorkingDirectory, local.FileRealmConfig.String()),
 			[]byte(fmt.Sprintf(`{"config_version": %d, "name":"eggcorn"}`, realm.DefaultAppConfigVersion)),
 			0666,
 		))

--- a/internal/commands/push/command.go
+++ b/internal/commands/push/command.go
@@ -169,7 +169,7 @@ func (cmd *Command) Handler(profile *user.Profile, ui terminal.UI, clients cli.C
 			return nil
 		}
 
-		newApp, proceed, err := createNewApp(ui, clients.Realm, cmd.inputs.LocalPath, appRemote.GroupID, app.AppData)
+		newApp, proceed, err := createNewApp(ui, clients.Realm, app.RootDir, appRemote.GroupID, app.AppData)
 		if err != nil {
 			return err
 		}

--- a/internal/commands/push/command.go
+++ b/internal/commands/push/command.go
@@ -392,6 +392,7 @@ type namer interface{ Name() string }
 type locationer interface{ Location() realm.Location }
 type deploymentModeler interface{ DeploymentModel() realm.DeploymentModel }
 type environmenter interface{ Environment() realm.Environment }
+type configVersioner interface{ ConfigVersion() realm.AppConfigVersion }
 
 func createNewApp(ui terminal.UI, realmClient realm.Client, appDirectory, groupID string, appData interface{}) (realm.App, bool, error) {
 	if proceed, err := ui.Confirm("Do you wish to create a new app?"); err != nil {
@@ -401,6 +402,7 @@ func createNewApp(ui terminal.UI, realmClient realm.Client, appDirectory, groupI
 	}
 
 	var name, location, deploymentModel, environment string
+	appConfigVersion := realm.DefaultAppConfigVersion
 	if appData != nil {
 		if n, ok := appData.(namer); ok {
 			name = n.Name()
@@ -416,6 +418,10 @@ func createNewApp(ui terminal.UI, realmClient realm.Client, appDirectory, groupI
 
 		if e, ok := appData.(environmenter); ok {
 			environment = e.Environment().String()
+		}
+
+		if cv, ok := appData.(configVersioner); ok {
+			appConfigVersion = cv.ConfigVersion()
 		}
 	}
 
@@ -475,7 +481,7 @@ func createNewApp(ui terminal.UI, realmClient realm.Client, appDirectory, groupI
 		return realm.App{}, false, err
 	}
 
-	if err := local.AsApp(appDirectory, app, realm.DefaultAppConfigVersion).WriteConfig(); err != nil {
+	if err := local.AsApp(appDirectory, app, appConfigVersion).WriteConfig(); err != nil {
 		return realm.App{}, false, err
 	}
 	return app, true, nil

--- a/internal/commands/push/command_test.go
+++ b/internal/commands/push/command_test.go
@@ -1035,11 +1035,11 @@ Try instead: realm-cli push --local testdata/dependencies --remote appID --inclu
 		}
 		realmClient.CreateAppFn = func(groupID, name string, meta realm.AppMeta) (realm.App, error) {
 			return realm.App{
-				GroupID: groupID,
+				GroupID:     groupID,
 				ClientAppID: "eggcorn-abcde",
-				ID:      primitive.NewObjectID().Hex(),
-				Name:    name,
-				AppMeta: meta,
+				ID:          primitive.NewObjectID().Hex(),
+				Name:        name,
+				AppMeta:     meta,
 			}, nil
 		}
 		realmClient.DiffFn = func(groupID, appID string, appData interface{}) ([]string, error) {

--- a/internal/commands/push/command_test.go
+++ b/internal/commands/push/command_test.go
@@ -1036,6 +1036,7 @@ Try instead: realm-cli push --local testdata/dependencies --remote appID --inclu
 		realmClient.CreateAppFn = func(groupID, name string, meta realm.AppMeta) (realm.App, error) {
 			return realm.App{
 				GroupID: groupID,
+				ClientAppID: "eggcorn-abcde",
 				ID:      primitive.NewObjectID().Hex(),
 				Name:    name,
 				AppMeta: meta,
@@ -1058,6 +1059,7 @@ Try instead: realm-cli push --local testdata/dependencies --remote appID --inclu
 		assert.Nil(t, readErr)
 		assert.Equal(t, `{
     "config_version": 20210101,
+    "app_id": "eggcorn-abcde",
     "name": "eggcorn",
     "location": "US-VA",
     "deployment_model": "GLOBAL"

--- a/internal/commands/push/command_test.go
+++ b/internal/commands/push/command_test.go
@@ -1066,7 +1066,7 @@ Try instead: realm-cli push --local testdata/dependencies --remote appID --inclu
 
 		// Verify that a config file was not created in the nested directory, either.
 		_, fileErr := os.Stat(filepath.Join(testApp.RootDir, "functions", local.FileRealmConfig.String()))
-		assert.NotNil(t, fileErr)
+		assert.True(t, os.IsNotExist(fileErr), "expected nested config path to not exist, but fileErr was: %s", fileErr)
 	})
 }
 

--- a/internal/commands/push/command_test.go
+++ b/internal/commands/push/command_test.go
@@ -1127,7 +1127,7 @@ func TestPushHandlerCreateNewApp(t *testing.T) {
 `,
 		},
 	} {
-		t.Run(fmt.Sprintf("with a %s config file", tc.appConfig.String()), func(t *testing.T) {
+		t.Run(fmt.Sprintf("with a %s config file and nested local path", tc.appConfig.String()), func(t *testing.T) {
 			tmpDir, teardown, tmpDirErr := u.NewTempDir("push_handler")
 			assert.Nil(t, tmpDirErr)
 			defer teardown()
@@ -1148,6 +1148,9 @@ func TestPushHandlerCreateNewApp(t *testing.T) {
 			configData, readErr := ioutil.ReadFile(filepath.Join(tmpDir, tc.appConfig.String()))
 			assert.Nil(t, readErr)
 			assert.Equal(t, tc.expectedConfig, string(configData))
+
+			_, fileErr := os.Stat(filepath.Join(tmpDir, "nested", tc.appConfig.String()))
+			assert.True(t, os.IsNotExist(fileErr), "expected nested config path to not exist, but err was: %s", err)
 		})
 	}
 }

--- a/internal/commands/push/command_test.go
+++ b/internal/commands/push/command_test.go
@@ -1050,35 +1050,22 @@ func TestPushHandlerUseCreateNewApp(t *testing.T) {
 		return []string{}, nil
 	}
 
-	t.Run("with a realm_config.json", func(t *testing.T) {
-		tmpDir, teardown, tmpDirErr := u.NewTempDir("push_handler")
-		assert.Nil(t, tmpDirErr)
-		defer teardown()
-
-		app := local.App{RootDir: tmpDir, Config: local.FileRealmConfig, AppData: &local.AppRealmConfigJSON{local.AppDataV2{local.AppStructureV2{
-			ConfigVersion:   realm.AppConfigVersion20210101,
-			Name:            "eggcorn",
-			Location:        realm.Location("location"),
-			DeploymentModel: realm.DeploymentModel("deployment_model"),
-			Environment:     realm.Environment("environment"),
-		}}}}
-
-		app.WriteConfig()
-
-		out := new(bytes.Buffer)
-		console, ui, consoleErr := mock.NewConsoleWithOptions(mock.UIOptions{AutoConfirm: true}, out)
-		assert.Nil(t, consoleErr)
-		defer console.Close()
-
-		// Run handler method on both root directory and nested directory.
-		for _, localPath := range []string{tmpDir, filepath.Join(tmpDir, "nested_directory")} {
-			cmd := &Command{inputs{LocalPath: localPath, RemoteApp: "appID"}}
-			err := cmd.Handler(nil, ui, cli.Clients{Realm: realmClient})
-
-			assert.Nil(t, err)
-			configData, readErr := ioutil.ReadFile(filepath.Join(tmpDir, local.FileRealmConfig.String()))
-			assert.Nil(t, readErr)
-			assert.Equal(t, `{
+	for _, tc := range []struct {
+		description    string
+		appConfig      local.File
+		appData        local.AppData
+		expectedConfig string
+	}{
+		{
+			appConfig: local.FileRealmConfig,
+			appData: &local.AppRealmConfigJSON{local.AppDataV2{local.AppStructureV2{
+				ConfigVersion:   realm.AppConfigVersion20210101,
+				Name:            "eggcorn",
+				Location:        realm.Location("location"),
+				DeploymentModel: realm.DeploymentModel("deployment_model"),
+				Environment:     realm.Environment("environment"),
+			}}},
+			expectedConfig: `{
     "config_version": 20210101,
     "app_id": "eggcorn-abcde",
     "name": "eggcorn",
@@ -1086,40 +1073,18 @@ func TestPushHandlerUseCreateNewApp(t *testing.T) {
     "deployment_model": "deployment_model",
     "environment": "environment"
 }
-`, string(configData))
-		}
-	})
-
-	t.Run("with a config.json", func(t *testing.T) {
-		tmpDir, teardown, tmpDirErr := u.NewTempDir("push_handler")
-		assert.Nil(t, tmpDirErr)
-		defer teardown()
-
-		app := local.App{RootDir: tmpDir, Config: local.FileConfig, AppData: &local.AppConfigJSON{local.AppDataV1{local.AppStructureV1{
-			ConfigVersion:   realm.AppConfigVersion20200603,
-			Name:            "eggcorn",
-			Location:        realm.Location("location"),
-			DeploymentModel: realm.DeploymentModel("deployment_model"),
-			Environment:     realm.Environment("environment"),
-		}}}}
-
-		app.WriteConfig()
-
-		out := new(bytes.Buffer)
-		console, ui, consoleErr := mock.NewConsoleWithOptions(mock.UIOptions{AutoConfirm: true}, out)
-		assert.Nil(t, consoleErr)
-		defer console.Close()
-
-		// Run handler method on both root directory and nested directory.
-		for _, localPath := range []string{tmpDir, filepath.Join(tmpDir, "nested_directory")} {
-			cmd := &Command{inputs{LocalPath: localPath, RemoteApp: "appID"}}
-			err := cmd.Handler(nil, ui, cli.Clients{Realm: realmClient})
-
-			assert.Nil(t, err)
-			configData, readErr := ioutil.ReadFile(filepath.Join(tmpDir, local.FileConfig.String()))
-			fmt.Println(tmpDir)
-			assert.Nil(t, readErr)
-			assert.Equal(t, `{
+`,
+		},
+		{
+			appConfig: local.FileConfig,
+			appData: &local.AppConfigJSON{local.AppDataV1{local.AppStructureV1{
+				ConfigVersion:   realm.AppConfigVersion20200603,
+				Name:            "eggcorn",
+				Location:        realm.Location("location"),
+				DeploymentModel: realm.DeploymentModel("deployment_model"),
+				Environment:     realm.Environment("environment"),
+			}}},
+			expectedConfig: `{
     "config_version": 20200603,
     "app_id": "eggcorn-abcde",
     "name": "eggcorn",
@@ -1134,40 +1099,18 @@ func TestPushHandlerUseCreateNewApp(t *testing.T) {
         "development_mode_enabled": false
     }
 }
-`, string(configData))
-		}
-	})
-
-	t.Run("with a stitch.json", func(t *testing.T) {
-		tmpDir, teardown, tmpDirErr := u.NewTempDir("push_handler")
-		assert.Nil(t, tmpDirErr)
-		defer teardown()
-
-		app := local.App{RootDir: tmpDir, Config: local.FileStitch, AppData: &local.AppConfigJSON{local.AppDataV1{local.AppStructureV1{
-			ConfigVersion:   realm.AppConfigVersion20180301,
-			Name:            "eggcorn",
-			Location:        realm.Location("location"),
-			DeploymentModel: realm.DeploymentModel("deployment_model"),
-			Environment:     realm.Environment("environment"),
-		}}}}
-
-		app.WriteConfig()
-
-		out := new(bytes.Buffer)
-		console, ui, consoleErr := mock.NewConsoleWithOptions(mock.UIOptions{AutoConfirm: true}, out)
-		assert.Nil(t, consoleErr)
-		defer console.Close()
-
-		// Run handler method on both root directory and nested directory.
-		for _, localPath := range []string{tmpDir, filepath.Join(tmpDir, "nested_directory")} {
-			cmd := &Command{inputs{LocalPath: localPath, RemoteApp: "appID"}}
-			err := cmd.Handler(nil, ui, cli.Clients{Realm: realmClient})
-
-			assert.Nil(t, err)
-			configData, readErr := ioutil.ReadFile(filepath.Join(tmpDir, local.FileStitch.String()))
-			fmt.Println(tmpDir)
-			assert.Nil(t, readErr)
-			assert.Equal(t, `{
+`,
+		},
+		{
+			appConfig: local.FileStitch,
+			appData: &local.AppConfigJSON{local.AppDataV1{local.AppStructureV1{
+				ConfigVersion:   realm.AppConfigVersion20180301,
+				Name:            "eggcorn",
+				Location:        realm.Location("location"),
+				DeploymentModel: realm.DeploymentModel("deployment_model"),
+				Environment:     realm.Environment("environment"),
+			}}},
+			expectedConfig: `{
     "config_version": 20180301,
     "app_id": "eggcorn-abcde",
     "name": "eggcorn",
@@ -1182,9 +1125,32 @@ func TestPushHandlerUseCreateNewApp(t *testing.T) {
         "development_mode_enabled": false
     }
 }
-`, string(configData))
-		}
-	})
+`,
+		},
+	} {
+		t.Run(fmt.Sprintf("with a %s config file", tc.appConfig.String()), func(t *testing.T) {
+			tmpDir, teardown, tmpDirErr := u.NewTempDir("push_handler")
+			assert.Nil(t, tmpDirErr)
+			defer teardown()
+
+			app := local.App{RootDir: tmpDir, Config: tc.appConfig, AppData: tc.appData}
+
+			app.WriteConfig()
+
+			out := new(bytes.Buffer)
+			console, ui, consoleErr := mock.NewConsoleWithOptions(mock.UIOptions{AutoConfirm: true}, out)
+			assert.Nil(t, consoleErr)
+			defer console.Close()
+
+			cmd := &Command{inputs{LocalPath: tmpDir, RemoteApp: "appID"}}
+			err := cmd.Handler(nil, ui, cli.Clients{Realm: realmClient})
+
+			assert.Nil(t, err)
+			configData, readErr := ioutil.ReadFile(filepath.Join(tmpDir, tc.appConfig.String()))
+			assert.Nil(t, readErr)
+			assert.Equal(t, tc.expectedConfig, string(configData))
+		})
+	}
 }
 
 func TestPushCommandCreateNewApp(t *testing.T) {
@@ -1348,21 +1314,6 @@ func TestPushCommandCreateNewApp(t *testing.T) {
 					description:       "should use the package name when present and zero values for app meta",
 					appData:           local.AppConfigJSON{local.AppDataV1{local.AppStructureV1{ConfigVersion: realm.AppConfigVersion20200603, Name: "name"}}},
 					expectedAppConfig: local.FileConfig,
-				},
-				{
-					description:       "should use realm_config when config version is not specified in appData",
-					appData:           &local.AppConfigJSON{local.AppDataV1{local.AppStructureV1{Name: "name"}}},
-					expectedAppConfig: local.FileRealmConfig,
-				},
-				{
-					description:       "should downgrade to stitch config when specified in appData",
-					appData:           local.AppRealmConfigJSON{local.AppDataV2{local.AppStructureV2{ConfigVersion: realm.AppConfigVersion20180301, Name: "name"}}},
-					expectedAppConfig: local.FileStitch,
-				},
-				{
-					description:       "should upgrade to realm config when specified in appData",
-					appData:           local.AppConfigJSON{local.AppDataV1{local.AppStructureV1{ConfigVersion: realm.AppConfigVersion20210101, Name: "name"}}},
-					expectedAppConfig: local.FileRealmConfig,
 				},
 				{
 					description: "should use the package name location deployment model and environment when present",

--- a/internal/commands/push/command_test.go
+++ b/internal/commands/push/command_test.go
@@ -1051,7 +1051,6 @@ func TestPushHandlerCreateNewApp(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
-		description    string
 		appConfig      local.File
 		appData        local.AppData
 		expectedConfig string

--- a/internal/commands/push/command_test.go
+++ b/internal/commands/push/command_test.go
@@ -1027,48 +1027,163 @@ Try instead: realm-cli push --local testdata/dependencies --remote appID --inclu
 
 		assert.Nil(t, err)
 	})
+}
 
-	t.Run("with local path in nested directory", func(t *testing.T) {
-		var realmClient mock.RealmClient
-		realmClient.FindAppsFn = func(filter realm.AppFilter) ([]realm.App, error) {
-			return []realm.App{{GroupID: "groupID"}}, nil
-		}
-		realmClient.CreateAppFn = func(groupID, name string, meta realm.AppMeta) (realm.App, error) {
-			return realm.App{
-				GroupID:     groupID,
-				ClientAppID: "eggcorn-abcde",
-				ID:          primitive.NewObjectID().Hex(),
-				Name:        name,
-				AppMeta:     meta,
-			}, nil
-		}
-		realmClient.DiffFn = func(groupID, appID string, appData interface{}) ([]string, error) {
-			return []string{}, nil
-		}
+func TestPushHandlerUseCreateNewApp(t *testing.T) {
+	groupID := "groupID"
+	appID := "eggcorn-abcde"
+
+	realmClient := mock.RealmClient{}
+	realmClient.FindAppsFn = func(filter realm.AppFilter) ([]realm.App, error) {
+		return []realm.App{{GroupID: groupID, ClientAppID: appID}}, nil
+	}
+	realmClient.CreateAppFn = func(groupID, name string, meta realm.AppMeta) (realm.App, error) {
+		return realm.App{
+			GroupID:     groupID,
+			ClientAppID: "eggcorn-abcde",
+			ID:          appID,
+			Name:        name,
+			AppMeta:     meta,
+		}, nil
+	}
+	realmClient.DiffFn = func(groupID, appID string, appData interface{}) ([]string, error) {
+		return []string{}, nil
+	}
+
+	t.Run("with a realm_config.json", func(t *testing.T) {
+		tmpDir, teardown, tmpDirErr := u.NewTempDir("push_handler")
+		assert.Nil(t, tmpDirErr)
+		defer teardown()
+
+		app := local.App{RootDir: tmpDir, Config: local.FileRealmConfig, AppData: &local.AppRealmConfigJSON{local.AppDataV2{local.AppStructureV2{
+			ConfigVersion:   realm.AppConfigVersion20210101,
+			Name:            "eggcorn",
+			Location:        realm.Location("location"),
+			DeploymentModel: realm.DeploymentModel("deployment_model"),
+			Environment:     realm.Environment("environment"),
+		}}}}
+
+		app.WriteConfig()
 
 		out := new(bytes.Buffer)
-		ui := mock.NewUIWithOptions(mock.UIOptions{AutoConfirm: true}, out)
+		console, ui, consoleErr := mock.NewConsoleWithOptions(mock.UIOptions{AutoConfirm: true}, out)
+		assert.Nil(t, consoleErr)
+		defer console.Close()
 
-		cmd := &Command{inputs{LocalPath: filepath.Join(testApp.RootDir, "functions"), RemoteApp: "appID"}}
-		err := cmd.Handler(nil, ui, cli.Clients{Realm: realmClient})
-		defer os.Remove(filepath.Join(testApp.RootDir, local.FileRealmConfig.String()))
+		// Run handler method on both root directory and nested directory.
+		for _, localPath := range []string{tmpDir, filepath.Join(tmpDir, "nested_directory")} {
+			cmd := &Command{inputs{LocalPath: localPath, RemoteApp: "appID"}}
+			err := cmd.Handler(nil, ui, cli.Clients{Realm: realmClient})
 
-		assert.Nil(t, err)
-		configData, readErr := ioutil.ReadFile(filepath.Join(testApp.RootDir, local.FileRealmConfig.String()))
-
-		assert.Nil(t, readErr)
-		assert.Equal(t, `{
+			assert.Nil(t, err)
+			configData, readErr := ioutil.ReadFile(filepath.Join(tmpDir, local.FileRealmConfig.String()))
+			assert.Nil(t, readErr)
+			assert.Equal(t, `{
     "config_version": 20210101,
     "app_id": "eggcorn-abcde",
     "name": "eggcorn",
-    "location": "US-VA",
-    "deployment_model": "GLOBAL"
+    "location": "location",
+    "deployment_model": "deployment_model",
+    "environment": "environment"
 }
 `, string(configData))
+		}
+	})
 
-		// Verify that a config file was not created in the nested directory, either.
-		_, fileErr := os.Stat(filepath.Join(testApp.RootDir, "functions", local.FileRealmConfig.String()))
-		assert.True(t, os.IsNotExist(fileErr), "expected nested config path to not exist, but fileErr was: %s", fileErr)
+	t.Run("with a config.json", func(t *testing.T) {
+		tmpDir, teardown, tmpDirErr := u.NewTempDir("push_handler")
+		assert.Nil(t, tmpDirErr)
+		defer teardown()
+
+		app := local.App{RootDir: tmpDir, Config: local.FileConfig, AppData: &local.AppConfigJSON{local.AppDataV1{local.AppStructureV1{
+			ConfigVersion:   realm.AppConfigVersion20200603,
+			Name:            "eggcorn",
+			Location:        realm.Location("location"),
+			DeploymentModel: realm.DeploymentModel("deployment_model"),
+			Environment:     realm.Environment("environment"),
+		}}}}
+
+		app.WriteConfig()
+
+		out := new(bytes.Buffer)
+		console, ui, consoleErr := mock.NewConsoleWithOptions(mock.UIOptions{AutoConfirm: true}, out)
+		assert.Nil(t, consoleErr)
+		defer console.Close()
+
+		// Run handler method on both root directory and nested directory.
+		for _, localPath := range []string{tmpDir, filepath.Join(tmpDir, "nested_directory")} {
+			cmd := &Command{inputs{LocalPath: localPath, RemoteApp: "appID"}}
+			err := cmd.Handler(nil, ui, cli.Clients{Realm: realmClient})
+
+			assert.Nil(t, err)
+			configData, readErr := ioutil.ReadFile(filepath.Join(tmpDir, local.FileConfig.String()))
+			fmt.Println(tmpDir)
+			assert.Nil(t, readErr)
+			assert.Equal(t, `{
+    "config_version": 20200603,
+    "app_id": "eggcorn-abcde",
+    "name": "eggcorn",
+    "location": "location",
+    "deployment_model": "deployment_model",
+    "environment": "environment",
+    "security": null,
+    "custom_user_data_config": {
+        "enabled": false
+    },
+    "sync": {
+        "development_mode_enabled": false
+    }
+}
+`, string(configData))
+		}
+	})
+
+	t.Run("with a stitch.json", func(t *testing.T) {
+		tmpDir, teardown, tmpDirErr := u.NewTempDir("push_handler")
+		assert.Nil(t, tmpDirErr)
+		defer teardown()
+
+		app := local.App{RootDir: tmpDir, Config: local.FileStitch, AppData: &local.AppConfigJSON{local.AppDataV1{local.AppStructureV1{
+			ConfigVersion:   realm.AppConfigVersion20180301,
+			Name:            "eggcorn",
+			Location:        realm.Location("location"),
+			DeploymentModel: realm.DeploymentModel("deployment_model"),
+			Environment:     realm.Environment("environment"),
+		}}}}
+
+		app.WriteConfig()
+
+		out := new(bytes.Buffer)
+		console, ui, consoleErr := mock.NewConsoleWithOptions(mock.UIOptions{AutoConfirm: true}, out)
+		assert.Nil(t, consoleErr)
+		defer console.Close()
+
+		// Run handler method on both root directory and nested directory.
+		for _, localPath := range []string{tmpDir, filepath.Join(tmpDir, "nested_directory")} {
+			cmd := &Command{inputs{LocalPath: localPath, RemoteApp: "appID"}}
+			err := cmd.Handler(nil, ui, cli.Clients{Realm: realmClient})
+
+			assert.Nil(t, err)
+			configData, readErr := ioutil.ReadFile(filepath.Join(tmpDir, local.FileStitch.String()))
+			fmt.Println(tmpDir)
+			assert.Nil(t, readErr)
+			assert.Equal(t, `{
+    "config_version": 20180301,
+    "app_id": "eggcorn-abcde",
+    "name": "eggcorn",
+    "location": "location",
+    "deployment_model": "deployment_model",
+    "environment": "environment",
+    "security": null,
+    "custom_user_data_config": {
+        "enabled": false
+    },
+    "sync": {
+        "development_mode_enabled": false
+    }
+}
+`, string(configData))
+		}
 	})
 }
 
@@ -1077,6 +1192,7 @@ func TestPushCommandCreateNewApp(t *testing.T) {
 	appID := primitive.NewObjectID().Hex()
 
 	fullPkg := &local.AppConfigJSON{local.AppDataV1{local.AppStructureV1{
+		ConfigVersion:   realm.AppConfigVersion20200603,
 		Name:            "name",
 		Location:        realm.Location("location"),
 		DeploymentModel: realm.DeploymentModel("deployment_model"),
@@ -1223,13 +1339,30 @@ func TestPushCommandCreateNewApp(t *testing.T) {
 			ui := mock.NewUIWithOptions(mock.UIOptions{AutoConfirm: true}, out)
 
 			for _, tc := range []struct {
-				description     string
-				appData         interface{}
-				expectedAppMeta realm.AppMeta
+				description       string
+				appData           interface{}
+				expectedAppMeta   realm.AppMeta
+				expectedAppConfig local.File
 			}{
 				{
-					description: "should use the package name when present and zero values for app meta",
-					appData:     local.AppConfigJSON{local.AppDataV1{local.AppStructureV1{Name: "name"}}},
+					description:       "should use the package name when present and zero values for app meta",
+					appData:           local.AppConfigJSON{local.AppDataV1{local.AppStructureV1{ConfigVersion: realm.AppConfigVersion20200603, Name: "name"}}},
+					expectedAppConfig: local.FileConfig,
+				},
+				{
+					description:       "should use realm_config when config version is not specified in appData",
+					appData:           &local.AppConfigJSON{local.AppDataV1{local.AppStructureV1{Name: "name"}}},
+					expectedAppConfig: local.FileRealmConfig,
+				},
+				{
+					description:       "should downgrade to stitch config when specified in appData",
+					appData:           local.AppRealmConfigJSON{local.AppDataV2{local.AppStructureV2{ConfigVersion: realm.AppConfigVersion20180301, Name: "name"}}},
+					expectedAppConfig: local.FileStitch,
+				},
+				{
+					description:       "should upgrade to realm config when specified in appData",
+					appData:           local.AppConfigJSON{local.AppDataV1{local.AppStructureV1{ConfigVersion: realm.AppConfigVersion20210101, Name: "name"}}},
+					expectedAppConfig: local.FileRealmConfig,
 				},
 				{
 					description: "should use the package name location deployment model and environment when present",
@@ -1239,6 +1372,7 @@ func TestPushCommandCreateNewApp(t *testing.T) {
 						DeploymentModel: realm.DeploymentModel("deployment_model"),
 						Environment:     realm.Environment("environment"),
 					},
+					expectedAppConfig: local.FileConfig,
 				},
 			} {
 				t.Run(tc.description, func(t *testing.T) {
@@ -1257,6 +1391,9 @@ func TestPushCommandCreateNewApp(t *testing.T) {
 					assert.Nil(t, err)
 					assert.True(t, proceed, "should proceed")
 					assert.Equal(t, expectedApp, app)
+
+					_, fileErr := os.Stat(filepath.Join(tmpDir, tc.expectedAppConfig.String()))
+					assert.Nil(t, fileErr)
 				})
 			}
 		})

--- a/internal/commands/push/command_test.go
+++ b/internal/commands/push/command_test.go
@@ -1029,7 +1029,7 @@ Try instead: realm-cli push --local testdata/dependencies --remote appID --inclu
 	})
 }
 
-func TestPushHandlerUseCreateNewApp(t *testing.T) {
+func TestPushHandlerCreateNewApp(t *testing.T) {
 	groupID := "groupID"
 	appID := "eggcorn-abcde"
 
@@ -1142,7 +1142,7 @@ func TestPushHandlerUseCreateNewApp(t *testing.T) {
 			assert.Nil(t, consoleErr)
 			defer console.Close()
 
-			cmd := &Command{inputs{LocalPath: tmpDir, RemoteApp: "appID"}}
+			cmd := &Command{inputs{LocalPath: filepath.Join(tmpDir, "nested"), RemoteApp: "appID"}}
 			err := cmd.Handler(nil, ui, cli.Clients{Realm: realmClient})
 
 			assert.Nil(t, err)

--- a/internal/commands/push/inputs_test.go
+++ b/internal/commands/push/inputs_test.go
@@ -71,7 +71,7 @@ func TestPushInputsResolve(t *testing.T) {
 		defer teardown()
 
 		assert.Nil(t, ioutil.WriteFile(
-			filepath.Join(profile.WorkingDirectory, local.FileConfig.String()),
+			filepath.Join(profile.WorkingDirectory, local.FileRealmConfig.String()),
 			[]byte(fmt.Sprintf(`{"config_version": %d, "app_id": "eggcorn-abcde", "name":"eggcorn"}`, realm.DefaultAppConfigVersion)),
 			0666,
 		))

--- a/internal/local/app.go
+++ b/internal/local/app.go
@@ -49,7 +49,6 @@ func (a App) Option() string {
 	return a.AppData.Name()
 }
 
-// hasValidConfigVersion returns whether or not the config file and version number match
 func (a App) hasValidConfigVersion() bool {
 	switch a.ConfigVersion() {
 	case realm.AppConfigVersion20180301:

--- a/internal/local/app.go
+++ b/internal/local/app.go
@@ -65,6 +65,7 @@ func NewApp(rootDir, clientAppID, name string, location realm.Location, deployme
 // AsApp converts the realm.App into a local app
 func AsApp(rootDir string, app realm.App, configVersion realm.AppConfigVersion) App {
 	var appData AppData
+	var config File
 	switch configVersion {
 	case realm.AppConfigVersion20180301:
 		appData = &AppStitchJSON{AppDataV1{AppStructureV1{
@@ -99,6 +100,7 @@ func AsApp(rootDir string, app realm.App, configVersion realm.AppConfigVersion) 
 				},
 			},
 		}}}
+		config = FileStitch
 	case realm.AppConfigVersion20200603:
 		appData = &AppConfigJSON{AppDataV1{AppStructureV1{
 			ConfigVersion:        configVersion,
@@ -132,6 +134,7 @@ func AsApp(rootDir string, app realm.App, configVersion realm.AppConfigVersion) 
 				},
 			},
 		}}}
+		config = FileConfig
 	default:
 		appData = &AppRealmConfigJSON{AppDataV2{AppStructureV2{
 			ConfigVersion:   configVersion,
@@ -173,10 +176,11 @@ func AsApp(rootDir string, app realm.App, configVersion realm.AppConfigVersion) 
 				CustomResolvers: []map[string]interface{}{},
 			},
 		}}}
+		config = FileRealmConfig
 	}
 	return App{
 		RootDir: rootDir,
-		Config:  FileRealmConfig,
+		Config:  config,
 		AppData: appData,
 	}
 }

--- a/internal/local/app.go
+++ b/internal/local/app.go
@@ -49,6 +49,20 @@ func (a App) Option() string {
 	return a.AppData.Name()
 }
 
+// HasValidConfigVersion returns whether or not the config file and version number match
+func (a App) HasValidConfigVersion() bool {
+	switch a.ConfigVersion() {
+	case realm.AppConfigVersion20180301:
+		return a.Config == FileStitch
+	case realm.AppConfigVersion20200603:
+		return a.Config == FileConfig
+	case realm.AppConfigVersion20210101:
+		return a.Config == FileRealmConfig
+	default:
+		return false
+	}
+}
+
 // NewApp returns a new local app
 func NewApp(rootDir, clientAppID, name string, location realm.Location, deploymentModel realm.DeploymentModel, environment realm.Environment, configVersion realm.AppConfigVersion) App {
 	return AsApp(rootDir, realm.App{
@@ -280,7 +294,7 @@ func FindApp(path string) (App, bool, error) {
 			}
 
 			// if no config version is found then continue searching for the app's root directory config
-			if app.ConfigVersion() == 0 {
+			if app.ConfigVersion() == 0 || !app.HasValidConfigVersion() {
 				continue
 			}
 			return app, true, nil

--- a/internal/local/app.go
+++ b/internal/local/app.go
@@ -49,8 +49,8 @@ func (a App) Option() string {
 	return a.AppData.Name()
 }
 
-// HasValidConfigVersion returns whether or not the config file and version number match
-func (a App) HasValidConfigVersion() bool {
+// hasValidConfigVersion returns whether or not the config file and version number match
+func (a App) hasValidConfigVersion() bool {
 	switch a.ConfigVersion() {
 	case realm.AppConfigVersion20180301:
 		return a.Config == FileStitch
@@ -294,7 +294,7 @@ func FindApp(path string) (App, bool, error) {
 			}
 
 			// if no config version is found then continue searching for the app's root directory config
-			if app.ConfigVersion() == 0 || !app.HasValidConfigVersion() {
+			if app.ConfigVersion() == 0 || !app.hasValidConfigVersion() {
 				continue
 			}
 			return app, true, nil

--- a/internal/local/app_test.go
+++ b/internal/local/app_test.go
@@ -205,7 +205,7 @@ func TestFindApp(t *testing.T) {
 				assert.Nil(t, err)
 				assert.False(t, foundApp, "should not be found")
 			})
-			
+
 			t.Run("and a mismatched version in the config file should fail to find app", func(t *testing.T) {
 				path := filepath.Join(testRoot, "mismatch_version")
 				_, foundApp, err := FindApp(path)

--- a/internal/local/app_test.go
+++ b/internal/local/app_test.go
@@ -205,6 +205,13 @@ func TestFindApp(t *testing.T) {
 				assert.Nil(t, err)
 				assert.False(t, foundApp, "should not be found")
 			})
+			
+			t.Run("and a mismatched version in the config file should fail to find app", func(t *testing.T) {
+				path := filepath.Join(testRoot, "mismatch_version")
+				_, foundApp, err := FindApp(path)
+				assert.Nil(t, err)
+				assert.False(t, foundApp, "should not be found")
+			})
 		})
 	}
 }

--- a/internal/local/app_test.go
+++ b/internal/local/app_test.go
@@ -383,7 +383,7 @@ func TestAppWrite20180301(t *testing.T) {
 
 		assert.Nil(t, app.Write())
 
-		data, readErr := ioutil.ReadFile(filepath.Join(tmpDir, FileRealmConfig.String()))
+		data, readErr := ioutil.ReadFile(filepath.Join(tmpDir, FileStitch.String()))
 		assert.Nil(t, readErr)
 
 		var config AppStitchJSON
@@ -441,17 +441,17 @@ func TestAppWrite20200603(t *testing.T) {
 		assert.Nil(t, err)
 		defer cleanupTmpDir()
 
-		app := NewApp(tmpDir, "test-app-abcde", "test-app", realm.LocationIreland, realm.DeploymentModelLocal, realm.EnvironmentDevelopment, realm.AppConfigVersion20180301)
+		app := NewApp(tmpDir, "test-app-abcde", "test-app", realm.LocationIreland, realm.DeploymentModelLocal, realm.EnvironmentDevelopment, realm.AppConfigVersion20200603)
 
 		assert.Nil(t, app.Write())
 
-		data, readErr := ioutil.ReadFile(filepath.Join(tmpDir, FileRealmConfig.String()))
+		data, readErr := ioutil.ReadFile(filepath.Join(tmpDir, FileConfig.String()))
 		assert.Nil(t, readErr)
 
 		var config AppConfigJSON
 		assert.Nil(t, json.Unmarshal(data, &config))
 		assert.Equal(t, AppConfigJSON{AppDataV1{AppStructureV1{
-			ConfigVersion:        realm.AppConfigVersion20180301,
+			ConfigVersion:        realm.AppConfigVersion20200603,
 			ID:                   "test-app-abcde",
 			Name:                 "test-app",
 			Location:             realm.LocationIreland,
@@ -513,7 +513,7 @@ func TestAppWrite20210101(t *testing.T) {
 		var config AppRealmConfigJSON
 		assert.Nil(t, json.Unmarshal(data, &config))
 		assert.Equal(t, AppRealmConfigJSON{AppDataV2{AppStructureV2{
-			ConfigVersion:   realm.DefaultAppConfigVersion,
+			ConfigVersion:   realm.AppConfigVersion20210101,
 			ID:              "test-app-abcde",
 			Name:            "test-app",
 			Location:        realm.LocationIreland,

--- a/internal/local/testdata/20180301/mismatch_version/stitch.json
+++ b/internal/local/testdata/20180301/mismatch_version/stitch.json
@@ -1,0 +1,26 @@
+
+{
+  "config_version": 20210101,
+  "name": "20180301-mismatch",
+  "location": "US-VA",
+  "deployment_model": "GLOBAL",
+  "security": {
+      "allowed_request_origins": [
+          "http://localhost:8080"
+      ]
+  },
+  "hosting": {
+      "enabled": true,
+      "app_default_domain": "full-tkdcx.stitch-statichosting-dev.baas-dev.10gen.cc"
+  },
+  "custom_user_data_config": {
+      "enabled": true,
+      "mongo_service_name": "mongodb-atlas",
+      "database_name": "test",
+      "collection_name": "coll3",
+      "user_id_field": "xref"
+  },
+  "sync": {
+      "development_mode_enabled": false
+  }
+}

--- a/internal/local/testdata/20200603/mismatch_version/config.json
+++ b/internal/local/testdata/20200603/mismatch_version/config.json
@@ -1,0 +1,25 @@
+{
+  "config_version": 20210101,
+  "name": "20200603-mismatch",
+  "location": "US-VA",
+  "deployment_model": "GLOBAL",
+  "security": {
+      "allowed_request_origins": [
+          "http://localhost:8080"
+      ]
+  },
+  "hosting": {
+      "enabled": true,
+      "app_default_domain": "full-tkdcx.stitch-statichosting-dev.baas-dev.10gen.cc"
+  },
+  "custom_user_data_config": {
+      "enabled": true,
+      "mongo_service_name": "mongodb-atlas",
+      "database_name": "test",
+      "collection_name": "coll3",
+      "user_id_field": "xref"
+  },
+  "sync": {
+      "development_mode_enabled": false
+  }
+}

--- a/internal/local/testdata/20210101/mismatch_version/realm_config.json
+++ b/internal/local/testdata/20210101/mismatch_version/realm_config.json
@@ -1,0 +1,9 @@
+{
+  "config_version": 20200603,
+  "name": "20210101-mismatch",
+  "location": "US-VA",
+  "deployment_model": "GLOBAL",
+  "allowed_request_origins": [
+    "http://localhost:8080"
+  ]
+}


### PR DESCRIPTION
[Ticket here](https://jira.mongodb.org/browse/REALMC-11800)

I added one test to verify that the `realm_config` was being created properly when running the command. I couldn't figure out a clean way to teardown the test, though, since the push handler tests all use the existing `testdata/project` directory for the environment.

Mocking out the `createNewApp` method might be a nice way to do this, since we could just verify that the method's being called with the right params, but it didn't seem like that's something we support in this repo.