### PR TITLE
point to README after pulling template apps

### DIFF
--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -66,7 +66,7 @@ func TestCLI(t *testing.T) {
 		{
 			description: "the app create command",
 			args:        []string{"app", "create"},
-			firstLine:   "Create a new app from your current working directory and deploy it to the Realm server",
+			firstLine:   "Create a new app or a template app from your current working directory and deploy it to the Realm server",
 		},
 		{
 			description: "the app list command",

--- a/internal/commands/app/create.go
+++ b/internal/commands/app/create.go
@@ -481,6 +481,11 @@ func (cmd CommandCreate) handleCreateTemplateApp(
 	// TODO(REALMC-9460): Add better template-app-specific directions for checking out the newly created template app
 	ui.Print(terminal.NewJSONLog("Successfully created app", output))
 	ui.Print(terminal.NewFollowupLog("Check out your app", fmt.Sprintf("cd ./%s && %s app describe", cmd.inputs.LocalPath, cli.Name)))
+
+	if matches, err := filepath.Glob(filepath.Join(frontendDir, cmd.inputs.Template, "README.*")); err == nil && len(matches) == 1 {
+		ui.Print(terminal.NewFollowupLog(fmt.Sprintf("View directions on how to run the template app: %s", matches[0])))
+	}
+
 	return nil
 }
 

--- a/internal/commands/app/create.go
+++ b/internal/commands/app/create.go
@@ -21,7 +21,7 @@ import (
 var CommandMetaCreate = cli.CommandMeta{
 	Use:         "create",
 	Display:     "app create",
-	Description: "Create a new app from your current working directory and deploy it to the Realm server",
+	Description: "Create a new app or a template app from your current working directory and deploy it to the Realm server",
 	HelpText: `Creates a new Realm app by saving your configuration files in a local directory
 and deploying the new app to the Realm server. This command will create a new
 directory for your project.

--- a/internal/commands/pull/command.go
+++ b/internal/commands/pull/command.go
@@ -258,17 +258,20 @@ func (cmd *Command) Handler(profile *user.Profile, ui terminal.UI, clients cli.C
 		ui.Print(terminal.NewDebugLog("Fetched hosting assets"))
 	}
 
-	successfulTemplateWrites := make([]string, 0, len(clientTemplates))
+	successfulTemplateWrites := make([]interface{}, 0, len(clientTemplates))
 	for _, ct := range clientTemplates {
 		if err := local.WriteZip(filepath.Join(pathFrontend, ct.id), ct.zipPkg); err != nil {
 			return fmt.Errorf("unable to save template '%s' to disk: %s", ct.id, err)
 		}
-		successfulTemplateWrites = append(successfulTemplateWrites, ct.id)
+		successfulTemplateWrites = append(successfulTemplateWrites,
+			fmt.Sprintf("[%s] %s", ct.id, filepath.Join(pathRelative, local.FrontendPath, ct.id, "README.md")),
+		)
 	}
 
 	ui.Print(terminal.NewTextLog("Successfully pulled app down: %s", pathRelative))
 	if len(successfulTemplateWrites) != 0 {
-		ui.Print(terminal.NewListLog("Successfully saved template(s) to disk", successfulTemplateWrites))
+		ui.Print(terminal.NewListLog("Successfully saved template(s) to disk", successfulTemplateWrites...))
+		ui.Print(terminal.NewTextLog("  Navigate to the saved directory to view directions on how to run the template app(s)"))
 	}
 
 	return nil

--- a/internal/commands/pull/command.go
+++ b/internal/commands/pull/command.go
@@ -263,9 +263,11 @@ func (cmd *Command) Handler(profile *user.Profile, ui terminal.UI, clients cli.C
 		if err := local.WriteZip(filepath.Join(pathFrontend, ct.id), ct.zipPkg); err != nil {
 			return fmt.Errorf("unable to save template '%s' to disk: %s", ct.id, err)
 		}
-		successfulTemplateWrites = append(successfulTemplateWrites,
-			fmt.Sprintf("[%s] %s", ct.id, filepath.Join(pathRelative, local.FrontendPath, ct.id, "README.md")),
-		)
+		readmeFile := ""
+		if matches, err := filepath.Glob(filepath.Join(pathRelative, local.FrontendPath, ct.id, "README.*")); err == nil && len(matches) == 1 {
+			readmeFile = matches[0]
+		}
+		successfulTemplateWrites = append(successfulTemplateWrites, fmt.Sprintf("[%s] %s", ct.id, readmeFile))
 	}
 
 	ui.Print(terminal.NewTextLog("Successfully pulled app down: %s", pathRelative))


### PR DESCRIPTION
```
jamie.anderson@M-C02F15DGMD6M mongodb % ./realm-cli-next --profile prod pull --template xamarin.todo --remote application-4-ibxpm --project 618d73185dec6736635bf41a
Saved app to disk
Successfully pulled app down: Application-4
Successfully saved template(s) to disk
  [xamarin.todo] Application-4/frontend/xamarin.todo/README.md
  Navigate to the saved directory to view directions on how to run the template app(s)
```