### PR TITLE
REALMC-12450: Update onboarding docs for M1 users

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ To lint the project, run:
 ```cmd
 golangci-lint run
 ```
+> Note: `golangci-lint` seems to panic on M1 machines with a `can't load fmt` error. This issue is documented [here](https://github.com/golangci/golangci-lint/issues/2374). While this is still being fixed, it seems that installing `golangci-lint` from source resolves the issue. 
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ To lint the project, run:
 ```cmd
 golangci-lint run
 ```
-> Note: `golangci-lint` seems to panic on M1 machines with a `can't load fmt` error. This issue is documented [here](https://github.com/golangci/golangci-lint/issues/2374). While this is still being fixed, it seems that installing `golangci-lint` from source resolves the issue. 
+> Note: `golangci-lint` panics on M1 machines with a `can't load fmt` error. This issue is documented [here](https://github.com/golangci/golangci-lint/issues/2374). While this is still being fixed, it seems that installing `golangci-lint` from source resolves the issue. 
 
 ## Testing
 


### PR DESCRIPTION
[Ticket](https://jira.mongodb.org/browse/REALMC-12450)

This one isn't blocked by the stitch support lib ticket but we can wait until the [baas PR](https://github.com/10gen/baas/pull/6261) is merged if we want to close out the ticket all at once.