### PR TITLE
REALMC-12113: Add DefaultRule to exported app structure

### DIFF
--- a/internal/local/app_test.go
+++ b/internal/local/app_test.go
@@ -720,7 +720,6 @@ exports = function({ query }) {
 				{
 					"database":   "foo",
 					"collection": "bar",
-					"name":       "foo.bar",
 				},
 			},
 		},

--- a/internal/local/app_test.go
+++ b/internal/local/app_test.go
@@ -698,6 +698,32 @@ exports = function({ query }) {
 				},
 			},
 		},
+		{
+			Config: map[string]interface{}{
+				"type":    "mongodb",
+				"name":    "mdbSvc",
+				"config":  map[string]interface{}{},
+				"version": float64(1),
+			},
+			DefaultRule: map[string]interface{}{
+				"roles": []interface{}{
+					map[string]interface{}{
+						"name": "owner",
+						"apply_when": map[string]interface{}{
+							"userId": "%%user.id",
+						},
+						"read": true,
+					},
+				},
+			},
+			Rules: []map[string]interface{}{
+				{
+					"database":   "foo",
+					"collection": "bar",
+					"name":       "foo.bar",
+				},
+			},
+		},
 	},
 	Triggers: []map[string]interface{}{
 		{

--- a/internal/local/data.go
+++ b/internal/local/data.go
@@ -65,6 +65,7 @@ const (
 	NameDataSources      = "data_sources"
 	NameHTTPEndpoints    = "http_endpoints"
 	NameIncomingWebhooks = "incoming_webhooks"
+	NameDefaultRule      = "default_rule"
 	NameRules            = "rules"
 	NameSchema           = "schema"
 	NameSchemas          = "schemas"
@@ -100,6 +101,7 @@ var (
 	FileProviders      = File{NameProviders, extJSON}
 
 	// data sources
+	FileDefaultRule   = File{NameDefaultRule, extJSON}
 	FileRules         = File{NameRules, extJSON}
 	FileSchema        = File{NameSchema, extJSON}
 	FileRelationships = File{NameRelationships, extJSON}

--- a/internal/local/structure_test.go
+++ b/internal/local/structure_test.go
@@ -1,8 +1,10 @@
 package local
 
 import (
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	u "github.com/10gen/realm-cli/internal/utils/test"
@@ -337,9 +339,58 @@ exports = function({ query }) {
     }
 }
 `, string(rule))
+
+		_, err = ioutil.ReadFile(filepath.Join(tmpDir, NameServices, "http", FileDefaultRule.String()))
+		assert.NotNil(t, err)
+		assert.True(t, strings.Contains(err.Error(), "no such file or directory"),
+			fmt.Sprintf("expected 'no such file or directory' in error message but got '%s'", err.Error()))
 	})
 
 	t.Run("should write services with v2 Rules to disk", func(t *testing.T) {
+		mdbSvcName := "mdbSvc"
+		data := []ServiceStructure{{
+			Config: map[string]interface{}{
+				"name":    mdbSvcName,
+				"type":    "mongodb",
+				"config":  map[string]interface{}{},
+				"version": 1,
+			},
+			Rules: []map[string]interface{}{
+				{
+					"database":   "foo",
+					"collection": "bar",
+				},
+			},
+		}}
+
+		err := writeServices(tmpDir, data)
+		assert.Nil(t, err)
+
+		config, err := ioutil.ReadFile(filepath.Join(tmpDir, NameServices, mdbSvcName, FileConfig.String()))
+		assert.Nil(t, err)
+		assert.Equal(t, `{
+    "config": {},
+    "name": "mdbSvc",
+    "type": "mongodb",
+    "version": 1
+}
+`, string(config))
+
+		_, err = ioutil.ReadFile(filepath.Join(tmpDir, NameServices, mdbSvcName, FileDefaultRule.String()))
+		assert.NotNil(t, err)
+		assert.True(t, strings.Contains(err.Error(), "no such file or directory"),
+			fmt.Sprintf("expected 'no such file or directory' in error message but got '%s'", err.Error()))
+
+		rule, err := ioutil.ReadFile(filepath.Join(tmpDir, NameServices, mdbSvcName, NameRules, "foo.bar"+extJSON))
+		assert.Nil(t, err)
+		assert.Equal(t, `{
+    "collection": "bar",
+    "database": "foo"
+}
+`, string(rule))
+	})
+
+	t.Run("should write services with v2 Rules and a default rule to disk", func(t *testing.T) {
 		mdbSvcName := "mdbSvc"
 		data := []ServiceStructure{{
 			Config: map[string]interface{}{
@@ -361,7 +412,6 @@ exports = function({ query }) {
 			},
 			Rules: []map[string]interface{}{
 				{
-					"name":       "foo.bar",
 					"database":   "foo",
 					"collection": "bar",
 				},
@@ -400,8 +450,7 @@ exports = function({ query }) {
 		assert.Nil(t, err)
 		assert.Equal(t, `{
     "collection": "bar",
-    "database": "foo",
-    "name": "foo.bar"
+    "database": "foo"
 }
 `, string(rule))
 	})

--- a/internal/local/structure_v2.go
+++ b/internal/local/structure_v2.go
@@ -585,16 +585,18 @@ func writeDataSources(rootDir string, dataSources []DataSourceStructure) error {
 		}
 
 		// Default Rule
-		defaultRule, err := MarshalJSON(ds.DefaultRule)
-		if err != nil {
-			return err
-		}
-		if err := WriteFile(
-			filepath.Join(dir, name, FileDefaultRule.String()),
-			0666,
-			bytes.NewReader(defaultRule),
-		); err != nil {
-			return err
+		if ds.DefaultRule != nil {
+			defaultRule, err := MarshalJSON(ds.DefaultRule)
+			if err != nil {
+				return err
+			}
+			if err := WriteFile(
+				filepath.Join(dir, name, FileDefaultRule.String()),
+				0666,
+				bytes.NewReader(defaultRule),
+			); err != nil {
+				return err
+			}
 		}
 
 		// Rules

--- a/internal/local/testdata/data_sources/data_sources/mongodb-atlas/default_rule.json
+++ b/internal/local/testdata/data_sources/data_sources/mongodb-atlas/default_rule.json
@@ -1,0 +1,11 @@
+{
+  "roles": [
+    {
+      "name": "owner",
+      "apply_when": {
+        "userId": "%%user.id"
+      },
+      "read": true
+    }
+  ]
+}

--- a/internal/local/testdata/full_project/services/mdbSvc/config.json
+++ b/internal/local/testdata/full_project/services/mdbSvc/config.json
@@ -1,0 +1,6 @@
+{
+    "name": "mdbSvc",
+    "type": "mongodb",
+    "config": {},
+    "version": 1
+}

--- a/internal/local/testdata/full_project/services/mdbSvc/default_rule.json
+++ b/internal/local/testdata/full_project/services/mdbSvc/default_rule.json
@@ -1,0 +1,11 @@
+{
+  "roles": [
+    {
+      "name": "owner",
+      "apply_when": {
+        "userId": "%%user.id"
+      },
+      "read": true
+    }
+  ]
+}

--- a/internal/local/testdata/full_project/services/mdbSvc/rules/foo.bar.json
+++ b/internal/local/testdata/full_project/services/mdbSvc/rules/foo.bar.json
@@ -1,0 +1,5 @@
+{
+  "database": "foo",
+  "collection": "bar",
+  "name": "foo.bar"
+}

--- a/internal/local/testdata/full_project/services/mdbSvc/rules/foo.bar.json
+++ b/internal/local/testdata/full_project/services/mdbSvc/rules/foo.bar.json
@@ -1,5 +1,4 @@
 {
   "database": "foo",
-  "collection": "bar",
-  "name": "foo.bar"
+  "collection": "bar"
 }


### PR DESCRIPTION
## Changes
- Add the Default Rule to the exported app structure for App Structure V1 and V2
- Write and parse the default rule to/from the Data Sources directory for App Structure V2
- Write and parse the default rule to/from the Services directory for App Structure V1