### PR TITLE
BAAS-14012: Skip setting Data API Config run_as_system=true in import/export round trip tests

### DIFF
--- a/internal/cloud/realm/dependencies_test.go
+++ b/internal/cloud/realm/dependencies_test.go
@@ -33,7 +33,7 @@ func TestRealmDependencies(t *testing.T) {
 			uploadPath := filepath.Join(wd, "testdata/dependencies_upload.zip")
 
 			_, err = client.DependenciesStatus(groupID, app.ID)
-			assert.Equal(t, realm.ServerError{Message: "dependency installation not found"}, err)
+			assert.Nil(t, err)
 
 			assert.Nil(t, client.ImportDependencies(groupID, app.ID, uploadPath))
 
@@ -118,7 +118,7 @@ func TestRealmDependencies(t *testing.T) {
 			uploadPath := filepath.Join(wd, "testdata/package.json")
 
 			_, err = client.DependenciesStatus(groupID, app.ID)
-			assert.Equal(t, realm.ServerError{Message: "dependency installation not found"}, err)
+			assert.Nil(t, err)
 
 			assert.Nil(t, client.ImportDependencies(groupID, app.ID, uploadPath))
 

--- a/internal/cloud/realm/import_export_test.go
+++ b/internal/cloud/realm/import_export_test.go
@@ -277,7 +277,6 @@ console.log('got heem!');
 		},
 		DataAPIConfig: map[string]interface{}{
 			"versions":                     []interface{}{"v1"},
-			"run_as_system":                true,
 			"run_as_user_id":               "",
 			"run_as_user_id_script_source": "exports = function () { return 'goofygoof'; }",
 			"disabled":                     false,
@@ -487,7 +486,6 @@ func appDataV2(app realm.App) local.AppDataV2 {
 		},
 		DataAPIConfig: map[string]interface{}{
 			"versions":                     []interface{}{"v1"},
-			"run_as_system":                true,
 			"run_as_user_id":               "",
 			"run_as_user_id_script_source": "exports = function () { return 'goofygoof'; }",
 			"disabled":                     false,


### PR DESCRIPTION
Should go in after 10gen/baas#6766 gets merged, the tests will fail in the meantime