### PR TITLE
REALMC-13094: fetch all available groups from Atlas Public API

### DIFF
--- a/internal/cli/inputs.go
+++ b/internal/cli/inputs.go
@@ -117,7 +117,7 @@ func ResolveApp(ui terminal.UI, client realm.Client, opts AppOptions) (realm.App
 
 // ResolveGroupID will use the provided MongoDB Cloud Atlas client to resolve the user's group id
 func ResolveGroupID(ui terminal.UI, client atlas.Client) (string, error) {
-	groups, groupsErr := client.Groups()
+	groups, groupsErr := atlas.AllGroups(client)
 	if groupsErr != nil {
 		return "", groupsErr
 	}

--- a/internal/cli/inputs_test.go
+++ b/internal/cli/inputs_test.go
@@ -239,14 +239,14 @@ func TestResolveGroupID(t *testing.T) {
 
 	for _, tc := range []struct {
 		description     string
-		groups          []atlas.Group
+		groups          atlas.Groups
 		procedure       func(c *expect.Console)
 		expectedGroupID string
 		expectedErr     error
 	}{
 		{
 			description:     "should return the single group found from the client call",
-			groups:          []atlas.Group{testGroup},
+			groups:          atlas.Groups{Results: []atlas.Group{testGroup}},
 			procedure:       func(c *expect.Console) {},
 			expectedGroupID: testGroup.ID,
 		},
@@ -257,7 +257,7 @@ func TestResolveGroupID(t *testing.T) {
 		},
 		{
 			description: "should prompt user to select a group when more than one is returned from the client call",
-			groups:      []atlas.Group{testGroup, testGroup},
+			groups:      atlas.Groups{Results: []atlas.Group{testGroup, testGroup}},
 			procedure: func(c *expect.Console) {
 				c.ExpectString("Atlas Project")
 				c.SendLine("egg")
@@ -267,7 +267,7 @@ func TestResolveGroupID(t *testing.T) {
 	} {
 		t.Run(tc.description, func(t *testing.T) {
 			atlasClient := mock.AtlasClient{}
-			atlasClient.GroupsFn = func() ([]atlas.Group, error) {
+			atlasClient.GroupsFn = func(url string, useBaseURL bool) (atlas.Groups, error) {
 				return tc.groups, nil
 			}
 
@@ -292,8 +292,8 @@ func TestResolveGroupID(t *testing.T) {
 
 	t.Run("should return the client error if one occurs", func(t *testing.T) {
 		atlasClient := mock.AtlasClient{}
-		atlasClient.GroupsFn = func() ([]atlas.Group, error) {
-			return nil, errors.New("something bad happened")
+		atlasClient.GroupsFn = func(url string, useBaseURL bool) (atlas.Groups, error) {
+			return atlas.Groups{}, errors.New("something bad happened")
 		}
 
 		_, err := cli.ResolveGroupID(nil, atlasClient)

--- a/internal/cloud/atlas/client.go
+++ b/internal/cloud/atlas/client.go
@@ -22,7 +22,7 @@ const (
 
 // Client is a MongoDB Cloud Atlas client
 type Client interface {
-	Groups() ([]Group, error)
+	Groups(url string, useBaseURL bool) (Groups, error)
 
 	Clusters(groupID string) ([]Cluster, error)
 	ServerlessInstances(groupID string) ([]ServerlessInstance, error)
@@ -49,8 +49,12 @@ type client struct {
 	transport *digest.Transport
 }
 
-func (c *client) do(method, path string, options api.RequestOptions) (*http.Response, error) {
-	req, reqErr := http.NewRequest(method, c.baseURL+path, options.Body)
+func (c *client) doWithBaseURL(method, path string, options api.RequestOptions) (*http.Response, error) {
+	return c.doWithURL(method, c.baseURL+path, options)
+}
+
+func (c *client) doWithURL(method, url string, options api.RequestOptions) (*http.Response, error) {
+	req, reqErr := http.NewRequest(method, url, options.Body)
 	if reqErr != nil {
 		return nil, reqErr
 	}

--- a/internal/cloud/atlas/clusters.go
+++ b/internal/cloud/atlas/clusters.go
@@ -24,7 +24,7 @@ const (
 )
 
 func (c *client) Clusters(groupID string) ([]Cluster, error) {
-	res, err := c.do(
+	res, err := c.doWithBaseURL(
 		http.MethodGet,
 		fmt.Sprintf(clustersPattern, groupID),
 		api.RequestOptions{},

--- a/internal/cloud/atlas/data_lakes.go
+++ b/internal/cloud/atlas/data_lakes.go
@@ -19,7 +19,7 @@ const (
 )
 
 func (c *client) Datalakes(groupID string) ([]Datalake, error) {
-	res, err := c.do(
+	res, err := c.doWithBaseURL(
 		http.MethodGet,
 		fmt.Sprintf(datalakesPattern, groupID),
 		api.RequestOptions{},

--- a/internal/cloud/atlas/serverless_instances.go
+++ b/internal/cloud/atlas/serverless_instances.go
@@ -24,7 +24,7 @@ const (
 )
 
 func (c *client) ServerlessInstances(groupID string) ([]ServerlessInstance, error) {
-	res, err := c.do(
+	res, err := c.doWithBaseURL(
 		http.MethodGet,
 		fmt.Sprintf(serverlessInstancesPattern, groupID),
 		api.RequestOptions{},

--- a/internal/cloud/atlas/status.go
+++ b/internal/cloud/atlas/status.go
@@ -13,7 +13,7 @@ var (
 )
 
 func (c *client) Status() error {
-	res, err := c.do(http.MethodGet, publicAPI, api.RequestOptions{})
+	res, err := c.doWithBaseURL(http.MethodGet, publicAPI, api.RequestOptions{})
 	if err != nil {
 		return ErrServerUnavailable
 	}

--- a/internal/commands/app/create_test.go
+++ b/internal/commands/app/create_test.go
@@ -229,8 +229,8 @@ Check out your app: cd ./test-app && realm-cli app describe
 			return nil
 		}
 		ac := mock.AtlasClient{}
-		ac.GroupsFn = func() ([]atlas.Group, error) {
-			return []atlas.Group{{ID: "123"}}, nil
+		ac.GroupsFn = func(url string, useBaseURL bool) (atlas.Groups, error) {
+			return atlas.Groups{Results: []atlas.Group{{ID: "123"}}}, nil
 		}
 
 		cmd := &CommandCreate{createInputs{newAppInputs: newAppInputs{
@@ -1011,8 +1011,8 @@ Check out your app: cd ./test-app && realm-cli app describe
 			description: "should error when resolving groupID when project is not set",
 			clients: cli.Clients{
 				Atlas: mock.AtlasClient{
-					GroupsFn: func() ([]atlas.Group, error) {
-						return nil, errors.New("atlas client error")
+					GroupsFn: func(url string, useBaseURL bool) (atlas.Groups, error) {
+						return atlas.Groups{}, errors.New("atlas client error")
 					},
 				},
 			},
@@ -1094,8 +1094,8 @@ Check out your app: cd ./test-app && realm-cli app describe
 					},
 				},
 				Atlas: mock.AtlasClient{
-					GroupsFn: func() ([]atlas.Group, error) {
-						return []atlas.Group{{ID: "123"}}, nil
+					GroupsFn: func(url string, useBaseURL bool) (atlas.Groups, error) {
+						return atlas.Groups{Results: []atlas.Group{{ID: "123"}}}, nil
 					},
 				},
 			},

--- a/internal/commands/pull/inputs_test.go
+++ b/internal/commands/pull/inputs_test.go
@@ -152,8 +152,8 @@ func TestPullInputsResolveRemoteApp(t *testing.T) {
 		i := inputs{RemoteApp: "some-app"}
 
 		var atlasClient mock.AtlasClient
-		atlasClient.GroupsFn = func() ([]atlas.Group, error) {
-			return []atlas.Group{{ID: "group-id", Name: "group-name"}}, nil
+		atlasClient.GroupsFn = func(url string, useBaseURL bool) (atlas.Groups, error) {
+			return atlas.Groups{Results: []atlas.Group{{ID: "group-id", Name: "group-name"}}}, nil
 		}
 
 		var realmClient mock.RealmClient
@@ -193,8 +193,8 @@ func TestPullInputsResolveRemoteApp(t *testing.T) {
 		var i inputs
 
 		var atlasClient mock.AtlasClient
-		atlasClient.GroupsFn = func() ([]atlas.Group, error) {
-			return nil, errors.New("something bad happened")
+		atlasClient.GroupsFn = func(url string, useBaseURL bool) (atlas.Groups, error) {
+			return atlas.Groups{}, errors.New("something bad happened")
 		}
 
 		_, err := i.resolveRemoteApp(nil, cli.Clients{Atlas: atlasClient})

--- a/internal/commands/push/command_test.go
+++ b/internal/commands/push/command_test.go
@@ -63,8 +63,8 @@ func TestPushHandler(t *testing.T) {
 
 	t.Run("should return an error if the command fails to resolve group id", func(t *testing.T) {
 		var atlasClient mock.AtlasClient
-		atlasClient.GroupsFn = func() ([]atlas.Group, error) {
-			return nil, errors.New("something bad happened")
+		atlasClient.GroupsFn = func(url string, useBaseURL bool) (atlas.Groups, error) {
+			return atlas.Groups{}, errors.New("something bad happened")
 		}
 
 		var realmClient mock.RealmClient
@@ -836,9 +836,9 @@ Successfully pushed app up: eggcorn-abcde
 			t.Run(tc.description, func(t *testing.T) {
 				var atlasClient mock.AtlasClient
 				var calledGroups bool
-				atlasClient.GroupsFn = func() ([]atlas.Group, error) {
+				atlasClient.GroupsFn = func(url string, useBaseURL bool) (atlas.Groups, error) {
 					calledGroups = true
-					return []atlas.Group{{ID: "groupID", Name: "groupName"}}, nil
+					return atlas.Groups{Results: []atlas.Group{{ID: "groupID", Name: "groupName"}}}, nil
 				}
 
 				var realmClient mock.RealmClient
@@ -928,9 +928,9 @@ Deployed app is identical to proposed version, nothing to do
 
 		var atlasClient mock.AtlasClient
 		var groupsCalled bool
-		atlasClient.GroupsFn = func() ([]atlas.Group, error) {
+		atlasClient.GroupsFn = func(url string, useBaseURL bool) (atlas.Groups, error) {
 			groupsCalled = true
-			return []atlas.Group{{ID: "groupID", Name: "groupName"}}, nil
+			return atlas.Groups{Results: []atlas.Group{{ID: "groupID", Name: "groupName"}}}, nil
 		}
 
 		cmd := &Command{inputs{LocalPath: "testdata/project-meta", DryRun: true}}

--- a/internal/utils/test/mock/atlas_client.go
+++ b/internal/utils/test/mock/atlas_client.go
@@ -5,7 +5,7 @@ import "github.com/10gen/realm-cli/internal/cloud/atlas"
 // AtlasClient is a mocked Atlas client
 type AtlasClient struct {
 	atlas.Client
-	GroupsFn              func() ([]atlas.Group, error)
+	GroupsFn              func(url string, useBaseURL bool) (atlas.Groups, error)
 	ClustersFn            func(groupID string) ([]atlas.Cluster, error)
 	ServerlessInstancesFn func(groupID string) ([]atlas.ServerlessInstance, error)
 	DatalakesFn           func(groupID string) ([]atlas.Datalake, error)
@@ -14,11 +14,11 @@ type AtlasClient struct {
 // Groups calls the mocked Groups implementation if provided,
 // otherwise the call falls back to the underlying atlas.Client implementation.
 // NOTE: this may panic if the underlying atlas.Client is left undefined
-func (ac AtlasClient) Groups() ([]atlas.Group, error) {
+func (ac AtlasClient) Groups(url string, useBaseURL bool) (atlas.Groups, error) {
 	if ac.GroupsFn != nil {
-		return ac.GroupsFn()
+		return ac.GroupsFn(url, useBaseURL)
 	}
-	return ac.Client.Groups()
+	return ac.Client.Groups(url, useBaseURL)
 }
 
 // Clusters calls the mocked Clusters implementation if provided,


### PR DESCRIPTION
In terms of testing, it looks like we only have access to 1 group. Is it possible to add more groups? at least 1 so we can pass in a `itemsPerPage = 1` query param to force the fetch for more groups: https://github.com/10gen/realm-cli/blob/3795c0740d25d61bed4de823807e7351fcd06bbf/internal/utils/test/test.go#L39


ex
for testing manually, I passed `api.RequestOptions{Query: map[string]string{"itemsPerPage":"1"}}` for profiles in which I had multiple groups and 'printed' the 'next link' to the terminal

```
jamie.anderson@M-C02F15DGMD6M mongodb % ./realm-cli-next --profile dev pull
NEXT LINK: &{https://cloud-dev.mongodb.com/api/public/v1.0/groups?itemsPerPage=1&pageNum=2 next}
NEXT LINK: &{https://cloud-dev.mongodb.com/api/public/v1.0/groups?itemsPerPage=1&pageNum=3 next}
? Atlas Project  [Use arrows to move, type to filter]
> Project - 621e79993ab79a6b79c2b6d9
  Project0 - 60ad6d0cb54e70155ff5ac5a
  Project1 - 60b125e4090b4831f3287555
```
