### PR TITLE
REALMC-11567: Allow users to link serverless instances on app creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ node_modules/
 
 # build
 realm-cli*
+
+# VSCode
+.vscode

--- a/internal/cloud/atlas/client.go
+++ b/internal/cloud/atlas/client.go
@@ -25,6 +25,7 @@ type Client interface {
 	Groups() ([]Group, error)
 
 	Clusters(groupID string) ([]Cluster, error)
+	ServerlessInstances(groupID string) ([]ServerlessInstance, error)
 	Datalakes(groupID string) ([]Datalake, error)
 
 	Status() error

--- a/internal/cloud/atlas/serverless_instances.go
+++ b/internal/cloud/atlas/serverless_instances.go
@@ -1,0 +1,46 @@
+package atlas
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/10gen/realm-cli/internal/utils/api"
+)
+
+// ServerlessInstance contains non sensitive data about an Atlas serverless instance
+type ServerlessInstance struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	State string `json:"stateName"`
+}
+
+type serverlessInstancesResponse struct {
+	Results []ServerlessInstance `json:"results"`
+}
+
+const (
+	serverlessInstancesPattern = atlasAPI + "/groups/%s/serverless"
+)
+
+func (c *client) ServerlessInstances(groupID string) ([]ServerlessInstance, error) {
+	res, err := c.do(
+		http.MethodGet,
+		fmt.Sprintf(serverlessInstancesPattern, groupID),
+		api.RequestOptions{},
+	)
+	if err != nil {
+		return nil, err
+	}
+	if res.StatusCode != http.StatusOK {
+		return nil, api.ErrUnexpectedStatusCode{"get serverless instances", res.StatusCode}
+	}
+	defer res.Body.Close()
+
+	var serverlessInstances serverlessInstancesResponse
+	if err := json.NewDecoder(res.Body).Decode(&serverlessInstances); err != nil {
+		return nil, err
+	}
+
+	return serverlessInstances.Results, nil
+}

--- a/internal/cloud/atlas/serverless_instances_test.go
+++ b/internal/cloud/atlas/serverless_instances_test.go
@@ -12,27 +12,29 @@ import (
 func TestServerlessInstances(t *testing.T) {
 	u.SkipUnlessAtlasServerRunning(t)
 
-	for _, tc := range []struct {
-		description string
-		client      atlas.Client
-		expectedErr error
-	}{
-		{
-			description: "without an auth client",
-			client:      atlas.NewClient(u.AtlasServerURL()),
-			expectedErr: atlas.ErrMissingAuth,
-		},
-		{
-			description: "with a client with bad credentials",
-			client:      atlas.NewAuthClient(u.AtlasServerURL(), user.Credentials{PublicAPIKey: "username", PrivateAPIKey: "password"}),
-			expectedErr: atlas.ErrUnauthorized{"You are not authorized for this resource."},
-		},
-	} {
-		t.Run(tc.description, func(t *testing.T) {
-			_, err := tc.client.ServerlessInstances(u.CloudGroupID())
-			assert.Equal(t, tc.expectedErr, err)
-		})
-	}
+	t.Run("should fail", func(t *testing.T) {
+		for _, tc := range []struct {
+			description string
+			client      atlas.Client
+			expectedErr error
+		}{
+			{
+				description: "without an auth client",
+				client:      atlas.NewClient(u.AtlasServerURL()),
+				expectedErr: atlas.ErrMissingAuth,
+			},
+			{
+				description: "with a client with bad credentials",
+				client:      atlas.NewAuthClient(u.AtlasServerURL(), user.Credentials{PublicAPIKey: "username", PrivateAPIKey: "password"}),
+				expectedErr: atlas.ErrUnauthorized{"You are not authorized for this resource."},
+			},
+		} {
+			t.Run(tc.description, func(t *testing.T) {
+				_, err := tc.client.ServerlessInstances(u.CloudGroupID())
+				assert.Equal(t, tc.expectedErr, err)
+			})
+		}
+	})
 
 	t.Run("with an authenticated client should return the list of atlas serverless instances", func(t *testing.T) {
 		client := newAuthClient(t)

--- a/internal/cloud/atlas/serverless_instances_test.go
+++ b/internal/cloud/atlas/serverless_instances_test.go
@@ -1,0 +1,44 @@
+package atlas_test
+
+import (
+	"testing"
+
+	"github.com/10gen/realm-cli/internal/cli/user"
+	"github.com/10gen/realm-cli/internal/cloud/atlas"
+	u "github.com/10gen/realm-cli/internal/utils/test"
+	"github.com/10gen/realm-cli/internal/utils/test/assert"
+)
+
+func TestServerlessInstances(t *testing.T) {
+	u.SkipUnlessAtlasServerRunning(t)
+
+	for _, tc := range []struct {
+		description string
+		client      atlas.Client
+		expectedErr error
+	}{
+		{
+			description: "without an auth client",
+			client:      atlas.NewClient(u.AtlasServerURL()),
+			expectedErr: atlas.ErrMissingAuth,
+		},
+		{
+			description: "with a client with bad credentials",
+			client:      atlas.NewAuthClient(u.AtlasServerURL(), user.Credentials{PublicAPIKey: "username", PrivateAPIKey: "password"}),
+			expectedErr: atlas.ErrUnauthorized{"You are not authorized for this resource."},
+		},
+	} {
+		t.Run(tc.description, func(t *testing.T) {
+			_, err := tc.client.ServerlessInstances(u.CloudGroupID())
+			assert.Equal(t, tc.expectedErr, err)
+		})
+	}
+
+	t.Run("with an authenticated client should return the list of atlas serverless instances", func(t *testing.T) {
+		client := newAuthClient(t)
+
+		serverlessInstances, err := client.ServerlessInstances(u.CloudGroupID())
+		assert.Nil(t, err)
+		assert.Equal(t, u.CloudAtlasServerlessInstanceCount(), len(serverlessInstances))
+	})
+}

--- a/internal/commands/app/create.go
+++ b/internal/commands/app/create.go
@@ -396,7 +396,8 @@ func (cmd CommandCreate) handleCreateApp(
 	return nil
 }
 
-// handleCreateTemplateApp does not take in serverless instances because they are not compatible with template apps
+// handleCreateTemplateApp creates a template app and writes it to the user's disk.
+// This function does not take in serverless instances because they are not compatible with template apps.
 func (cmd CommandCreate) handleCreateTemplateApp(
 	profile *user.Profile,
 	ui terminal.UI,

--- a/internal/commands/app/create.go
+++ b/internal/commands/app/create.go
@@ -322,8 +322,7 @@ func (cmd CommandCreate) handleCreateApp(
 		}
 	}
 
-	dsClustersAndServerlessInstances := append(dsClusters, dsServerlessInstances...)
-	for _, dsCluster := range dsClustersAndServerlessInstances {
+	for _, dsCluster := range dsClusters {
 		local.AddDataSource(appLocal.AppData, map[string]interface{}{
 			"name": dsCluster.Name,
 			"type": dsCluster.Type,
@@ -334,6 +333,21 @@ func (cmd CommandCreate) handleCreateApp(
 			},
 			"version": dsCluster.Version,
 		})
+
+	}
+
+	for _, dsServerlessInstance := range dsServerlessInstances {
+		local.AddDataSource(appLocal.AppData, map[string]interface{}{
+			"name": dsServerlessInstance.Name,
+			"type": dsServerlessInstance.Type,
+			"config": map[string]interface{}{
+				"clusterName":         dsServerlessInstance.Config.ClusterName,
+				"readPreference":      dsServerlessInstance.Config.ReadPreference,
+				"wireProtocolEnabled": dsServerlessInstance.Config.WireProtocolEnabled,
+			},
+			"version": dsServerlessInstance.Version,
+		})
+
 	}
 
 	for _, dsDatalake := range dsDatalakes {

--- a/internal/commands/app/create.go
+++ b/internal/commands/app/create.go
@@ -232,7 +232,7 @@ func (cmd *CommandCreate) Handler(profile *user.Profile, ui terminal.UI, clients
 	if cmd.inputs.Template == "" {
 		return cmd.handleCreateApp(profile, ui, clients, groupID, rootDir, appRemote, dsClusters, dsDatalakes, dsServerlessInstances)
 	}
-	return cmd.handleCreateTemplateApp(profile, ui, clients, groupID, rootDir, dsClusters, dsDatalakes, dsServerlessInstances)
+	return cmd.handleCreateTemplateApp(profile, ui, clients, groupID, rootDir, dsClusters, dsDatalakes)
 }
 
 func (cmd CommandCreate) handleCreateApp(
@@ -396,6 +396,7 @@ func (cmd CommandCreate) handleCreateApp(
 	return nil
 }
 
+// handleCreateTemplateApp does not take in serverless instances because they are not compatible with template apps
 func (cmd CommandCreate) handleCreateTemplateApp(
 	profile *user.Profile,
 	ui terminal.UI,
@@ -404,11 +405,10 @@ func (cmd CommandCreate) handleCreateTemplateApp(
 	rootDir string,
 	dsClusters []dataSourceCluster,
 	dsDatalakes []dataSourceDatalake,
-	dsServerlessInstances []dataSourceCluster,
 ) error {
 	if cmd.inputs.DryRun {
 		// +2 indicates that there are two logs in addition to the data lake and cluster ones
-		logs := make([]terminal.Log, 0, len(dsClusters)+len(dsDatalakes)+len(dsServerlessInstances)+2)
+		logs := make([]terminal.Log, 0, len(dsClusters)+len(dsDatalakes)+2)
 		logs = append(logs, terminal.NewTextLog(
 			"A Realm app would be created at %s using the '%s' template",
 			rootDir,
@@ -417,9 +417,6 @@ func (cmd CommandCreate) handleCreateTemplateApp(
 
 		for _, cluster := range dsClusters {
 			logs = append(logs, terminal.NewTextLog("The cluster '%s' would be linked as data source '%s'", cluster.Config.ClusterName, cluster.Name))
-		}
-		for _, serverlessInstance := range dsServerlessInstances {
-			logs = append(logs, terminal.NewTextLog("The serverless instance '%s' would be linked as data source '%s'", serverlessInstance.Config.ClusterName, serverlessInstance.Name))
 		}
 		for _, datalake := range dsDatalakes {
 			logs = append(logs, terminal.NewTextLog("The data lake '%s' would be linked as data source '%s'", datalake.Config.DatalakeName, datalake.Name))

--- a/internal/commands/app/create.go
+++ b/internal/commands/app/create.go
@@ -230,7 +230,7 @@ func (cmd *CommandCreate) Handler(profile *user.Profile, ui terminal.UI, clients
 	}
 
 	if cmd.inputs.Template == "" {
-		return cmd.handleCreateApp(profile, ui, clients, groupID, rootDir, appRemote, dsClusters, dsDatalakes, dsServerlessInstances)
+		return cmd.handleCreateApp(profile, ui, clients, groupID, rootDir, appRemote, dsClusters, dsServerlessInstances, dsDatalakes)
 	}
 	return cmd.handleCreateTemplateApp(profile, ui, clients, groupID, rootDir, dsClusters, dsDatalakes)
 }
@@ -243,8 +243,8 @@ func (cmd CommandCreate) handleCreateApp(
 	rootDir string,
 	appRemote realm.App,
 	dsClusters []dataSourceCluster,
-	dsDatalakes []dataSourceDatalake,
 	dsServerlessInstances []dataSourceCluster,
+	dsDatalakes []dataSourceDatalake,
 ) error {
 	if cmd.inputs.DryRun {
 		logs := make([]terminal.Log, 0, 4)
@@ -322,7 +322,8 @@ func (cmd CommandCreate) handleCreateApp(
 		}
 	}
 
-	for _, dsCluster := range dsClusters {
+	dsClustersAndServerlessInstances := append(dsClusters, dsServerlessInstances...)
+	for _, dsCluster := range dsClustersAndServerlessInstances {
 		local.AddDataSource(appLocal.AppData, map[string]interface{}{
 			"name": dsCluster.Name,
 			"type": dsCluster.Type,
@@ -333,21 +334,6 @@ func (cmd CommandCreate) handleCreateApp(
 			},
 			"version": dsCluster.Version,
 		})
-
-	}
-
-	for _, dsServerlessInstance := range dsServerlessInstances {
-		local.AddDataSource(appLocal.AppData, map[string]interface{}{
-			"name": dsServerlessInstance.Name,
-			"type": dsServerlessInstance.Type,
-			"config": map[string]interface{}{
-				"clusterName":         dsServerlessInstance.Config.ClusterName,
-				"readPreference":      dsServerlessInstance.Config.ReadPreference,
-				"wireProtocolEnabled": dsServerlessInstance.Config.WireProtocolEnabled,
-			},
-			"version": dsServerlessInstance.Version,
-		})
-
 	}
 
 	for _, dsDatalake := range dsDatalakes {

--- a/internal/commands/app/create.go
+++ b/internal/commands/app/create.go
@@ -211,11 +211,11 @@ func (cmd *CommandCreate) Handler(profile *user.Profile, ui terminal.UI, clients
 	for _, missingCluster := range dsClustersMissing {
 		nonExistingDataSources = append(nonExistingDataSources, fmt.Sprintf("'%s'", missingCluster))
 	}
-	for _, missingDatalake := range dsDatalakesMissing {
-		nonExistingDataSources = append(nonExistingDataSources, fmt.Sprintf("'%s'", missingDatalake))
-	}
 	for _, missingServerlessInstance := range dsServerlessInstancesMissing {
 		nonExistingDataSources = append(nonExistingDataSources, fmt.Sprintf("'%s'", missingServerlessInstance))
+	}
+	for _, missingDatalake := range dsDatalakesMissing {
+		nonExistingDataSources = append(nonExistingDataSources, fmt.Sprintf("'%s'", missingDatalake))
 	}
 
 	if len(nonExistingDataSources) > 0 {

--- a/internal/commands/app/create_inputs.go
+++ b/internal/commands/app/create_inputs.go
@@ -405,6 +405,12 @@ func (i createInputs) args(omitDryRun bool) []flags.Arg {
 			args = append(args, flags.Arg{flagClusterServiceName, i.ClusterServiceNames[idx]})
 		}
 	}
+	for idx, serverlessInstanceName := range i.ServerlessInstances {
+		args = append(args, flags.Arg{flagServerlessInstance, serverlessInstanceName})
+		if len(i.ServerlessInstanceServiceNames) > idx {
+			args = append(args, flags.Arg{flagServerlessInstanceServiceName, i.ServerlessInstanceServiceNames[idx]})
+		}
+	}
 	for idx, datalakeName := range i.Datalakes {
 		args = append(args, flags.Arg{flagDatalake, datalakeName})
 		if len(i.DatalakeServiceNames) > idx {

--- a/internal/commands/app/create_inputs.go
+++ b/internal/commands/app/create_inputs.go
@@ -20,23 +20,27 @@ import (
 )
 
 var (
-	flagLocalPathCreate     = "local"
-	flagCluster             = "cluster"
-	flagClusterServiceName  = "cluster-service-name"
-	flagDatalake            = "datalake"
-	flagDatalakeServiceName = "datalake-service-name"
-	flagTemplate            = "template"
-	flagDryRun              = "dry-run"
+	flagLocalPathCreate               = "local"
+	flagCluster                       = "cluster"
+	flagClusterServiceName            = "cluster-service-name"
+	flagServerlessInstance            = "serverless-instance"
+	flagServerlessInstanceServiceName = "serverless-instance-service-name"
+	flagDatalake                      = "datalake"
+	flagDatalakeServiceName           = "datalake-service-name"
+	flagTemplate                      = "template"
+	flagDryRun                        = "dry-run"
 )
 
 type createInputs struct {
 	newAppInputs
-	LocalPath            string
-	Clusters             []string
-	ClusterServiceNames  []string
-	Datalakes            []string
-	DatalakeServiceNames []string
-	DryRun               bool
+	LocalPath                      string
+	Clusters                       []string
+	ClusterServiceNames            []string
+	ServerlessInstances            []string
+	ServerlessInstanceServiceNames []string
+	Datalakes                      []string
+	DatalakeServiceNames           []string
+	DryRun                         bool
 }
 
 type dataSourceCluster struct {
@@ -266,6 +270,58 @@ func (i *createInputs) resolveClusters(ui terminal.UI, client atlas.Client, grou
 	}
 
 	return dsClusters, nonExistingClusters, nil
+}
+
+func (i *createInputs) resolveServerlessInstances(ui terminal.UI, client atlas.Client, groupID string) ([]dataSourceCluster, []string, error) {
+	if i.Template != "" && len(i.ServerlessInstances) > 0 {
+		return nil, nil, errors.New("cannot create a template app with Serverless instances")
+	}
+
+	serverlessInstances, err := client.ServerlessInstances(groupID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	existingServerlessInstances := map[string]struct{}{}
+	for _, d := range serverlessInstances {
+		existingServerlessInstances[d.Name] = struct{}{}
+	}
+	nonExistingServerlessInstances := make([]string, 0, len(i.ServerlessInstances))
+
+	dsServerlessInstances := make([]dataSourceCluster, 0, len(i.ServerlessInstances))
+	for idx, serverlessInstanceName := range i.ServerlessInstances {
+		if _, ok := existingServerlessInstances[serverlessInstanceName]; !ok {
+			nonExistingServerlessInstances = append(nonExistingServerlessInstances, serverlessInstanceName)
+			continue
+		}
+
+		serviceName := serverlessInstanceName
+		if len(i.ServerlessInstanceServiceNames) > idx {
+			serviceName = i.ServerlessInstanceServiceNames[idx]
+		} else {
+			if !ui.AutoConfirm() {
+				if err := ui.AskOne(&serviceName, &survey.Input{
+					Message: fmt.Sprintf("Enter a Service Name for Serverless instance '%s'", serverlessInstanceName),
+					Default: serviceName,
+				}); err != nil {
+					return nil, nil, err
+				}
+			}
+		}
+		dsServerlessInstances = append(dsServerlessInstances,
+			dataSourceCluster{
+				Name: serviceName,
+				Type: realm.ServiceTypeCluster,
+				Config: configCluster{
+					ClusterName:         serverlessInstanceName,
+					ReadPreference:      "primary",
+					WireProtocolEnabled: false,
+				},
+				Version: 1,
+			})
+	}
+
+	return dsServerlessInstances, nonExistingServerlessInstances, nil
 }
 
 func (i *createInputs) resolveDatalakes(ui terminal.UI, client atlas.Client, groupID string) ([]dataSourceDatalake, []string, error) {

--- a/internal/commands/app/create_inputs_test.go
+++ b/internal/commands/app/create_inputs_test.go
@@ -875,6 +875,366 @@ func TestAppCreateInputsResolveCluster(t *testing.T) {
 	})
 }
 
+func TestAppCreateInputsResolveServerlessInstance(t *testing.T) {
+	t.Run("should return data source config of a provided serverless instance", func(t *testing.T) {
+		_, ui := mock.NewUI()
+		var expectedGroupID string
+		ac := mock.AtlasClient{}
+		ac.ServerlessInstancesFn = func(groupID string) ([]atlas.ServerlessInstance, error) {
+			expectedGroupID = groupID
+			return []atlas.ServerlessInstance{{Name: "test-serverless-instance"}}, nil
+		}
+
+		inputs := createInputs{
+			newAppInputs:                   newAppInputs{Name: "test-app"},
+			ServerlessInstances:            []string{"test-serverless-instance"},
+			ServerlessInstanceServiceNames: []string{"mongodb-atlas"},
+		}
+
+		ds, _, err := inputs.resolveServerlessInstances(ui, ac, "123")
+		assert.Nil(t, err)
+
+		assert.Equal(t, []dataSourceCluster{
+			{
+				Name: "mongodb-atlas",
+				Type: realm.ServiceTypeCluster,
+				Config: configCluster{
+					ClusterName:         "test-serverless-instance",
+					ReadPreference:      "primary",
+					WireProtocolEnabled: false,
+				},
+				Version: 1,
+			},
+		}, ds)
+		assert.Equal(t, "123", expectedGroupID)
+	})
+
+	t.Run("should return data source config of multiple provided serverless instances", func(t *testing.T) {
+		_, ui := mock.NewUI()
+		var expectedGroupID string
+		ac := mock.AtlasClient{}
+		ac.ServerlessInstancesFn = func(groupID string) ([]atlas.ServerlessInstance, error) {
+			expectedGroupID = groupID
+			return []atlas.ServerlessInstance{
+				{Name: "test-serverless-instance-1"},
+				{Name: "test-serverless-instance-2"},
+			}, nil
+		}
+
+		inputs := createInputs{
+			newAppInputs:                   newAppInputs{Name: "test-app"},
+			ServerlessInstances:            []string{"test-serverless-instance-1", "test-serverless-instance-2"},
+			ServerlessInstanceServiceNames: []string{"mongodb-atlas", "another-data-source"},
+		}
+
+		ds, _, err := inputs.resolveServerlessInstances(ui, ac, "123")
+		assert.Nil(t, err)
+
+		assert.Equal(t, []dataSourceCluster{
+			{
+				Name: "mongodb-atlas",
+				Type: realm.ServiceTypeCluster,
+				Config: configCluster{
+					ClusterName:         "test-serverless-instance-1",
+					ReadPreference:      "primary",
+					WireProtocolEnabled: false,
+				},
+				Version: 1,
+			},
+			{
+				Name: "another-data-source",
+				Type: realm.ServiceTypeCluster,
+				Config: configCluster{
+					ClusterName:         "test-serverless-instance-2",
+					ReadPreference:      "primary",
+					WireProtocolEnabled: false,
+				},
+				Version: 1,
+			},
+		}, ds)
+		assert.Equal(t, "123", expectedGroupID)
+	})
+
+	t.Run("should warn user if serverless instances are not found and auto confirm is set", func(t *testing.T) {
+		profile, teardown := mock.NewProfileFromTmpDir(t, "app_create_test")
+		defer teardown()
+
+		console, ui, err := mock.NewConsoleWithOptions(mock.UIOptions{AutoConfirm: true})
+		assert.Nil(t, err)
+		defer console.Close()
+
+		testApp := realm.App{
+			ID:          primitive.NewObjectID().Hex(),
+			GroupID:     primitive.NewObjectID().Hex(),
+			ClientAppID: "test-app-abcde",
+			Name:        "test-app",
+		}
+
+		rc := mock.RealmClient{}
+		rc.CreateAppFn = func(groupID, name string, meta realm.AppMeta) (realm.App, error) {
+			return testApp, nil
+		}
+		rc.ImportFn = func(groupID, appID string, appData interface{}) error {
+			return nil
+		}
+		rc.AllTemplatesFn = func() ([]realm.Template, error) {
+			return []realm.Template{}, nil
+		}
+
+		ac := mock.AtlasClient{}
+		ac.ServerlessInstancesFn = func(groupID string) ([]atlas.ServerlessInstance, error) {
+			return []atlas.ServerlessInstance{
+				{Name: "test-serverless-instance-1"},
+			}, nil
+		}
+
+		dummyServerlessInstances := []string{"test-dummy-serverless-instance-1", "test-dummy-serverless-instance-2"}
+		inputs := createInputs{
+			newAppInputs:                   newAppInputs{Name: testApp.Name, Project: testApp.GroupID},
+			ServerlessInstances:            []string{"test-serverless-instance-1", dummyServerlessInstances[0], dummyServerlessInstances[1]},
+			ServerlessInstanceServiceNames: []string{"mongodb-atlas"},
+		}
+
+		doneCh := make(chan (struct{}))
+		go func() {
+			defer close(doneCh)
+			console.ExpectString("Note: The following data sources were not linked because they could not be found: 'test-dummy-serverless-instance-1', 'test-dummy-serverless-instance-2'")
+			console.ExpectEOF()
+		}()
+
+		cmd := &CommandCreate{inputs}
+		assert.Nil(t, cmd.Handler(profile, ui, cli.Clients{Realm: rc, Atlas: ac}))
+
+		ds, _, err := inputs.resolveServerlessInstances(ui, ac, "123")
+		assert.Nil(t, err)
+
+		assert.Equal(t, []dataSourceCluster{
+			{
+				Name: "mongodb-atlas",
+				Type: realm.ServiceTypeCluster,
+				Config: configCluster{
+					ClusterName:         "test-serverless-instance-1",
+					ReadPreference:      "primary",
+					WireProtocolEnabled: false,
+				},
+				Version: 1,
+			},
+		}, ds)
+	})
+
+	t.Run("should prompt user for confirmation if serverless instances are not found", func(t *testing.T) {
+		testApp := realm.App{
+			ID:          primitive.NewObjectID().Hex(),
+			GroupID:     primitive.NewObjectID().Hex(),
+			ClientAppID: "test-app-abcde",
+			Name:        "test-app",
+		}
+
+		rc := mock.RealmClient{}
+		rc.ImportFn = func(groupID, appID string, appData interface{}) error {
+			return nil
+		}
+		rc.AllTemplatesFn = func() ([]realm.Template, error) {
+			return []realm.Template{}, nil
+		}
+
+		ac := mock.AtlasClient{}
+		ac.ServerlessInstancesFn = func(groupID string) ([]atlas.ServerlessInstance, error) {
+			return []atlas.ServerlessInstance{
+				{Name: "test-serverless-instance-1"},
+			}, nil
+		}
+
+		dummyServerlessInstances := []string{"test-dummy-serverless-instance-1", "test-dummy-serverless-instance-2"}
+		inputs := createInputs{
+			newAppInputs:                   newAppInputs{Name: testApp.Name, Project: testApp.GroupID},
+			ServerlessInstances:            []string{"test-serverless-instance-1", dummyServerlessInstances[0], dummyServerlessInstances[1]},
+			ServerlessInstanceServiceNames: []string{"mongodb-atlas"},
+		}
+
+		for _, tc := range []struct {
+			description string
+			response    string
+			appCreated  bool
+		}{
+			{
+				description: "and quit if not confirmed",
+				response:    "no",
+			},
+			{
+				description: "and continue to create app if confirmed",
+				response:    "yes",
+				appCreated:  true,
+			},
+		} {
+			t.Run(tc.description, func(t *testing.T) {
+				profile, teardown := mock.NewProfileFromTmpDir(t, "app_create_test")
+				defer teardown()
+
+				_, console, _, ui, err := mock.NewVT10XConsole()
+				assert.Nil(t, err)
+				defer console.Close()
+
+				doneCh := make(chan (struct{}))
+				go func() {
+					defer close(doneCh)
+					console.ExpectString("Note: The following data sources were not linked because they could not be found: 'test-dummy-serverless-instance-1', 'test-dummy-serverless-instance-2'")
+					console.ExpectString("Would you still like to create the app?")
+					console.SendLine(tc.response)
+					console.ExpectEOF()
+				}()
+
+				var appCreated bool
+				rc.CreateAppFn = func(groupID, name string, meta realm.AppMeta) (realm.App, error) {
+					appCreated = true
+					return testApp, nil
+				}
+
+				cmd := &CommandCreate{inputs}
+				assert.Nil(t, cmd.Handler(profile, ui, cli.Clients{Realm: rc, Atlas: ac}))
+				assert.Equal(t, tc.appCreated, appCreated)
+			})
+		}
+	})
+
+	t.Run("should return data source configs of serverless instances with serverless instance service names", func(t *testing.T) {
+		serverlessInstanceNames := []string{"ServerlessInstance0", "ServerlessInstance1"}
+		serverlessInstanceServiceNames := []string{"mongodb-atlas", "another-data-source"}
+
+		ac := mock.AtlasClient{}
+		ac.ServerlessInstancesFn = func(groupID string) ([]atlas.ServerlessInstance, error) {
+			return []atlas.ServerlessInstance{
+				{Name: serverlessInstanceNames[0]},
+				{Name: serverlessInstanceNames[1]},
+			}, nil
+		}
+
+		for _, tc := range []struct {
+			description                            string
+			serverlessInstanceNames                []string
+			serverlessInstanceServiceNames         []string
+			procedure                              func(c *expect.Console)
+			autoConfirm                            bool
+			expectedServerlessInstanceServiceNames []string
+		}{
+			{
+				description:                            "use serverless instance names provided",
+				serverlessInstanceNames:                serverlessInstanceNames,
+				serverlessInstanceServiceNames:         serverlessInstanceServiceNames,
+				procedure:                              func(c *expect.Console) {},
+				autoConfirm:                            false,
+				expectedServerlessInstanceServiceNames: serverlessInstanceServiceNames,
+			},
+			{
+				description:             "prompt user if no serverless instance service names are provided",
+				serverlessInstanceNames: serverlessInstanceNames,
+				procedure: func(c *expect.Console) {
+					c.ExpectString("Enter a Service Name for Serverless instance 'ServerlessInstance0'")
+					c.SendLine(serverlessInstanceServiceNames[0])
+					c.ExpectString("Enter a Service Name for Serverless instance 'ServerlessInstance1'")
+					c.SendLine(serverlessInstanceServiceNames[1])
+					c.ExpectEOF()
+				},
+				autoConfirm:                            false,
+				expectedServerlessInstanceServiceNames: serverlessInstanceServiceNames,
+			},
+			{
+				description:                    "prompt user if any serverless instance service name is not provided",
+				serverlessInstanceNames:        serverlessInstanceNames,
+				serverlessInstanceServiceNames: []string{serverlessInstanceServiceNames[0]},
+				procedure: func(c *expect.Console) {
+					c.ExpectString("Enter a Service Name for Serverless instance 'ServerlessInstance1'")
+					c.SendLine(serverlessInstanceServiceNames[1])
+					c.ExpectEOF()
+				},
+				autoConfirm:                            false,
+				expectedServerlessInstanceServiceNames: serverlessInstanceServiceNames,
+			},
+			{
+				description:                            "default serverless instance service names to serverless instance names if not provided and auto confirm is set",
+				serverlessInstanceNames:                serverlessInstanceNames,
+				procedure:                              func(c *expect.Console) {},
+				autoConfirm:                            true,
+				expectedServerlessInstanceServiceNames: serverlessInstanceNames,
+			},
+		} {
+			t.Run(tc.description, func(t *testing.T) {
+				console, _, ui, err := mock.NewVT10XConsoleWithOptions(mock.UIOptions{AutoConfirm: tc.autoConfirm})
+				assert.Nil(t, err)
+				defer console.Close()
+
+				doneCh := make(chan (struct{}))
+				go func() {
+					defer close(doneCh)
+					tc.procedure(console)
+				}()
+
+				inputs := createInputs{
+					newAppInputs:                   newAppInputs{Name: "test-app"},
+					ServerlessInstances:            tc.serverlessInstanceNames,
+					ServerlessInstanceServiceNames: tc.serverlessInstanceServiceNames,
+				}
+
+				ds, _, err := inputs.resolveServerlessInstances(ui, ac, "123")
+				assert.Nil(t, err)
+
+				assert.Equal(t, []dataSourceCluster{
+					{
+						Name: tc.expectedServerlessInstanceServiceNames[0],
+						Type: realm.ServiceTypeCluster,
+						Config: configCluster{
+							ClusterName:         tc.serverlessInstanceNames[0],
+							ReadPreference:      "primary",
+							WireProtocolEnabled: false,
+						},
+						Version: 1,
+					},
+					{
+						Name: tc.expectedServerlessInstanceServiceNames[1],
+						Type: realm.ServiceTypeCluster,
+						Config: configCluster{
+							ClusterName:         tc.serverlessInstanceNames[1],
+							ReadPreference:      "primary",
+							WireProtocolEnabled: false,
+						},
+						Version: 1,
+					},
+				}, ds)
+			})
+		}
+	})
+
+	t.Run("should error from client", func(t *testing.T) {
+		_, ui := mock.NewUI()
+		var expectedGroupID string
+		ac := mock.AtlasClient{}
+		ac.ServerlessInstancesFn = func(groupID string) ([]atlas.ServerlessInstance, error) {
+			expectedGroupID = groupID
+			return nil, errors.New("client error")
+		}
+
+		inputs := createInputs{ServerlessInstances: []string{"test-serverless-instance"}}
+
+		_, _, err := inputs.resolveServerlessInstances(ui, ac, "123")
+		assert.Equal(t, errors.New("client error"), err)
+		assert.Equal(t, "123", expectedGroupID)
+	})
+
+	t.Run("should error if creating template with a serverless instance", func(t *testing.T) {
+		_, ui := mock.NewUI()
+		ac := mock.AtlasClient{}
+		inputs := createInputs{
+			newAppInputs: newAppInputs{
+				Template: "ios.template.todo",
+			},
+			ServerlessInstances: []string{"test-serverless-instance"},
+		}
+
+		_, _, err := inputs.resolveServerlessInstances(ui, ac, "123")
+		assert.Equal(t, errors.New("cannot create a template app with Serverless instances"), err)
+	})
+}
+
 func TestAppCreateInputsResolveDatalake(t *testing.T) {
 	t.Run("should return data source config of a provided data lake", func(t *testing.T) {
 		_, ui := mock.NewUI()

--- a/internal/commands/app/create_test.go
+++ b/internal/commands/app/create_test.go
@@ -684,7 +684,7 @@ Check out your app: cd ./remote-app && realm-cli app describe
   ]`,
 		},
 		{
-			description:                    "should create minimal project with a data lake and serverless instance and cluster data source when data lake and serverless instance and cluster is set",
+			description:                    "should create minimal project with a cluster and serverless instance and data lake data source when cluster and serverless instance and data lake is set",
 			clusters:                       []string{"test-cluster"},
 			clusterServiceNames:            []string{"mongodb-atlas"},
 			serverlessInstances:            []string{"test-serverless-instance"},

--- a/internal/commands/app/output.go
+++ b/internal/commands/app/output.go
@@ -15,13 +15,14 @@ const (
 )
 
 type newAppOutputs struct {
-	AppID     string              `json:"client_app_id"`
-	Filepath  string              `json:"filepath"`
-	URL       string              `json:"url,omitempty"`
-	Backend   string              `json:"backend,omitempty"`
-	Frontends string              `json:"frontends,omitempty"`
-	Clusters  []dataSourceOutputs `json:"clusters,omitempty"`
-	Datalakes []dataSourceOutputs `json:"datalakes,omitempty"`
+	AppID               string              `json:"client_app_id"`
+	Filepath            string              `json:"filepath"`
+	URL                 string              `json:"url,omitempty"`
+	Backend             string              `json:"backend,omitempty"`
+	Frontends           string              `json:"frontends,omitempty"`
+	Clusters            []dataSourceOutputs `json:"clusters,omitempty"`
+	ServerlessInstances []dataSourceOutputs `json:"serverless_instances,omitempty"`
+	Datalakes           []dataSourceOutputs `json:"datalakes,omitempty"`
 }
 
 type dataSourceOutputs struct {

--- a/internal/utils/test/mock/atlas_client.go
+++ b/internal/utils/test/mock/atlas_client.go
@@ -5,9 +5,10 @@ import "github.com/10gen/realm-cli/internal/cloud/atlas"
 // AtlasClient is a mocked Atlas client
 type AtlasClient struct {
 	atlas.Client
-	GroupsFn    func() ([]atlas.Group, error)
-	ClustersFn  func(groupID string) ([]atlas.Cluster, error)
-	DatalakesFn func(groupID string) ([]atlas.Datalake, error)
+	GroupsFn              func() ([]atlas.Group, error)
+	ClustersFn            func(groupID string) ([]atlas.Cluster, error)
+	ServerlessInstancesFn func(groupID string) ([]atlas.ServerlessInstance, error)
+	DatalakesFn           func(groupID string) ([]atlas.Datalake, error)
 }
 
 // Groups calls the mocked Groups implementation if provided,
@@ -28,6 +29,16 @@ func (ac AtlasClient) Clusters(groupID string) ([]atlas.Cluster, error) {
 		return ac.ClustersFn(groupID)
 	}
 	return ac.Client.Clusters(groupID)
+}
+
+// ServerlessInstances calls the mocked ServerlessInstances implementation if provided,
+// otherwise the call falls back to the underlying atlas.Client implementation.
+// NOTE: this may panic if the underlying atlas.Client is left undefined
+func (ac AtlasClient) ServerlessInstances(groupID string) ([]atlas.ServerlessInstance, error) {
+	if ac.ServerlessInstancesFn != nil {
+		return ac.ServerlessInstancesFn(groupID)
+	}
+	return ac.Client.ServerlessInstances(groupID)
 }
 
 // Datalakes calls the mocked Datalakes implementation if provided,

--- a/internal/utils/test/test.go
+++ b/internal/utils/test/test.go
@@ -19,12 +19,13 @@ func MustSkipf(t *testing.T, format string, args ...interface{}) {
 }
 
 const (
-	defaultGroupID            = "5fd45718cface356de9d104d"
-	defaultGroupName          = "Project 0"
-	defaultAtlasServerURL     = "https://cloud-dev.mongodb.com"
-	defaultRealmServerURL     = "http://localhost:8080"
-	defaultAtlasClusterCount  = 3
-	defaultAtlasDatalakeCount = 1
+	defaultGroupID                      = "5fd45718cface356de9d104d"
+	defaultGroupName                    = "Project 0"
+	defaultAtlasServerURL               = "https://cloud-dev.mongodb.com"
+	defaultRealmServerURL               = "http://localhost:8080"
+	defaultAtlasClusterCount            = 3
+	defaultAtlasServerlessInstanceCount = 1
+	defaultAtlasDatalakeCount           = 1
 )
 
 var realmServerRunning = false
@@ -81,6 +82,18 @@ func CloudAtlasClusterCount() int {
 		return c
 	}
 	return defaultAtlasClusterCount
+}
+
+// CloudAtlasServerlessInstanceCount returns the count of serverless instances to use for testing
+func CloudAtlasServerlessInstanceCount() int {
+	if count := os.Getenv("BAAS_MONGODB_CLOUD_ATLAS_SERVERLESS_INSTANCE_COUNT"); count != "" {
+		c, err := strconv.Atoi(count)
+		if err != nil {
+			panic("BAAS_MONGODB_CLOUD_ATLAS_SERVERLESS_INSTANCE_COUNT must be set with an integer")
+		}
+		return c
+	}
+	return defaultAtlasServerlessInstanceCount
 }
 
 // CloudAtlasDatalakeCount returns the count of clusters to use for testing


### PR DESCRIPTION
https://jira.mongodb.org/browse/REALMC-11567

Adding `--serverless-instance` and `--serverless-instance-service-name` flags to `realm-cli apps create`