### PR TITLE
BAAS-13288 add provider region to app create flow

### DIFF
--- a/internal/cloud/realm/app.go
+++ b/internal/cloud/realm/app.go
@@ -19,6 +19,7 @@ const (
 // AppMeta is Realm application metadata
 type AppMeta struct {
 	Location        Location        `json:"location,omitempty"`
+	ProviderRegion  ProviderRegion  `json:"provider_region,omitempty"`
 	DeploymentModel DeploymentModel `json:"deployment_model,omitempty"`
 	Environment     Environment     `json:"environment,omitempty"`
 	Template        string          `json:"template_id,omitempty"`

--- a/internal/cloud/realm/function_test.go
+++ b/internal/cloud/realm/function_test.go
@@ -41,6 +41,7 @@ func TestFunctions(t *testing.T) {
 				ID:              app.ClientAppID,
 				Name:            app.Name,
 				Location:        app.Location,
+				ProviderRegion:  app.ProviderRegion,
 				DeploymentModel: app.DeploymentModel,
 				Functions: local.FunctionsStructure{
 					Configs: []map[string]interface{}{
@@ -87,6 +88,7 @@ func TestAppDebugExecuteFunction(t *testing.T) {
 			ID:              app.ClientAppID,
 			Name:            app.Name,
 			Location:        app.Location,
+			ProviderRegion:  app.ProviderRegion,
 			DeploymentModel: app.DeploymentModel,
 			Functions: local.FunctionsStructure{
 				Configs: []map[string]interface{}{

--- a/internal/cloud/realm/import_export_test.go
+++ b/internal/cloud/realm/import_export_test.go
@@ -92,6 +92,7 @@ func TestRealmImport20210101(t *testing.T) {
 			ID:              app.ClientAppID,
 			Name:            app.Name,
 			Location:        app.Location,
+			ProviderRegion:  app.ProviderRegion,
 			DeploymentModel: app.DeploymentModel,
 			Services: []local.ServiceStructure{
 				{
@@ -157,6 +158,7 @@ func TestRealmImportLegacy(t *testing.T) {
 				ID:              app.ClientAppID,
 				Name:            app.Name,
 				Location:        app.Location,
+				ProviderRegion:  app.ProviderRegion,
 				DeploymentModel: app.DeploymentModel,
 				Services: []local.ServiceStructure{
 					{
@@ -212,6 +214,7 @@ func appDataV1(configVersion realm.AppConfigVersion, app realm.App) local.AppDat
 		ID:                   app.ClientAppID,
 		Name:                 app.Name,
 		Location:             app.Location,
+		ProviderRegion:       app.ProviderRegion,
 		DeploymentModel:      app.DeploymentModel,
 		Sync:                 map[string]interface{}{"development_mode_enabled": false},
 		CustomUserDataConfig: map[string]interface{}{"enabled": false},
@@ -295,6 +298,7 @@ func appDataV2(app realm.App) local.AppDataV2 {
 		ID:                    app.ClientAppID,
 		Name:                  app.Name,
 		Location:              app.Location,
+		ProviderRegion:        app.ProviderRegion,
 		DeploymentModel:       app.DeploymentModel,
 		AllowedRequestOrigins: []string{"http://localhost:8080"},
 		Environments: map[string]map[string]interface{}{

--- a/internal/cloud/realm/realm.go
+++ b/internal/cloud/realm/realm.go
@@ -256,11 +256,12 @@ func isValidLocation(l Location) bool {
 
 // Set of supported cloud providers
 const (
-	CloudProviderAWS = "aws"
-	// TODOO CloudProviderGCP   = "gcp"
+	CloudProviderAWS   = "aws"
 	CloudProviderAzure = "azure"
+	CloudProviderGCP   = "gcp"
 )
 
+// TODO(BAAS-xxxx) add ticket number here if we want to do gcp separately
 var CloudProviderValues = []string{CloudProviderAWS, CloudProviderAzure}
 
 // The provider regions that we currently support
@@ -325,6 +326,7 @@ type ProviderRegion string
 // String returns the ProviderRegion display
 func (p ProviderRegion) String() string { return string(p) }
 
+// Label returns the ProviderRegion display without the cloud provider
 func (p ProviderRegion) Label() string {
 	return p.String()[strings.IndexByte(p.String(), '-')+1:]
 }

--- a/internal/cloud/realm/realm.go
+++ b/internal/cloud/realm/realm.go
@@ -297,6 +297,7 @@ const (
 // location values. This is necessary as the backing clusters no longer match our current
 // operating regions. In order to do backing cluster storage, we must leverage a lookup here.
 var ProviderRegionToLocation = map[ProviderRegion]Location{
+	ProviderRegionEmpty:              LocationVirginia,
 	AWSProviderRegionUSEast1:         LocationVirginia,
 	AWSProviderRegionUSWest2:         LocationOregon,
 	AWSProviderRegionEUCentral1:      LocationFrankfurt,

--- a/internal/cloud/realm/user_ext_test.go
+++ b/internal/cloud/realm/user_ext_test.go
@@ -35,6 +35,7 @@ func TestRealmUsers(t *testing.T) {
 			ID:              app.ClientAppID,
 			Name:            app.Name,
 			Location:        app.Location,
+			ProviderRegion:  app.ProviderRegion,
 			DeploymentModel: app.DeploymentModel,
 			Auth: local.AuthStructure{
 				Providers: map[string]interface{}{

--- a/internal/commands/app/create.go
+++ b/internal/commands/app/create.go
@@ -52,6 +52,7 @@ func (cmd *CommandCreate) Flags() []flags.Flag {
 		},
 		nameFlag(&cmd.inputs.Name),
 		locationFlag(&cmd.inputs.Location),
+		providerRegionFlag(&cmd.inputs.ProviderRegion),
 		deploymentModelFlag(&cmd.inputs.DeploymentModel),
 		environmentFlag(&cmd.inputs.Environment),
 		flags.StringSliceFlag{
@@ -273,6 +274,7 @@ func (cmd CommandCreate) handleCreateApp(
 
 	createAppMetadata := realm.AppMeta{
 		Location:        cmd.inputs.Location,
+		ProviderRegion:  cmd.inputs.ProviderRegion,
 		DeploymentModel: cmd.inputs.DeploymentModel,
 		Environment:     cmd.inputs.Environment,
 	}
@@ -293,6 +295,7 @@ func (cmd CommandCreate) handleCreateApp(
 			appRealm.ClientAppID,
 			cmd.inputs.Name,
 			cmd.inputs.Location,
+			cmd.inputs.ProviderRegion,
 			cmd.inputs.DeploymentModel,
 			cmd.inputs.Environment,
 			cmd.inputs.ConfigVersion,
@@ -432,6 +435,7 @@ func (cmd CommandCreate) handleCreateTemplateApp(
 	}
 	createAppMetadata := realm.AppMeta{
 		Location:        cmd.inputs.Location,
+		ProviderRegion:  cmd.inputs.ProviderRegion,
 		DeploymentModel: cmd.inputs.DeploymentModel,
 		Environment:     cmd.inputs.Environment,
 		Template:        cmd.inputs.Template,

--- a/internal/commands/app/create_inputs.go
+++ b/internal/commands/app/create_inputs.go
@@ -78,12 +78,14 @@ func (i *createInputs) Resolve(profile *user.Profile, ui terminal.UI) error {
 		if i.DeploymentModel == realm.DeploymentModelEmpty {
 			i.DeploymentModel = flagDeploymentModelDefault
 		}
-		if i.Location == realm.LocationEmpty {
-			i.Location = flagLocationDefault
-		}
+
 		if i.ProviderRegion == realm.ProviderRegionEmpty {
 			i.ProviderRegion = flagProviderRegionDefault
 		}
+		if i.Location == realm.LocationEmpty {
+			i.Location = realm.ProviderRegionToLocation[i.ProviderRegion]
+		}
+
 		if i.ConfigVersion == realm.AppConfigVersionZero {
 			i.ConfigVersion = realm.DefaultAppConfigVersion
 		}
@@ -394,13 +396,15 @@ func (i createInputs) args(omitDryRun bool) []flags.Arg {
 	if i.Template != "" {
 		args = append(args, flags.Arg{flagTemplate, i.Template})
 	}
-	if i.Location != flagLocationDefault {
-		args = append(args, flags.Arg{flagLocation, i.Location.String()})
-	}
-	// TODOO: We need to figure out what to do when location is provided but provider reigon is not
-	if i.ProviderRegion != "" {
+
+	if i.ProviderRegion != flagProviderRegionDefault && i.ProviderRegion != "" {
 		args = append(args, flags.Arg{flagProviderRegion, i.ProviderRegion.String()})
 	}
+
+	if i.Location != flagLocationDefault && i.ProviderRegion == "" {
+		args = append(args, flags.Arg{flagLocation, i.Location.String()})
+	}
+
 	if i.DeploymentModel != flagDeploymentModelDefault {
 		args = append(args, flags.Arg{flagDeploymentModel, i.DeploymentModel.String()})
 	}

--- a/internal/commands/app/create_inputs.go
+++ b/internal/commands/app/create_inputs.go
@@ -67,7 +67,6 @@ type configDatalake struct {
 	DatalakeName string `json:"dataLakeName"`
 }
 
-// TODOO
 func (i *createInputs) Resolve(profile *user.Profile, ui terminal.UI) error {
 	if i.RemoteApp == "" {
 		if i.Name == "" {

--- a/internal/commands/app/create_inputs.go
+++ b/internal/commands/app/create_inputs.go
@@ -67,6 +67,7 @@ type configDatalake struct {
 	DatalakeName string `json:"dataLakeName"`
 }
 
+// TODOO
 func (i *createInputs) Resolve(profile *user.Profile, ui terminal.UI) error {
 	if i.RemoteApp == "" {
 		if i.Name == "" {
@@ -79,6 +80,9 @@ func (i *createInputs) Resolve(profile *user.Profile, ui terminal.UI) error {
 		}
 		if i.Location == realm.LocationEmpty {
 			i.Location = flagLocationDefault
+		}
+		if i.ProviderRegion == realm.ProviderRegionEmpty {
+			i.ProviderRegion = flagProviderRegionDefault
 		}
 		if i.ConfigVersion == realm.AppConfigVersionZero {
 			i.ConfigVersion = realm.DefaultAppConfigVersion
@@ -392,6 +396,10 @@ func (i createInputs) args(omitDryRun bool) []flags.Arg {
 	}
 	if i.Location != flagLocationDefault {
 		args = append(args, flags.Arg{flagLocation, i.Location.String()})
+	}
+	// TODOO: We need to figure out what to do when location is provided but provider reigon is not
+	if i.ProviderRegion != "" {
+		args = append(args, flags.Arg{flagProviderRegion, i.ProviderRegion.String()})
 	}
 	if i.DeploymentModel != flagDeploymentModelDefault {
 		args = append(args, flags.Arg{flagDeploymentModel, i.DeploymentModel.String()})

--- a/internal/commands/app/create_inputs_test.go
+++ b/internal/commands/app/create_inputs_test.go
@@ -23,7 +23,6 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
-// TODOO
 func TestAppCreateInputsResolve(t *testing.T) {
 	t.Run("with no flags set should prompt for just name and set deployment model location provider region and environment to defaults", func(t *testing.T) {
 		profile := mock.NewProfile(t)

--- a/internal/commands/app/create_inputs_test.go
+++ b/internal/commands/app/create_inputs_test.go
@@ -104,24 +104,6 @@ func TestAppCreateInputsResolve(t *testing.T) {
 		assert.Equal(t, realm.AWSProviderRegionUSWest2, inputs.ProviderRegion)
 		assert.Equal(t, realm.EnvironmentDevelopment, inputs.Environment)
 	})
-
-	t.Run("with no provider region set should not set from location", func(t *testing.T) {
-		profile := mock.NewProfile(t)
-
-		inputs := createInputs{newAppInputs: newAppInputs{
-			Name:            "test-app",
-			DeploymentModel: realm.DeploymentModelLocal,
-			Location:        realm.LocationOregon,
-			Environment:     realm.EnvironmentDevelopment,
-		}}
-		assert.Nil(t, inputs.Resolve(profile, nil))
-
-		assert.Equal(t, "test-app", inputs.Name)
-		assert.Equal(t, realm.DeploymentModelLocal, inputs.DeploymentModel)
-		assert.Equal(t, realm.LocationOregon, inputs.Location)
-		assert.Equal(t, realm.ProviderRegionEmpty, inputs.ProviderRegion)
-		assert.Equal(t, realm.EnvironmentDevelopment, inputs.Environment)
-	})
 }
 
 func TestAppCreateInputsResolveName(t *testing.T) {

--- a/internal/commands/app/create_test.go
+++ b/internal/commands/app/create_test.go
@@ -22,6 +22,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
+// TODOO
 func TestAppCreateHandler(t *testing.T) {
 	t.Run("should create minimal project when no remote type is specified", func(t *testing.T) {
 		profile, teardown := mock.NewProfileFromTmpDir(t, "app_create_test")
@@ -51,6 +52,7 @@ func TestAppCreateHandler(t *testing.T) {
 			Name:            "test-app",
 			Project:         "123",
 			Location:        realm.LocationVirginia,
+			ProviderRegion:  realm.AWSProviderRegionUSEast1,
 			DeploymentModel: realm.DeploymentModelGlobal,
 			ConfigVersion:   realm.DefaultAppConfigVersion,
 		}}}
@@ -67,6 +69,7 @@ func TestAppCreateHandler(t *testing.T) {
 			ID:              "test-app-abcde",
 			Name:            "test-app",
 			Location:        realm.LocationVirginia,
+			ProviderRegion:  realm.AWSProviderRegionUSEast1,
 			DeploymentModel: realm.DeploymentModelGlobal,
 			Environments: map[string]map[string]interface{}{
 				"development.json": {
@@ -237,6 +240,7 @@ Check out your app: cd ./test-app && realm-cli app describe
 			Name:            "test-app",
 			Project:         "123",
 			Location:        realm.LocationVirginia,
+			ProviderRegion:  realm.AWSProviderRegionUSEast1,
 			DeploymentModel: realm.DeploymentModelGlobal,
 			ConfigVersion:   realm.DefaultAppConfigVersion,
 		}}}
@@ -254,6 +258,7 @@ Check out your app: cd ./test-app && realm-cli app describe
 			ID:              "test-app-abcde",
 			Name:            "test-app",
 			Location:        realm.LocationVirginia,
+			ProviderRegion:  realm.AWSProviderRegionUSEast1,
 			DeploymentModel: realm.DeploymentModelGlobal,
 			Environments: map[string]map[string]interface{}{
 				"development.json": {
@@ -303,6 +308,7 @@ Check out your app: cd ./test-app && realm-cli app describe
 			ClientAppID: "test-app-abcde",
 			AppMeta: realm.AppMeta{
 				Location:        realm.LocationVirginia,
+				ProviderRegion:  realm.AWSProviderRegionUSEast1,
 				DeploymentModel: realm.DeploymentModelGlobal,
 			},
 		}, createdApp)
@@ -372,6 +378,7 @@ Check out your app: cd ./test-app && realm-cli app describe
 				Name:            "bitcoin-miner",
 				Project:         testApp.GroupID,
 				Location:        realm.LocationIreland,
+				ProviderRegion:  realm.AWSProviderRegionEUWest1,
 				DeploymentModel: realm.DeploymentModelGlobal,
 			},
 			Clusters: []string{"test-cluster"},
@@ -461,6 +468,7 @@ Check out your app: cd ./test-app && realm-cli app describe
 					RemoteApp:       testApp.Name,
 					Project:         tc.groupID,
 					Location:        realm.LocationIreland,
+					ProviderRegion:  realm.AWSProviderRegionEUWest1,
 					DeploymentModel: realm.DeploymentModelGlobal,
 				}}}
 
@@ -473,6 +481,7 @@ Check out your app: cd ./test-app && realm-cli app describe
 					ConfigVersion:   realm.DefaultAppConfigVersion,
 					Name:            testApp.Name,
 					Location:        realm.LocationIreland,
+					ProviderRegion:  realm.AWSProviderRegionEUWest1,
 					DeploymentModel: realm.DeploymentModelGlobal,
 					Auth: local.AuthStructure{
 						CustomUserData: map[string]interface{}{"enabled": false},
@@ -582,6 +591,7 @@ Check out your app: cd ./remote-app && realm-cli app describe
 				Project:         testApp.GroupID,
 				Template:        templateID,
 				Location:        realm.LocationIreland,
+				ProviderRegion:  realm.AWSProviderRegionEUWest1,
 				DeploymentModel: realm.DeploymentModelGlobal,
 			},
 			Clusters: []string{"test-cluster"},
@@ -754,6 +764,7 @@ Check out your app: cd ./remote-app && realm-cli app describe
 						Name:            "test-app",
 						Project:         "123",
 						Location:        realm.LocationVirginia,
+						ProviderRegion:  realm.AWSProviderRegionUSEast1,
 						DeploymentModel: realm.DeploymentModelGlobal,
 						ConfigVersion:   realm.DefaultAppConfigVersion,
 					},
@@ -779,6 +790,7 @@ Check out your app: cd ./remote-app && realm-cli app describe
 				ClientAppID: "test-app-abcde",
 				AppMeta: realm.AppMeta{
 					Location:        realm.LocationVirginia,
+					ProviderRegion:  realm.AWSProviderRegionUSEast1,
 					DeploymentModel: realm.DeploymentModelGlobal,
 				},
 			}, createdApp)
@@ -976,6 +988,7 @@ Check out your app: cd ./test-app && realm-cli app describe
 						Project:         "123",
 						Template:        tc.template,
 						Location:        realm.LocationVirginia,
+						ProviderRegion:  realm.AWSProviderRegionUSEast1,
 						DeploymentModel: realm.DeploymentModelGlobal,
 					},
 					Clusters:                       tc.clusters,
@@ -1181,6 +1194,7 @@ Check out your app: cd ./test-app && realm-cli app describe
 					Name:            "test-app",
 					Template:        tc.template,
 					Location:        realm.LocationVirginia,
+					ProviderRegion:  realm.AWSProviderRegionUSEast1,
 					DeploymentModel: realm.DeploymentModelGlobal,
 				},
 				Clusters:            tc.clusters,
@@ -1296,6 +1310,7 @@ func TestAppCreateCommandDisplay(t *testing.T) {
 					Name:            "test-app",
 					Project:         "123",
 					Location:        realm.LocationVirginia,
+					ProviderRegion:  realm.AWSProviderRegionUSEast1,
 					DeploymentModel: realm.DeploymentModelGlobal,
 				},
 			},
@@ -1304,6 +1319,61 @@ func TestAppCreateCommandDisplay(t *testing.T) {
 	})
 
 	t.Run("should create a command with all inputs", func(t *testing.T) {
+		cmd := &CommandCreate{
+			inputs: createInputs{
+				newAppInputs: newAppInputs{
+					Name:            "test-app",
+					Project:         "123",
+					RemoteApp:       "remote-app",
+					Template:        "palm-pilot.bitcoin-miner",
+					Location:        realm.LocationIreland,
+					ProviderRegion:  realm.AWSProviderRegionEUWest1,
+					DeploymentModel: realm.DeploymentModelLocal,
+				},
+				LocalPath:                      "realm-app",
+				Clusters:                       []string{"Cluster0"},
+				ClusterServiceNames:            []string{"mongodb-atlas"},
+				ServerlessInstances:            []string{"ServerlessInstance0"},
+				ServerlessInstanceServiceNames: []string{"mongodb-atlas-1"},
+				Datalakes:                      []string{"Datalake0"},
+				DatalakeServiceNames:           []string{"mongodb-datalake"},
+				DryRun:                         true,
+			},
+		}
+		assert.Equal(t,
+			cli.Name+" app create --project 123 --name test-app --remote remote-app --local realm-app --template palm-pilot.bitcoin-miner --location IE --provider-region aws-eu-west-1 --deployment-model LOCAL --cluster Cluster0 --cluster-service-name mongodb-atlas --serverless-instance ServerlessInstance0 --serverless-instance-service-name mongodb-atlas-1 --datalake Datalake0 --datalake-service-name mongodb-datalake --dry-run",
+			cmd.display(false),
+		)
+	})
+
+	t.Run("should create a command with no location input", func(t *testing.T) {
+		cmd := &CommandCreate{
+			inputs: createInputs{
+				newAppInputs: newAppInputs{
+					Name:            "test-app",
+					Project:         "123",
+					RemoteApp:       "remote-app",
+					Template:        "palm-pilot.bitcoin-miner",
+					ProviderRegion:  realm.AWSProviderRegionEUWest1,
+					DeploymentModel: realm.DeploymentModelLocal,
+				},
+				LocalPath:                      "realm-app",
+				Clusters:                       []string{"Cluster0"},
+				ClusterServiceNames:            []string{"mongodb-atlas"},
+				ServerlessInstances:            []string{"ServerlessInstance0"},
+				ServerlessInstanceServiceNames: []string{"mongodb-atlas-1"},
+				Datalakes:                      []string{"Datalake0"},
+				DatalakeServiceNames:           []string{"mongodb-datalake"},
+				DryRun:                         true,
+			},
+		}
+		assert.Equal(t,
+			cli.Name+" app create --project 123 --name test-app --remote remote-app --local realm-app --template palm-pilot.bitcoin-miner --provider-region aws-eu-west-1 --deployment-model LOCAL --cluster Cluster0 --cluster-service-name mongodb-atlas --serverless-instance ServerlessInstance0 --serverless-instance-service-name mongodb-atlas-1 --datalake Datalake0 --datalake-service-name mongodb-datalake --dry-run",
+			cmd.display(false),
+		)
+	})
+
+	t.Run("should create a command with no provider region input", func(t *testing.T) {
 		cmd := &CommandCreate{
 			inputs: createInputs{
 				newAppInputs: newAppInputs{
@@ -1338,7 +1408,7 @@ func TestAppCreateCommandDisplay(t *testing.T) {
 					Project:         "123",
 					RemoteApp:       "remote-app",
 					Template:        "palm-pilot.bitcoin-miner",
-					Location:        realm.LocationIreland,
+					ProviderRegion:  realm.AWSProviderRegionEUWest1,
 					DeploymentModel: realm.DeploymentModelLocal,
 				},
 				LocalPath:                      "realm-app",
@@ -1352,7 +1422,7 @@ func TestAppCreateCommandDisplay(t *testing.T) {
 			},
 		}
 		assert.Equal(t,
-			cli.Name+" app create --project 123 --name test-app --remote remote-app --local realm-app --template palm-pilot.bitcoin-miner --location IE --deployment-model LOCAL --cluster Cluster0 --cluster-service-name mongodb-atlas-0 --cluster Cluster1 --cluster-service-name mongodb-atlas-1 --cluster Cluster2 --cluster-service-name mongodb-atlas-2 --serverless-instance ServerlessInstance0 --serverless-instance-service-name mongodb-atlas-3 --serverless-instance ServerlessInstance1 --serverless-instance-service-name mongodb-atlas-4 --serverless-instance ServerlessInstance2 --serverless-instance-service-name mongodb-atlas-5 --datalake Datalake0 --datalake-service-name mongodb-datalake-0 --datalake Datalake1 --datalake-service-name mongodb-datalake-1 --datalake Datalake2 --datalake-service-name mongodb-datalake-2 --dry-run",
+			cli.Name+" app create --project 123 --name test-app --remote remote-app --local realm-app --template palm-pilot.bitcoin-miner --location IE --provider-region aws-eu-west-1 --deployment-model LOCAL --cluster Cluster0 --cluster-service-name mongodb-atlas-0 --cluster Cluster1 --cluster-service-name mongodb-atlas-1 --cluster Cluster2 --cluster-service-name mongodb-atlas-2 --serverless-instance ServerlessInstance0 --serverless-instance-service-name mongodb-atlas-3 --serverless-instance ServerlessInstance1 --serverless-instance-service-name mongodb-atlas-4 --serverless-instance ServerlessInstance2 --serverless-instance-service-name mongodb-atlas-5 --datalake Datalake0 --datalake-service-name mongodb-datalake-0 --datalake Datalake1 --datalake-service-name mongodb-datalake-1 --datalake Datalake2 --datalake-service-name mongodb-datalake-2 --dry-run",
 			cmd.display(false),
 		)
 	})

--- a/internal/commands/app/create_test.go
+++ b/internal/commands/app/create_test.go
@@ -481,7 +481,6 @@ Check out your app: cd ./test-app && realm-cli app describe
 					ConfigVersion:   realm.DefaultAppConfigVersion,
 					Name:            testApp.Name,
 					Location:        realm.LocationIreland,
-					ProviderRegion:  realm.AWSProviderRegionEUWest1,
 					DeploymentModel: realm.DeploymentModelGlobal,
 					Auth: local.AuthStructure{
 						CustomUserData: map[string]interface{}{"enabled": false},
@@ -957,16 +956,16 @@ Check out your app: cd ./test-app && realm-cli app describe
 				Atlas: mock.AtlasClient{
 					ClustersFn: func(groupID string) ([]atlas.Cluster, error) {
 						return []atlas.Cluster{
-							{Name: "cluster0"},
+							{Name: "Cluster0"},
 						}, nil
 					},
 				},
 			},
-			clusters: []string{"cluster0"},
+			clusters: []string{"Cluster0"},
 			displayExpected: func(dir string, cmd *CommandCreate) string {
 				return strings.Join([]string{
 					fmt.Sprintf("A Realm app would be created at %s using the 'palm-pilot.bitcoin-miner' template", dir),
-					"The cluster 'cluster0' would be linked as data source 'mongodb-atlas'",
+					"The cluster 'Cluster0' would be linked as data source 'mongodb-atlas'",
 					"To create this app run: " + cmd.display(true),
 					"",
 				}, "\n")
@@ -1341,7 +1340,7 @@ func TestAppCreateCommandDisplay(t *testing.T) {
 			},
 		}
 		assert.Equal(t,
-			cli.Name+" app create --project 123 --name test-app --remote remote-app --local realm-app --template palm-pilot.bitcoin-miner --location IE --provider-region aws-eu-west-1 --deployment-model LOCAL --cluster Cluster0 --cluster-service-name mongodb-atlas --serverless-instance ServerlessInstance0 --serverless-instance-service-name mongodb-atlas-1 --datalake Datalake0 --datalake-service-name mongodb-datalake --dry-run",
+			cli.Name+" app create --project 123 --name test-app --remote remote-app --local realm-app --template palm-pilot.bitcoin-miner --provider-region aws-eu-west-1 --deployment-model LOCAL --cluster Cluster0 --cluster-service-name mongodb-atlas --serverless-instance ServerlessInstance0 --serverless-instance-service-name mongodb-atlas-1 --datalake Datalake0 --datalake-service-name mongodb-datalake --dry-run",
 			cmd.display(false),
 		)
 	})
@@ -1422,7 +1421,7 @@ func TestAppCreateCommandDisplay(t *testing.T) {
 			},
 		}
 		assert.Equal(t,
-			cli.Name+" app create --project 123 --name test-app --remote remote-app --local realm-app --template palm-pilot.bitcoin-miner --location IE --provider-region aws-eu-west-1 --deployment-model LOCAL --cluster Cluster0 --cluster-service-name mongodb-atlas-0 --cluster Cluster1 --cluster-service-name mongodb-atlas-1 --cluster Cluster2 --cluster-service-name mongodb-atlas-2 --serverless-instance ServerlessInstance0 --serverless-instance-service-name mongodb-atlas-3 --serverless-instance ServerlessInstance1 --serverless-instance-service-name mongodb-atlas-4 --serverless-instance ServerlessInstance2 --serverless-instance-service-name mongodb-atlas-5 --datalake Datalake0 --datalake-service-name mongodb-datalake-0 --datalake Datalake1 --datalake-service-name mongodb-datalake-1 --datalake Datalake2 --datalake-service-name mongodb-datalake-2 --dry-run",
+			cli.Name+" app create --project 123 --name test-app --remote remote-app --local realm-app --template palm-pilot.bitcoin-miner --provider-region aws-eu-west-1 --deployment-model LOCAL --cluster Cluster0 --cluster-service-name mongodb-atlas-0 --cluster Cluster1 --cluster-service-name mongodb-atlas-1 --cluster Cluster2 --cluster-service-name mongodb-atlas-2 --serverless-instance ServerlessInstance0 --serverless-instance-service-name mongodb-atlas-3 --serverless-instance ServerlessInstance1 --serverless-instance-service-name mongodb-atlas-4 --serverless-instance ServerlessInstance2 --serverless-instance-service-name mongodb-atlas-5 --datalake Datalake0 --datalake-service-name mongodb-datalake-0 --datalake Datalake1 --datalake-service-name mongodb-datalake-1 --datalake Datalake2 --datalake-service-name mongodb-datalake-2 --dry-run",
 			cmd.display(false),
 		)
 	})

--- a/internal/commands/app/create_test.go
+++ b/internal/commands/app/create_test.go
@@ -22,7 +22,6 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
-// TODOO
 func TestAppCreateHandler(t *testing.T) {
 	t.Run("should create minimal project when no remote type is specified", func(t *testing.T) {
 		profile, teardown := mock.NewProfileFromTmpDir(t, "app_create_test")

--- a/internal/commands/app/flags.go
+++ b/internal/commands/app/flags.go
@@ -10,7 +10,7 @@ const (
 	flagName            = "name"
 	flagDeploymentModel = "deployment-model"
 	flagLocation        = "location"
-	flagProviderRegion  = "providerRegion"
+	flagProviderRegion  = "provider-region"
 	flagEnvironment     = "environment"
 	flagProject         = "project"
 

--- a/internal/commands/app/flags.go
+++ b/internal/commands/app/flags.go
@@ -10,6 +10,7 @@ const (
 	flagName            = "name"
 	flagDeploymentModel = "deployment-model"
 	flagLocation        = "location"
+	flagProviderRegion  = "providerRegion"
 	flagEnvironment     = "environment"
 	flagProject         = "project"
 
@@ -58,6 +59,23 @@ func locationFlag(value *realm.Location) flags.CustomFlag {
 					string(realm.LocationSydney),
 					string(realm.LocationMumbai),
 					string(realm.LocationSingapore),
+				},
+			},
+		},
+	}
+}
+
+func providerRegionFlag(value *realm.ProviderRegion) flags.CustomFlag {
+	return flags.CustomFlag{
+		Value: value,
+		Meta: flags.Meta{
+			Name:      "provider region",
+			Shorthand: "p",
+			Usage: flags.Usage{
+				Description:  "Select the Realm app's provider region",
+				DefaultValue: "<none>",
+				AllowedValues: []string{
+					string(realm.LocationVirginia),
 				},
 			},
 		},

--- a/internal/commands/app/init.go
+++ b/internal/commands/app/init.go
@@ -36,6 +36,7 @@ func (cmd *CommandInit) Flags() []flags.Flag {
 		remoteAppFlag(&cmd.inputs.RemoteApp),
 		nameFlag(&cmd.inputs.Name),
 		locationFlag(&cmd.inputs.Location),
+		providerRegionFlag(&cmd.inputs.ProviderRegion),
 		deploymentModelFlag(&cmd.inputs.DeploymentModel),
 		environmentFlag(&cmd.inputs.Environment),
 		cli.ProjectFlag(&cmd.inputs.Project),
@@ -74,6 +75,7 @@ func (cmd *CommandInit) writeAppFromScratch(wd string) error {
 		"", // no app id yet
 		cmd.inputs.Name,
 		cmd.inputs.Location,
+		cmd.inputs.ProviderRegion,
 		cmd.inputs.DeploymentModel,
 		cmd.inputs.Environment,
 		cmd.inputs.ConfigVersion,

--- a/internal/commands/app/init_inputs.go
+++ b/internal/commands/app/init_inputs.go
@@ -34,6 +34,10 @@ func (i *initInputs) Resolve(profile *user.Profile, ui terminal.UI) error {
 		if i.Location == realm.LocationEmpty {
 			i.Location = flagLocationDefault
 		}
+		// TODOO
+		if i.ProviderRegion == realm.ProviderRegionEmpty {
+			i.ProviderRegion = ""
+		}
 		if i.ConfigVersion == realm.AppConfigVersionZero {
 			i.ConfigVersion = realm.DefaultAppConfigVersion
 		}

--- a/internal/commands/app/init_inputs.go
+++ b/internal/commands/app/init_inputs.go
@@ -31,12 +31,11 @@ func (i *initInputs) Resolve(profile *user.Profile, ui terminal.UI) error {
 		if i.DeploymentModel == realm.DeploymentModelEmpty {
 			i.DeploymentModel = flagDeploymentModelDefault
 		}
-		if i.Location == realm.LocationEmpty {
-			i.Location = flagLocationDefault
+		if i.ProviderRegion == realm.ProviderRegionEmpty && i.Location == realm.LocationEmpty {
+			i.ProviderRegion = flagProviderRegionDefault
 		}
-		// TODOO
-		if i.ProviderRegion == realm.ProviderRegionEmpty {
-			i.ProviderRegion = ""
+		if i.Location == realm.LocationEmpty {
+			i.Location = realm.ProviderRegionToLocation[i.ProviderRegion]
 		}
 		if i.ConfigVersion == realm.AppConfigVersionZero {
 			i.ConfigVersion = realm.DefaultAppConfigVersion

--- a/internal/commands/app/init_inputs_test.go
+++ b/internal/commands/app/init_inputs_test.go
@@ -91,7 +91,7 @@ func TestAppInitInputsResolve(t *testing.T) {
 			test: func(t *testing.T, i initInputs) {
 				assert.Equal(t, "test-app", i.Name)
 				assert.Equal(t, realm.DeploymentModelLocal, i.DeploymentModel)
-				assert.Equal(t, realm.LocationOregon, i.Location)
+				assert.Equal(t, realm.LocationIreland, i.Location)
 				assert.Equal(t, realm.ProviderRegionEmpty, i.ProviderRegion)
 				assert.Equal(t, realm.EnvironmentDevelopment, i.Environment)
 			},

--- a/internal/commands/app/init_inputs_test.go
+++ b/internal/commands/app/init_inputs_test.go
@@ -36,7 +36,7 @@ func TestAppInitInputsResolve(t *testing.T) {
 		test        func(t *testing.T, i initInputs)
 	}{
 		{
-			description: "with no flags set should prompt for just name and set location deployment model and environment to defaults",
+			description: "with no flags set should prompt for just name and set deployment model location provider region and environment to defaults",
 			procedure: func(c *expect.Console) {
 				c.ExpectString("App Name")
 				c.SendLine("test-app")
@@ -46,26 +46,28 @@ func TestAppInitInputsResolve(t *testing.T) {
 				assert.Equal(t, "test-app", i.Name)
 				assert.Equal(t, flagDeploymentModelDefault, i.DeploymentModel)
 				assert.Equal(t, flagLocationDefault, i.Location)
+				assert.Equal(t, flagProviderRegionDefault, i.ProviderRegion)
 				assert.Equal(t, realm.EnvironmentNone, i.Environment)
 			},
 		},
 		{
-			description: "with a name flag set should prompt for nothing else and set location deployment model and environment to defaults",
+			description: "with a name flag set should prompt for nothing else and set deployment model location provider region and environment to defaults",
 			inputs:      initInputs{newAppInputs: newAppInputs{Name: "test-app"}},
 			procedure:   func(c *expect.Console) {},
 			test: func(t *testing.T, i initInputs) {
 				assert.Equal(t, "test-app", i.Name)
 				assert.Equal(t, flagDeploymentModelDefault, i.DeploymentModel)
 				assert.Equal(t, flagLocationDefault, i.Location)
+				assert.Equal(t, flagProviderRegionDefault, i.ProviderRegion)
 				assert.Equal(t, realm.EnvironmentNone, i.Environment)
 			},
 		},
 		{
-			description: "with name location deployment model and environment flags set should prompt for nothing else",
+			description: "with name provider region deployment model and environment flags set should set location and prompt for nothing else",
 			inputs: initInputs{newAppInputs: newAppInputs{
 				Name:            "test-app",
 				DeploymentModel: realm.DeploymentModelLocal,
-				Location:        realm.LocationOregon,
+				ProviderRegion:  realm.AWSProviderRegionUSWest2,
 				Environment:     realm.EnvironmentDevelopment,
 			}},
 			procedure: func(c *expect.Console) {},
@@ -73,6 +75,24 @@ func TestAppInitInputsResolve(t *testing.T) {
 				assert.Equal(t, "test-app", i.Name)
 				assert.Equal(t, realm.DeploymentModelLocal, i.DeploymentModel)
 				assert.Equal(t, realm.LocationOregon, i.Location)
+				assert.Equal(t, realm.AWSProviderRegionUSWest2, i.ProviderRegion)
+				assert.Equal(t, realm.EnvironmentDevelopment, i.Environment)
+			},
+		},
+		{
+			description: "with location and no provider region set should not set provider region and prompt for nothing else",
+			inputs: initInputs{newAppInputs: newAppInputs{
+				Name:            "test-app",
+				DeploymentModel: realm.DeploymentModelLocal,
+				Location:        realm.LocationIreland,
+				Environment:     realm.EnvironmentDevelopment,
+			}},
+			procedure: func(c *expect.Console) {},
+			test: func(t *testing.T, i initInputs) {
+				assert.Equal(t, "test-app", i.Name)
+				assert.Equal(t, realm.DeploymentModelLocal, i.DeploymentModel)
+				assert.Equal(t, realm.LocationOregon, i.Location)
+				assert.Equal(t, realm.ProviderRegionEmpty, i.ProviderRegion)
 				assert.Equal(t, realm.EnvironmentDevelopment, i.Environment)
 			},
 		},

--- a/internal/commands/app/init_test.go
+++ b/internal/commands/app/init_test.go
@@ -29,6 +29,7 @@ func TestAppInitHandler(t *testing.T) {
 			Project:         "test-project",
 			DeploymentModel: realm.DeploymentModelLocal,
 			Location:        realm.LocationSydney,
+			ProviderRegion:  realm.AWSProviderRegionAPSoutheast2,
 			ConfigVersion:   realm.DefaultAppConfigVersion,
 		}}}
 
@@ -45,6 +46,7 @@ func TestAppInitHandler(t *testing.T) {
 			ConfigVersion:   realm.DefaultAppConfigVersion,
 			Name:            "test-app",
 			Location:        realm.LocationSydney,
+			ProviderRegion:  realm.AWSProviderRegionAPSoutheast2,
 			DeploymentModel: realm.DeploymentModelLocal,
 		}}}, config)
 
@@ -164,6 +166,7 @@ func TestAppInitHandler(t *testing.T) {
 				ConfigVersion:   realm.DefaultAppConfigVersion,
 				Name:            "remote-app",
 				Location:        realm.LocationIreland,
+				ProviderRegion:  realm.AWSProviderRegionEUWest1,
 				DeploymentModel: realm.DeploymentModelGlobal,
 			}}}, config)
 		})

--- a/internal/commands/app/init_test.go
+++ b/internal/commands/app/init_test.go
@@ -166,7 +166,6 @@ func TestAppInitHandler(t *testing.T) {
 				ConfigVersion:   realm.DefaultAppConfigVersion,
 				Name:            "remote-app",
 				Location:        realm.LocationIreland,
-				ProviderRegion:  realm.AWSProviderRegionEUWest1,
 				DeploymentModel: realm.DeploymentModelGlobal,
 			}}}, config)
 		})

--- a/internal/commands/app/new_app_inputs.go
+++ b/internal/commands/app/new_app_inputs.go
@@ -11,6 +11,7 @@ import (
 const (
 	flagDeploymentModelDefault = realm.DeploymentModelGlobal
 	flagLocationDefault        = realm.LocationVirginia
+	flagProviderRegionDefault  = realm.AWSProviderRegionUSEast1
 )
 
 type newAppInputs struct {
@@ -19,6 +20,7 @@ type newAppInputs struct {
 	Name            string
 	DeploymentModel realm.DeploymentModel
 	Location        realm.Location
+	ProviderRegion  realm.ProviderRegion
 	Environment     realm.Environment
 	Template        string
 	ConfigVersion   realm.AppConfigVersion

--- a/internal/commands/push/command.go
+++ b/internal/commands/push/command.go
@@ -470,7 +470,9 @@ func createNewApp(ui terminal.UI, realmClient realm.Client, appDirectory, groupI
 		}
 	}
 
-	providerRegion = cloudProvider + "-" + providerRegionLabel
+	if providerRegionLabel != "" {
+		providerRegion = cloudProvider + "-" + providerRegionLabel
+	}
 
 	if !ui.AutoConfirm() {
 		if err := ui.AskOne(

--- a/internal/commands/push/command_test.go
+++ b/internal/commands/push/command_test.go
@@ -1099,8 +1099,8 @@ func TestPushHandlerCreateNewApp(t *testing.T) {
 				appData: &local.AppRealmConfigJSON{local.AppDataV2{local.AppStructureV2{
 					ConfigVersion:   realm.AppConfigVersion20210101,
 					Name:            "eggcorn",
-					Location:        realm.Location("location"),
-					ProviderRegion:  realm.ProviderRegion("provider"),
+					Location:        realm.Location(realm.LocationOregon),
+					ProviderRegion:  realm.ProviderRegion(realm.AWSProviderRegionUSWest2),
 					DeploymentModel: realm.DeploymentModel("deployment_model"),
 					Environment:     realm.Environment("environment"),
 				}}},
@@ -1108,8 +1108,8 @@ func TestPushHandlerCreateNewApp(t *testing.T) {
     "config_version": 20210101,
     "app_id": "eggcorn-abcde",
     "name": "eggcorn",
-    "location": "location",
-	"provider_region": "provider",
+    "location": "US-OR",
+    "provider_region": "aws-us-west-2",
     "deployment_model": "deployment_model",
     "environment": "environment"
 }
@@ -1120,8 +1120,8 @@ func TestPushHandlerCreateNewApp(t *testing.T) {
 				appData: &local.AppConfigJSON{local.AppDataV1{local.AppStructureV1{
 					ConfigVersion:   realm.AppConfigVersion20200603,
 					Name:            "eggcorn",
-					Location:        realm.Location("location"),
-					ProviderRegion:  realm.ProviderRegion("provider"),
+					Location:        realm.Location(realm.LocationOregon),
+					ProviderRegion:  realm.ProviderRegion(realm.AWSProviderRegionUSWest2),
 					DeploymentModel: realm.DeploymentModel("deployment_model"),
 					Environment:     realm.Environment("environment"),
 				}}},
@@ -1129,8 +1129,8 @@ func TestPushHandlerCreateNewApp(t *testing.T) {
     "config_version": 20200603,
     "app_id": "eggcorn-abcde",
     "name": "eggcorn",
-    "location": "location",
-	"provider_region": "provider",
+    "location": "US-OR",
+    "provider_region": "aws-us-west-2",
     "deployment_model": "deployment_model",
     "environment": "environment",
     "security": null,
@@ -1148,8 +1148,8 @@ func TestPushHandlerCreateNewApp(t *testing.T) {
 				appData: &local.AppStitchJSON{local.AppDataV1{local.AppStructureV1{
 					ConfigVersion:   realm.AppConfigVersion20180301,
 					Name:            "eggcorn",
-					Location:        realm.Location("location"),
-					ProviderRegion:  realm.ProviderRegion("provider"),
+					Location:        realm.Location(realm.LocationOregon),
+					ProviderRegion:  realm.ProviderRegion(realm.AWSProviderRegionUSWest2),
 					DeploymentModel: realm.DeploymentModel("deployment_model"),
 					Environment:     realm.Environment("environment"),
 				}}},
@@ -1157,8 +1157,8 @@ func TestPushHandlerCreateNewApp(t *testing.T) {
     "config_version": 20180301,
     "app_id": "eggcorn-abcde",
     "name": "eggcorn",
-    "location": "location",
-	"provider_region": "provider",
+    "location": "US-OR",
+    "provider_region": "aws-us-west-2",
     "deployment_model": "deployment_model",
     "environment": "environment",
     "security": null,
@@ -1247,8 +1247,8 @@ func TestPushHandlerCreateNewApp(t *testing.T) {
 				app := local.App{RootDir: tmpDir, Config: local.FileRealmConfig, AppData: &local.AppRealmConfigJSON{local.AppDataV2{local.AppStructureV2{
 					ConfigVersion:   realm.AppConfigVersion20210101,
 					Name:            "eggcorn",
-					Location:        realm.Location("location"),
-					ProviderRegion:  realm.ProviderRegion("provider"),
+					Location:        realm.Location(realm.LocationOregon),
+					ProviderRegion:  realm.ProviderRegion(realm.AWSProviderRegionUSWest2),
 					DeploymentModel: realm.DeploymentModel("deployment_model"),
 					Environment:     realm.Environment("environment"),
 				}}}}
@@ -1314,8 +1314,8 @@ func TestPushCommandCreateNewApp(t *testing.T) {
 	fullPkg := &local.AppConfigJSON{local.AppDataV1{local.AppStructureV1{
 		ConfigVersion:   realm.AppConfigVersion20200603,
 		Name:            "name",
-		Location:        realm.Location("location"),
-		ProviderRegion:  realm.ProviderRegion("provider"),
+		Location:        realm.Location(realm.LocationOregon),
+		ProviderRegion:  realm.ProviderRegion(realm.AWSProviderRegionUSWest2),
 		DeploymentModel: realm.DeploymentModel("deployment_model"),
 		Environment:     realm.Environment("environment"),
 	}}}
@@ -1389,7 +1389,7 @@ func TestPushCommandCreateNewApp(t *testing.T) {
     "config_version": 20210101,
     "name": "testApp",
     "location": "US-OR",
-	"provider-region": "aws-us-west-2",
+    "provider_region": "azure-westus",
     "deployment_model": "LOCAL",
     "environment": "testing"
 }
@@ -1401,7 +1401,7 @@ func TestPushCommandCreateNewApp(t *testing.T) {
 						Name:    "testApp",
 						AppMeta: realm.AppMeta{
 							Location:        realm.LocationOregon,
-							ProviderRegion:  realm.AWSProviderRegionUSWest2,
+							ProviderRegion:  realm.AzureProviderRegionWestUS,
 							DeploymentModel: realm.DeploymentModelLocal,
 							Environment:     realm.EnvironmentTesting,
 						},
@@ -1418,6 +1418,8 @@ func TestPushCommandCreateNewApp(t *testing.T) {
 						c.SendLine("testApp")
 
 						c.ExpectString("App Deployment Model")
+						c.Send(string(terminal.KeyArrowDown))
+						c.Send(string(terminal.KeyArrowUp))
 						c.SendLine("")
 
 						c.ExpectString("App Region")
@@ -1440,7 +1442,7 @@ func TestPushCommandCreateNewApp(t *testing.T) {
     "config_version": 20210101,
     "name": "testApp",
     "location": "US-OR",
-	"provider-region": "aws-us-west-2",
+    "provider_region": "aws-us-west-2",
     "deployment_model": "GLOBAL",
     "environment": "testing"
 }
@@ -1453,7 +1455,7 @@ func TestPushCommandCreateNewApp(t *testing.T) {
 						AppMeta: realm.AppMeta{
 							Location:        realm.LocationOregon,
 							ProviderRegion:  realm.AWSProviderRegionUSWest2,
-							DeploymentModel: realm.DeploymentModelLocal,
+							DeploymentModel: realm.DeploymentModelGlobal,
 							Environment:     realm.EnvironmentTesting,
 						},
 					},
@@ -1507,6 +1509,9 @@ func TestPushCommandCreateNewApp(t *testing.T) {
 						ID:      appID,
 						GroupID: groupID,
 						Name:    "testApp",
+						AppMeta: realm.AppMeta{
+							Location: realm.LocationVirginia,
+						},
 					},
 					expectedProceed: true,
 					test: func(t *testing.T, configPath string) {
@@ -1514,7 +1519,8 @@ func TestPushCommandCreateNewApp(t *testing.T) {
 						assert.Nil(t, readErr)
 						assert.Equal(t, `{
     "config_version": 20210101,
-    "name": "testApp"
+    "name": "testApp",
+    "location": "US-VA"
 }
 `, string(configData))
 					},
@@ -1564,13 +1570,16 @@ func TestPushCommandCreateNewApp(t *testing.T) {
 					description:       "should use the package name when present and zero values for app meta",
 					appData:           local.AppConfigJSON{local.AppDataV1{local.AppStructureV1{ConfigVersion: realm.AppConfigVersion20200603, Name: "name"}}},
 					expectedAppConfig: local.FileConfig,
+					expectedAppMeta: realm.AppMeta{
+						Location: realm.Location(realm.LocationVirginia),
+					},
 				},
 				{
 					description: "should use the package name deployment model location  provider region and environment when present",
 					appData:     fullPkg,
 					expectedAppMeta: realm.AppMeta{
-						Location:        realm.Location("location"),
-						ProviderRegion:  realm.ProviderRegion("provider"),
+						Location:        realm.Location(realm.LocationOregon),
+						ProviderRegion:  realm.ProviderRegion(realm.AWSProviderRegionUSWest2),
 						DeploymentModel: realm.DeploymentModel("deployment_model"),
 						Environment:     realm.Environment("environment"),
 					},
@@ -1608,10 +1617,10 @@ func TestPushCommandCreateNewApp(t *testing.T) {
 			}{
 				{
 					description: "should prompt for name if not present in the package",
-					appData:     local.AppConfigJSON{local.AppDataV1{local.AppStructureV1{Location: realm.Location("location"), ProviderRegion: "provider", DeploymentModel: realm.DeploymentModel("deployment_model"), Environment: realm.Environment("environment")}}},
+					appData:     local.AppConfigJSON{local.AppDataV1{local.AppStructureV1{Location: realm.Location(realm.LocationOregon), ProviderRegion: realm.ProviderRegion(realm.AWSProviderRegionUSWest2), DeploymentModel: realm.DeploymentModel("deployment_model"), Environment: realm.Environment("environment")}}},
 					expectedAppMeta: realm.AppMeta{
-						Location:        realm.Location("location"),
-						ProviderRegion:  "provider",
+						Location:        realm.Location(realm.LocationOregon),
+						ProviderRegion:  realm.ProviderRegion(realm.AWSProviderRegionUSWest2),
 						DeploymentModel: realm.DeploymentModel("deployment_model"),
 						Environment:     realm.Environment("environment"),
 					},
@@ -1619,6 +1628,9 @@ func TestPushCommandCreateNewApp(t *testing.T) {
 				{
 					description: "should not prompt for deployment model location provider region and environment even if not present in the package",
 					appData:     map[string]interface{}{},
+					expectedAppMeta: realm.AppMeta{
+						Location: realm.Location(realm.LocationVirginia),
+					},
 				},
 			} {
 				t.Run(tc.description, func(t *testing.T) {

--- a/internal/commands/push/command_test.go
+++ b/internal/commands/push/command_test.go
@@ -36,6 +36,7 @@ func TestPushHandler(t *testing.T) {
 			ID:                   "eggcorn-abcde",
 			Name:                 "eggcorn",
 			Location:             realm.LocationVirginia,
+			ProviderRegion:       realm.AWSProviderRegionUSEast1,
 			DeploymentModel:      realm.DeploymentModelGlobal,
 			Security:             map[string]interface{}{},
 			CustomUserDataConfig: map[string]interface{}{"enabled": true},
@@ -110,6 +111,7 @@ func TestPushHandler(t *testing.T) {
 		assert.Equal(t, "eggcorn", capturedName)
 		assert.Equal(t, realm.AppMeta{
 			Location:        realm.LocationVirginia,
+			ProviderRegion:  realm.AWSProviderRegionUSEast1,
 			DeploymentModel: realm.DeploymentModelGlobal,
 			Environment:     realm.EnvironmentNone,
 		}, capturedMeta)
@@ -1098,6 +1100,7 @@ func TestPushHandlerCreateNewApp(t *testing.T) {
 					ConfigVersion:   realm.AppConfigVersion20210101,
 					Name:            "eggcorn",
 					Location:        realm.Location("location"),
+					ProviderRegion:  realm.ProviderRegion("provider"),
 					DeploymentModel: realm.DeploymentModel("deployment_model"),
 					Environment:     realm.Environment("environment"),
 				}}},
@@ -1106,6 +1109,7 @@ func TestPushHandlerCreateNewApp(t *testing.T) {
     "app_id": "eggcorn-abcde",
     "name": "eggcorn",
     "location": "location",
+	"provider_region": "provider",
     "deployment_model": "deployment_model",
     "environment": "environment"
 }
@@ -1117,6 +1121,7 @@ func TestPushHandlerCreateNewApp(t *testing.T) {
 					ConfigVersion:   realm.AppConfigVersion20200603,
 					Name:            "eggcorn",
 					Location:        realm.Location("location"),
+					ProviderRegion:  realm.ProviderRegion("provider"),
 					DeploymentModel: realm.DeploymentModel("deployment_model"),
 					Environment:     realm.Environment("environment"),
 				}}},
@@ -1125,6 +1130,7 @@ func TestPushHandlerCreateNewApp(t *testing.T) {
     "app_id": "eggcorn-abcde",
     "name": "eggcorn",
     "location": "location",
+	"provider_region": "provider",
     "deployment_model": "deployment_model",
     "environment": "environment",
     "security": null,
@@ -1143,6 +1149,7 @@ func TestPushHandlerCreateNewApp(t *testing.T) {
 					ConfigVersion:   realm.AppConfigVersion20180301,
 					Name:            "eggcorn",
 					Location:        realm.Location("location"),
+					ProviderRegion:  realm.ProviderRegion("provider"),
 					DeploymentModel: realm.DeploymentModel("deployment_model"),
 					Environment:     realm.Environment("environment"),
 				}}},
@@ -1151,6 +1158,7 @@ func TestPushHandlerCreateNewApp(t *testing.T) {
     "app_id": "eggcorn-abcde",
     "name": "eggcorn",
     "location": "location",
+	"provider_region": "provider",
     "deployment_model": "deployment_model",
     "environment": "environment",
     "security": null,
@@ -1240,6 +1248,7 @@ func TestPushHandlerCreateNewApp(t *testing.T) {
 					ConfigVersion:   realm.AppConfigVersion20210101,
 					Name:            "eggcorn",
 					Location:        realm.Location("location"),
+					ProviderRegion:  realm.ProviderRegion("provider"),
 					DeploymentModel: realm.DeploymentModel("deployment_model"),
 					Environment:     realm.Environment("environment"),
 				}}}}
@@ -1259,11 +1268,15 @@ func TestPushHandlerCreateNewApp(t *testing.T) {
 					console.ExpectString("App Name")
 					console.SendLine("testApp")
 
-					console.ExpectString("App Location")
+					console.ExpectString("App Deployment Model")
 					console.Send(string(terminal.KeyArrowDown))
 					console.SendLine("")
 
-					console.ExpectString("App Deployment Model")
+					console.ExpectString("Cloud Provider")
+					console.Send(string(terminal.KeyArrowDown))
+					console.SendLine("")
+
+					console.ExpectString("App Region")
 					console.Send(string(terminal.KeyArrowDown))
 					console.SendLine("")
 
@@ -1302,6 +1315,7 @@ func TestPushCommandCreateNewApp(t *testing.T) {
 		ConfigVersion:   realm.AppConfigVersion20200603,
 		Name:            "name",
 		Location:        realm.Location("location"),
+		ProviderRegion:  realm.ProviderRegion("provider"),
 		DeploymentModel: realm.DeploymentModel("deployment_model"),
 		Environment:     realm.Environment("environment"),
 	}}}
@@ -1347,11 +1361,15 @@ func TestPushCommandCreateNewApp(t *testing.T) {
 						c.ExpectString("App Name")
 						c.SendLine("testApp")
 
-						c.ExpectString("App Location")
+						c.ExpectString("App Deployment Model")
 						c.Send(string(terminal.KeyArrowDown))
 						c.SendLine("")
 
-						c.ExpectString("App Deployment Model")
+						c.ExpectString("Cloud Provider")
+						c.Send(string(terminal.KeyArrowDown))
+						c.SendLine("")
+
+						c.ExpectString("App Region")
 						c.Send(string(terminal.KeyArrowDown))
 						c.SendLine("")
 
@@ -1371,6 +1389,7 @@ func TestPushCommandCreateNewApp(t *testing.T) {
     "config_version": 20210101,
     "name": "testApp",
     "location": "US-OR",
+	"provider-region": "aws-us-west-2",
     "deployment_model": "LOCAL",
     "environment": "testing"
 }
@@ -1382,6 +1401,58 @@ func TestPushCommandCreateNewApp(t *testing.T) {
 						Name:    "testApp",
 						AppMeta: realm.AppMeta{
 							Location:        realm.LocationOregon,
+							ProviderRegion:  realm.AWSProviderRegionUSWest2,
+							DeploymentModel: realm.DeploymentModelLocal,
+							Environment:     realm.EnvironmentTesting,
+						},
+					},
+					expectedProceed: true,
+				},
+				{
+					description: "should not prompt for cloud provider if deployment model is global",
+					procedure: func(c *expect.Console) {
+						c.ExpectString("Do you wish to create a new app?")
+						c.SendLine("y")
+
+						c.ExpectString("App Name")
+						c.SendLine("testApp")
+
+						c.ExpectString("App Deployment Model")
+						c.SendLine("")
+
+						c.ExpectString("App Region")
+						c.Send(string(terminal.KeyArrowDown))
+						c.SendLine("")
+
+						c.ExpectString("App Environment")
+						c.Send(string(terminal.KeyArrowDown))
+						c.SendLine("")
+
+						c.ExpectString("Please confirm the new app details shown above")
+						c.SendLine("y")
+
+						c.ExpectEOF()
+					},
+					test: func(t *testing.T, configPath string) {
+						configData, readErr := ioutil.ReadFile(configPath)
+						assert.Nil(t, readErr)
+						assert.Equal(t, `{
+    "config_version": 20210101,
+    "name": "testApp",
+    "location": "US-OR",
+	"provider-region": "aws-us-west-2",
+    "deployment_model": "GLOBAL",
+    "environment": "testing"
+}
+`, string(configData))
+					},
+					expectedApp: realm.App{
+						ID:      appID,
+						GroupID: groupID,
+						Name:    "testApp",
+						AppMeta: realm.AppMeta{
+							Location:        realm.LocationOregon,
+							ProviderRegion:  realm.AWSProviderRegionUSWest2,
 							DeploymentModel: realm.DeploymentModelLocal,
 							Environment:     realm.EnvironmentTesting,
 						},
@@ -1397,11 +1468,15 @@ func TestPushCommandCreateNewApp(t *testing.T) {
 						c.ExpectString("App Name")
 						c.SendLine("testApp")
 
-						c.ExpectString("App Location")
+						c.ExpectString("App Deployment Model")
 						c.Send(string(terminal.KeyArrowDown))
 						c.SendLine("")
 
-						c.ExpectString("App Deployment Model")
+						c.ExpectString("Cloud Provider")
+						c.Send(string(terminal.KeyArrowDown))
+						c.SendLine("")
+
+						c.ExpectString("App Region")
 						c.Send(string(terminal.KeyArrowDown))
 						c.SendLine("")
 
@@ -1491,10 +1566,11 @@ func TestPushCommandCreateNewApp(t *testing.T) {
 					expectedAppConfig: local.FileConfig,
 				},
 				{
-					description: "should use the package name location deployment model and environment when present",
+					description: "should use the package name deployment model location  provider region and environment when present",
 					appData:     fullPkg,
 					expectedAppMeta: realm.AppMeta{
 						Location:        realm.Location("location"),
+						ProviderRegion:  realm.ProviderRegion("provider"),
 						DeploymentModel: realm.DeploymentModel("deployment_model"),
 						Environment:     realm.Environment("environment"),
 					},
@@ -1532,15 +1608,16 @@ func TestPushCommandCreateNewApp(t *testing.T) {
 			}{
 				{
 					description: "should prompt for name if not present in the package",
-					appData:     local.AppConfigJSON{local.AppDataV1{local.AppStructureV1{Location: realm.Location("location"), DeploymentModel: realm.DeploymentModel("deployment_model"), Environment: realm.Environment("environment")}}},
+					appData:     local.AppConfigJSON{local.AppDataV1{local.AppStructureV1{Location: realm.Location("location"), ProviderRegion: "provider", DeploymentModel: realm.DeploymentModel("deployment_model"), Environment: realm.Environment("environment")}}},
 					expectedAppMeta: realm.AppMeta{
 						Location:        realm.Location("location"),
+						ProviderRegion:  "provider",
 						DeploymentModel: realm.DeploymentModel("deployment_model"),
 						Environment:     realm.Environment("environment"),
 					},
 				},
 				{
-					description: "should not prompt for location deployment model and environment even if not present in the package",
+					description: "should not prompt for deployment model location provider region and environment even if not present in the package",
 					appData:     map[string]interface{}{},
 				},
 			} {

--- a/internal/commands/push/testdata/project/config.json
+++ b/internal/commands/push/testdata/project/config.json
@@ -3,6 +3,7 @@
     "app_id": "eggcorn-abcde",
     "name": "eggcorn",
     "location": "US-VA",
+    "provider_region": "aws-us-east-1",
     "deployment_model": "GLOBAL",
     "security": {},
     "custom_user_data_config": {

--- a/internal/local/app.go
+++ b/internal/local/app.go
@@ -64,12 +64,13 @@ func (a App) Option() string {
 }
 
 // NewApp returns a new local app
-func NewApp(rootDir, clientAppID, name string, location realm.Location, deploymentModel realm.DeploymentModel, environment realm.Environment, configVersion realm.AppConfigVersion) App {
+func NewApp(rootDir, clientAppID, name string, location realm.Location, providerRegion realm.ProviderRegion, deploymentModel realm.DeploymentModel, environment realm.Environment, configVersion realm.AppConfigVersion) App {
 	return AsApp(rootDir, realm.App{
 		ClientAppID: clientAppID,
 		Name:        name,
 		AppMeta: realm.AppMeta{
 			Location:        location,
+			ProviderRegion:  providerRegion,
 			DeploymentModel: deploymentModel,
 			Environment:     environment,
 		},
@@ -87,6 +88,7 @@ func AsApp(rootDir string, app realm.App, configVersion realm.AppConfigVersion) 
 			ID:                   app.ClientAppID,
 			Name:                 app.Name,
 			Location:             app.Location,
+			ProviderRegion:       app.ProviderRegion,
 			DeploymentModel:      app.DeploymentModel,
 			Environment:          app.Environment,
 			CustomUserDataConfig: map[string]interface{}{"enabled": false},
@@ -121,6 +123,7 @@ func AsApp(rootDir string, app realm.App, configVersion realm.AppConfigVersion) 
 			ID:                   app.ClientAppID,
 			Name:                 app.Name,
 			Location:             app.Location,
+			ProviderRegion:       app.ProviderRegion,
 			DeploymentModel:      app.DeploymentModel,
 			Environment:          app.Environment,
 			CustomUserDataConfig: map[string]interface{}{"enabled": false},
@@ -155,6 +158,7 @@ func AsApp(rootDir string, app realm.App, configVersion realm.AppConfigVersion) 
 			ID:              app.ClientAppID,
 			Name:            app.Name,
 			Location:        app.Location,
+			ProviderRegion:  app.ProviderRegion,
 			DeploymentModel: app.DeploymentModel,
 			Environment:     app.Environment,
 			Environments: map[string]map[string]interface{}{

--- a/internal/local/app_test.go
+++ b/internal/local/app_test.go
@@ -228,7 +228,6 @@ func TestFindApp(t *testing.T) {
 			} {
 				t.Run(tc.description, func(t *testing.T) {
 					path := filepath.Join(testRoot, tc.name)
-
 					_, insideProject, err := FindApp(path)
 					assert.Nil(t, err)
 					assert.True(t, insideProject, "should be inside project")
@@ -290,7 +289,7 @@ func TestAppWriteConfig(t *testing.T) {
     "config_version": 0,
     "name": "",
     "location": "",
-	"provider_region": "",
+    "provider_region": "",
     "deployment_model": "",
     "security": null,
     "custom_user_data_config": null,
@@ -306,7 +305,7 @@ func TestAppWriteConfig(t *testing.T) {
     "config_version": 0,
     "name": "",
     "location": "",
-	"provider_region": "",
+    "provider_region": "",
     "deployment_model": "",
     "security": null,
     "custom_user_data_config": null,
@@ -330,6 +329,7 @@ func TestAppWriteConfig(t *testing.T) {
 					ID:                   "test-abcde",
 					Name:                 "test",
 					Location:             realm.LocationVirginia,
+					ProviderRegion:       realm.AWSProviderRegionUSEast1,
 					DeploymentModel:      realm.DeploymentModelGlobal,
 					Security:             map[string]interface{}{"allowed_origins": []string{"http://localhost:8080"}},
 					CustomUserDataConfig: map[string]interface{}{"enabled": true},
@@ -341,7 +341,7 @@ func TestAppWriteConfig(t *testing.T) {
     "app_id": "test-abcde",
     "name": "test",
     "location": "US-VA",
-	"provider_region": "aws-us-east-1",
+    "provider_region": "aws-us-east-1",
     "deployment_model": "GLOBAL",
     "security": {
         "allowed_origins": [
@@ -376,7 +376,7 @@ func TestAppWriteConfig(t *testing.T) {
     "app_id": "test-abcde",
     "name": "test",
     "location": "US-VA",
-	"provider_region": "aws-us-east-1",
+    "provider_region": "aws-us-east-1",
     "deployment_model": "GLOBAL",
     "security": {
         "allowed_origins": [
@@ -409,7 +409,7 @@ func TestAppWriteConfig(t *testing.T) {
     "app_id": "test-abcde",
     "name": "test",
     "location": "US-VA",
-	"provider_region": "aws-us-east-1",
+    "provider_region": "aws-us-east-1",
     "deployment_model": "GLOBAL",
     "allowed_request_origins": [
         "http://localhost:8080"
@@ -855,7 +855,7 @@ var appData20180301Local = AppDataV1{AppStructureV1{
 	ConfigVersion:        realm.AppConfigVersion20180301,
 	Name:                 "20180301-local",
 	Location:             realm.LocationVirginia,
-	ProviderRegion:       "us-east-1",
+	ProviderRegion:       "aws-us-east-1",
 	DeploymentModel:      realm.DeploymentModelGlobal,
 	Security:             appSecurity,
 	Hosting:              appHosting,
@@ -868,7 +868,7 @@ var appData20180301Remote = AppDataV1{AppStructureV1{
 	ID:                   "20180301-remote-abcde",
 	Name:                 "20180301-remote",
 	Location:             realm.LocationVirginia,
-	ProviderRegion:       "us-east-1",
+	ProviderRegion:       "aws-us-east-1",
 	DeploymentModel:      realm.DeploymentModelGlobal,
 	Security:             appSecurity,
 	Hosting:              appHosting,
@@ -880,7 +880,7 @@ var appData20180301Nested = AppDataV1{AppStructureV1{
 	ConfigVersion:        realm.AppConfigVersion20180301,
 	Name:                 "20180301-nested",
 	Location:             realm.LocationVirginia,
-	ProviderRegion:       "us-east-1",
+	ProviderRegion:       "aws-us-east-1",
 	DeploymentModel:      realm.DeploymentModelGlobal,
 	Security:             appSecurity,
 	Hosting:              appHosting,
@@ -899,7 +899,7 @@ var appData20200603Local = AppDataV1{AppStructureV1{
 	ConfigVersion:        realm.AppConfigVersion20200603,
 	Name:                 "20200603-local",
 	Location:             realm.LocationVirginia,
-	ProviderRegion:       "us-east-1",
+	ProviderRegion:       "aws-us-east-1",
 	DeploymentModel:      realm.DeploymentModelGlobal,
 	Security:             appSecurity,
 	Hosting:              appHosting,
@@ -912,7 +912,7 @@ var appData20200603Remote = AppDataV1{AppStructureV1{
 	ID:                   "20200603-remote-abcde",
 	Name:                 "20200603-remote",
 	Location:             realm.LocationVirginia,
-	ProviderRegion:       "us-east-1",
+	ProviderRegion:       "aws-us-east-1",
 	DeploymentModel:      realm.DeploymentModelGlobal,
 	Security:             appSecurity,
 	Hosting:              appHosting,
@@ -924,7 +924,7 @@ var appData20200603Nested = AppDataV1{AppStructureV1{
 	ConfigVersion:        realm.AppConfigVersion20200603,
 	Name:                 "20200603-nested",
 	Location:             realm.LocationVirginia,
-	ProviderRegion:       "us-east-1",
+	ProviderRegion:       "aws-us-east-1",
 	DeploymentModel:      realm.DeploymentModelGlobal,
 	Security:             appSecurity,
 	Hosting:              appHosting,
@@ -943,7 +943,7 @@ var appData20210101Local = AppDataV2{AppStructureV2{
 	ConfigVersion:         realm.AppConfigVersion20210101,
 	Name:                  "20210101-local",
 	Location:              realm.LocationVirginia,
-	ProviderRegion:        "us-east-1",
+	ProviderRegion:        "aws-us-east-1",
 	DeploymentModel:       realm.DeploymentModelGlobal,
 	AllowedRequestOrigins: allowedRequestOrigins,
 }}
@@ -953,7 +953,7 @@ var appData20210101Remote = AppDataV2{AppStructureV2{
 	ID:                    "20210101-remote-abcde",
 	Name:                  "20210101-remote",
 	Location:              realm.LocationVirginia,
-	ProviderRegion:        "us-east-1",
+	ProviderRegion:        "aws-us-east-1",
 	DeploymentModel:       realm.DeploymentModelGlobal,
 	AllowedRequestOrigins: allowedRequestOrigins,
 }}
@@ -962,7 +962,7 @@ var appData20210101Nested = AppDataV2{AppStructureV2{
 	ConfigVersion:         realm.AppConfigVersion20210101,
 	Name:                  "20210101-nested",
 	Location:              realm.LocationVirginia,
-	ProviderRegion:        "us-east-1",
+	ProviderRegion:        "aws-us-east-1",
 	DeploymentModel:       realm.DeploymentModelGlobal,
 	AllowedRequestOrigins: allowedRequestOrigins,
 	GraphQL:               appGraphQLStructure,

--- a/internal/local/app_test.go
+++ b/internal/local/app_test.go
@@ -24,6 +24,7 @@ func TestNewApp(t *testing.T) {
 				ID:              "testID",
 				Name:            "testName",
 				Location:        realm.LocationOregon,
+				ProviderRegion:  realm.AWSProviderRegionUSWest2,
 				DeploymentModel: realm.DeploymentModelGlobal,
 				Environment:     realm.EnvironmentDevelopment,
 				Environments: map[string]map[string]interface{}{
@@ -61,7 +62,7 @@ func TestNewApp(t *testing.T) {
 			}}},
 		}
 
-		app := NewApp("/path/to/project", "testID", "testName", realm.LocationOregon, realm.DeploymentModelGlobal, realm.EnvironmentDevelopment, realm.DefaultAppConfigVersion)
+		app := NewApp("/path/to/project", "testID", "testName", realm.LocationOregon, realm.AWSProviderRegionUSWest2, realm.DeploymentModelGlobal, realm.EnvironmentDevelopment, realm.DefaultAppConfigVersion)
 		assert.Equal(t, expectedApp, app)
 	})
 }
@@ -289,6 +290,7 @@ func TestAppWriteConfig(t *testing.T) {
     "config_version": 0,
     "name": "",
     "location": "",
+	"provider_region": "",
     "deployment_model": "",
     "security": null,
     "custom_user_data_config": null,
@@ -304,6 +306,7 @@ func TestAppWriteConfig(t *testing.T) {
     "config_version": 0,
     "name": "",
     "location": "",
+	"provider_region": "",
     "deployment_model": "",
     "security": null,
     "custom_user_data_config": null,
@@ -338,6 +341,7 @@ func TestAppWriteConfig(t *testing.T) {
     "app_id": "test-abcde",
     "name": "test",
     "location": "US-VA",
+	"provider_region": "aws-us-east-1",
     "deployment_model": "GLOBAL",
     "security": {
         "allowed_origins": [
@@ -360,6 +364,7 @@ func TestAppWriteConfig(t *testing.T) {
 					ID:                   "test-abcde",
 					Name:                 "test",
 					Location:             realm.LocationVirginia,
+					ProviderRegion:       realm.AWSProviderRegionUSEast1,
 					DeploymentModel:      realm.DeploymentModelGlobal,
 					Security:             map[string]interface{}{"allowed_origins": []string{"http://localhost:8080"}},
 					CustomUserDataConfig: map[string]interface{}{"enabled": true},
@@ -371,6 +376,7 @@ func TestAppWriteConfig(t *testing.T) {
     "app_id": "test-abcde",
     "name": "test",
     "location": "US-VA",
+	"provider_region": "aws-us-east-1",
     "deployment_model": "GLOBAL",
     "security": {
         "allowed_origins": [
@@ -393,6 +399,7 @@ func TestAppWriteConfig(t *testing.T) {
 					ID:                    "test-abcde",
 					Name:                  "test",
 					Location:              realm.LocationVirginia,
+					ProviderRegion:        realm.AWSProviderRegionUSEast1,
 					DeploymentModel:       realm.DeploymentModelGlobal,
 					AllowedRequestOrigins: []string{"http://localhost:8080"},
 				}}},
@@ -402,6 +409,7 @@ func TestAppWriteConfig(t *testing.T) {
     "app_id": "test-abcde",
     "name": "test",
     "location": "US-VA",
+	"provider_region": "aws-us-east-1",
     "deployment_model": "GLOBAL",
     "allowed_request_origins": [
         "http://localhost:8080"
@@ -436,7 +444,7 @@ func TestAppWrite20180301(t *testing.T) {
 		assert.Nil(t, err)
 		defer cleanupTmpDir()
 
-		app := NewApp(tmpDir, "test-app-abcde", "test-app", realm.LocationIreland, realm.DeploymentModelLocal, realm.EnvironmentDevelopment, realm.AppConfigVersion20180301)
+		app := NewApp(tmpDir, "test-app-abcde", "test-app", realm.LocationIreland, realm.AWSProviderRegionEUWest1, realm.DeploymentModelLocal, realm.EnvironmentDevelopment, realm.AppConfigVersion20180301)
 
 		assert.Nil(t, app.Write())
 
@@ -450,6 +458,7 @@ func TestAppWrite20180301(t *testing.T) {
 			ID:                   "test-app-abcde",
 			Name:                 "test-app",
 			Location:             realm.LocationIreland,
+			ProviderRegion:       realm.AWSProviderRegionEUWest1,
 			DeploymentModel:      realm.DeploymentModelLocal,
 			Environment:          realm.EnvironmentDevelopment,
 			CustomUserDataConfig: map[string]interface{}{"enabled": false},
@@ -498,7 +507,7 @@ func TestAppWrite20200603(t *testing.T) {
 		assert.Nil(t, err)
 		defer cleanupTmpDir()
 
-		app := NewApp(tmpDir, "test-app-abcde", "test-app", realm.LocationIreland, realm.DeploymentModelLocal, realm.EnvironmentDevelopment, realm.AppConfigVersion20200603)
+		app := NewApp(tmpDir, "test-app-abcde", "test-app", realm.LocationIreland, realm.AWSProviderRegionEUWest1, realm.DeploymentModelLocal, realm.EnvironmentDevelopment, realm.AppConfigVersion20200603)
 
 		assert.Nil(t, app.Write())
 
@@ -512,6 +521,7 @@ func TestAppWrite20200603(t *testing.T) {
 			ID:                   "test-app-abcde",
 			Name:                 "test-app",
 			Location:             realm.LocationIreland,
+			ProviderRegion:       realm.AWSProviderRegionEUWest1,
 			DeploymentModel:      realm.DeploymentModelLocal,
 			Environment:          realm.EnvironmentDevelopment,
 			CustomUserDataConfig: map[string]interface{}{"enabled": false},
@@ -560,7 +570,7 @@ func TestAppWrite20210101(t *testing.T) {
 		assert.Nil(t, err)
 		defer cleanupTmpDir()
 
-		app := NewApp(tmpDir, "test-app-abcde", "test-app", realm.LocationIreland, realm.DeploymentModelLocal, realm.EnvironmentDevelopment, realm.AppConfigVersion20210101)
+		app := NewApp(tmpDir, "test-app-abcde", "test-app", realm.LocationIreland, realm.AWSProviderRegionEUWest1, realm.DeploymentModelLocal, realm.EnvironmentDevelopment, realm.AppConfigVersion20210101)
 
 		assert.Nil(t, app.Write())
 
@@ -574,6 +584,7 @@ func TestAppWrite20210101(t *testing.T) {
 			ID:              "test-app-abcde",
 			Name:            "test-app",
 			Location:        realm.LocationIreland,
+			ProviderRegion:  realm.AWSProviderRegionEUWest1,
 			DeploymentModel: realm.DeploymentModelLocal,
 			Environment:     realm.EnvironmentDevelopment,
 		}}}, config)
@@ -640,6 +651,7 @@ var fullProject = &AppConfigJSON{AppDataV1{AppStructureV1{
 	ID:              "full-abcde",
 	Name:            "full",
 	Location:        "US-VA",
+	ProviderRegion:  "aws-us-east-1",
 	DeploymentModel: "GLOBAL",
 	Sync:            map[string]interface{}{"development_mode_enabled": false},
 	AuthProviders: []map[string]interface{}{
@@ -843,6 +855,7 @@ var appData20180301Local = AppDataV1{AppStructureV1{
 	ConfigVersion:        realm.AppConfigVersion20180301,
 	Name:                 "20180301-local",
 	Location:             realm.LocationVirginia,
+	ProviderRegion:       "us-east-1",
 	DeploymentModel:      realm.DeploymentModelGlobal,
 	Security:             appSecurity,
 	Hosting:              appHosting,
@@ -855,6 +868,7 @@ var appData20180301Remote = AppDataV1{AppStructureV1{
 	ID:                   "20180301-remote-abcde",
 	Name:                 "20180301-remote",
 	Location:             realm.LocationVirginia,
+	ProviderRegion:       "us-east-1",
 	DeploymentModel:      realm.DeploymentModelGlobal,
 	Security:             appSecurity,
 	Hosting:              appHosting,
@@ -866,6 +880,7 @@ var appData20180301Nested = AppDataV1{AppStructureV1{
 	ConfigVersion:        realm.AppConfigVersion20180301,
 	Name:                 "20180301-nested",
 	Location:             realm.LocationVirginia,
+	ProviderRegion:       "us-east-1",
 	DeploymentModel:      realm.DeploymentModelGlobal,
 	Security:             appSecurity,
 	Hosting:              appHosting,
@@ -884,6 +899,7 @@ var appData20200603Local = AppDataV1{AppStructureV1{
 	ConfigVersion:        realm.AppConfigVersion20200603,
 	Name:                 "20200603-local",
 	Location:             realm.LocationVirginia,
+	ProviderRegion:       "us-east-1",
 	DeploymentModel:      realm.DeploymentModelGlobal,
 	Security:             appSecurity,
 	Hosting:              appHosting,
@@ -896,6 +912,7 @@ var appData20200603Remote = AppDataV1{AppStructureV1{
 	ID:                   "20200603-remote-abcde",
 	Name:                 "20200603-remote",
 	Location:             realm.LocationVirginia,
+	ProviderRegion:       "us-east-1",
 	DeploymentModel:      realm.DeploymentModelGlobal,
 	Security:             appSecurity,
 	Hosting:              appHosting,
@@ -907,6 +924,7 @@ var appData20200603Nested = AppDataV1{AppStructureV1{
 	ConfigVersion:        realm.AppConfigVersion20200603,
 	Name:                 "20200603-nested",
 	Location:             realm.LocationVirginia,
+	ProviderRegion:       "us-east-1",
 	DeploymentModel:      realm.DeploymentModelGlobal,
 	Security:             appSecurity,
 	Hosting:              appHosting,
@@ -925,6 +943,7 @@ var appData20210101Local = AppDataV2{AppStructureV2{
 	ConfigVersion:         realm.AppConfigVersion20210101,
 	Name:                  "20210101-local",
 	Location:              realm.LocationVirginia,
+	ProviderRegion:        "us-east-1",
 	DeploymentModel:       realm.DeploymentModelGlobal,
 	AllowedRequestOrigins: allowedRequestOrigins,
 }}
@@ -934,6 +953,7 @@ var appData20210101Remote = AppDataV2{AppStructureV2{
 	ID:                    "20210101-remote-abcde",
 	Name:                  "20210101-remote",
 	Location:              realm.LocationVirginia,
+	ProviderRegion:        "us-east-1",
 	DeploymentModel:       realm.DeploymentModelGlobal,
 	AllowedRequestOrigins: allowedRequestOrigins,
 }}
@@ -942,6 +962,7 @@ var appData20210101Nested = AppDataV2{AppStructureV2{
 	ConfigVersion:         realm.AppConfigVersion20210101,
 	Name:                  "20210101-nested",
 	Location:              realm.LocationVirginia,
+	ProviderRegion:        "us-east-1",
 	DeploymentModel:       realm.DeploymentModelGlobal,
 	AllowedRequestOrigins: allowedRequestOrigins,
 	GraphQL:               appGraphQLStructure,

--- a/internal/local/config.go
+++ b/internal/local/config.go
@@ -21,6 +21,7 @@ func NewAppConfigJSON(name string, meta realm.AppMeta) AppConfigJSON {
 	return AppConfigJSON{AppDataV1{AppStructureV1{
 		Name:            name,
 		Location:        meta.Location,
+		ProviderRegion:  meta.ProviderRegion,
 		DeploymentModel: meta.DeploymentModel,
 	}}}
 }
@@ -35,6 +36,7 @@ func NewAppStitchJSON(name string, meta realm.AppMeta) AppStitchJSON {
 	return AppStitchJSON{AppDataV1{AppStructureV1{
 		Name:            name,
 		Location:        meta.Location,
+		ProviderRegion:  meta.ProviderRegion,
 		DeploymentModel: meta.DeploymentModel,
 	}}}
 }
@@ -49,6 +51,7 @@ func NewAppRealmConfigJSON(name string, meta realm.AppMeta) AppRealmConfigJSON {
 	return AppRealmConfigJSON{AppDataV2{AppStructureV2{
 		Name:            name,
 		Location:        meta.Location,
+		ProviderRegion:  meta.ProviderRegion,
 		DeploymentModel: meta.DeploymentModel,
 	}}}
 }

--- a/internal/local/data.go
+++ b/internal/local/data.go
@@ -17,6 +17,7 @@ type AppData interface {
 	ID() string
 	Name() string
 	Location() realm.Location
+	ProviderRegion() realm.ProviderRegion
 	DeploymentModel() realm.DeploymentModel
 	Environment() realm.Environment
 	LoadData(rootDir string) error

--- a/internal/local/structure_v1.go
+++ b/internal/local/structure_v1.go
@@ -16,6 +16,7 @@ type AppStructureV1 struct {
 	ID                   string                            `json:"app_id,omitempty"`
 	Name                 string                            `json:"name"`
 	Location             realm.Location                    `json:"location"`
+	ProviderRegion       realm.ProviderRegion              `json:"provider_region"`
 	DeploymentModel      realm.DeploymentModel             `json:"deployment_model"`
 	Environment          realm.Environment                 `json:"environment,omitempty"`
 	Environments         map[string]map[string]interface{} `json:"environments,omitempty"`
@@ -57,6 +58,11 @@ func (a AppDataV1) Name() string {
 // Location returns the local Realm app location
 func (a AppDataV1) Location() realm.Location {
 	return a.AppStructureV1.Location
+}
+
+// ProviderRegion returns the local Realm app provider region
+func (a AppDataV1) ProviderRegion() realm.ProviderRegion {
+	return a.AppStructureV1.ProviderRegion
 }
 
 // DeploymentModel returns the local Realm app deployment model
@@ -144,6 +150,7 @@ func (a AppDataV1) ConfigData() ([]byte, error) {
 		ID                   string                 `json:"app_id,omitempty"`
 		Name                 string                 `json:"name"`
 		Location             realm.Location         `json:"location"`
+		ProviderRegion       realm.ProviderRegion   `json:"provider_region"`
 		DeploymentModel      realm.DeploymentModel  `json:"deployment_model"`
 		Environment          realm.Environment      `json:"environment,omitempty"`
 		Security             map[string]interface{} `json:"security"`
@@ -155,6 +162,7 @@ func (a AppDataV1) ConfigData() ([]byte, error) {
 		ID:                   a.ID(),
 		Name:                 a.Name(),
 		Location:             a.Location(),
+		ProviderRegion:       a.ProviderRegion(),
 		DeploymentModel:      a.DeploymentModel(),
 		Environment:          a.Environment(),
 		Security:             a.Security,

--- a/internal/local/structure_v2.go
+++ b/internal/local/structure_v2.go
@@ -17,6 +17,7 @@ type AppStructureV2 struct {
 	ID                    string                            `json:"app_id,omitempty"`
 	Name                  string                            `json:"name,omitempty"`
 	Location              realm.Location                    `json:"location,omitempty"`
+	ProviderRegion        realm.ProviderRegion              `json:"provider_region,omitempty"`
 	DeploymentModel       realm.DeploymentModel             `json:"deployment_model,omitempty"`
 	Environment           realm.Environment                 `json:"environment,omitempty"`
 	Environments          map[string]map[string]interface{} `json:"environments,omitempty"`
@@ -96,6 +97,11 @@ func (a AppDataV2) Name() string {
 // Location returns the local Realm app location
 func (a AppDataV2) Location() realm.Location {
 	return a.AppStructureV2.Location
+}
+
+// ProviderRegion returns the local Realm app provider region
+func (a AppDataV2) ProviderRegion() realm.ProviderRegion {
+	return a.AppStructureV2.ProviderRegion
 }
 
 // DeploymentModel returns the local Realm app deployment model
@@ -432,6 +438,7 @@ func (a AppDataV2) ConfigData() ([]byte, error) {
 		ID                    string                 `json:"app_id,omitempty"`
 		Name                  string                 `json:"name,omitempty"`
 		Location              realm.Location         `json:"location,omitempty"`
+		ProviderRegion        realm.ProviderRegion   `json:"provider_region,omitempty"`
 		DeploymentModel       realm.DeploymentModel  `json:"deployment_model,omitempty"`
 		Environment           realm.Environment      `json:"environment,omitempty"`
 		AllowedRequestOrigins []string               `json:"allowed_request_origins,omitempty"`
@@ -440,6 +447,7 @@ func (a AppDataV2) ConfigData() ([]byte, error) {
 		ID:                    a.ID(),
 		Name:                  a.Name(),
 		Location:              a.Location(),
+		ProviderRegion:        a.ProviderRegion(),
 		DeploymentModel:       a.DeploymentModel(),
 		Environment:           a.Environment(),
 		AllowedRequestOrigins: a.AllowedRequestOrigins,

--- a/internal/local/testdata/20180301/app_meta/stitch.json
+++ b/internal/local/testdata/20180301/app_meta/stitch.json
@@ -2,6 +2,7 @@
     "config_version": 20180301,
     "name": "20180301-local",
     "location": "US-VA",
+    "provider_region": "aws-us-east-1",
     "deployment_model": "GLOBAL",
     "security": {
         "allowed_request_origins": [

--- a/internal/local/testdata/20180301/local/stitch.json
+++ b/internal/local/testdata/20180301/local/stitch.json
@@ -2,6 +2,7 @@
     "config_version": 20180301,
     "name": "20180301-local",
     "location": "US-VA",
+    "provider_region": "aws-us-east-1",
     "deployment_model": "GLOBAL",
     "security": {
         "allowed_request_origins": [

--- a/internal/local/testdata/20180301/nested/stitch.json
+++ b/internal/local/testdata/20180301/nested/stitch.json
@@ -2,6 +2,7 @@
     "config_version": 20180301,
     "name": "20180301-nested",
     "location": "US-VA",
+    "provider_region": "aws-us-east-1",
     "deployment_model": "GLOBAL",
     "security": {
         "allowed_request_origins": [

--- a/internal/local/testdata/20180301/remote/stitch.json
+++ b/internal/local/testdata/20180301/remote/stitch.json
@@ -3,6 +3,7 @@
     "app_id": "20180301-remote-abcde",
     "name": "20180301-remote",
     "location": "US-VA",
+    "provider_region": "aws-us-east-1",
     "deployment_model": "GLOBAL",
     "security": {
         "allowed_request_origins": [

--- a/internal/local/testdata/20200603/app_meta/config.json
+++ b/internal/local/testdata/20200603/app_meta/config.json
@@ -2,6 +2,7 @@
     "config_version": 20200603,
     "name": "20200603-local",
     "location": "US-VA",
+    "provider_region": "aws-us-east-1",
     "deployment_model": "GLOBAL",
     "security": {
         "allowed_request_origins": [

--- a/internal/local/testdata/20200603/local/config.json
+++ b/internal/local/testdata/20200603/local/config.json
@@ -2,6 +2,7 @@
     "config_version": 20200603,
     "name": "20200603-local",
     "location": "US-VA",
+    "provider_region": "aws-us-east-1",
     "deployment_model": "GLOBAL",
     "security": {
         "allowed_request_origins": [

--- a/internal/local/testdata/20200603/nested/config.json
+++ b/internal/local/testdata/20200603/nested/config.json
@@ -2,6 +2,7 @@
     "config_version": 20200603,
     "name": "20200603-nested",
     "location": "US-VA",
+    "provider_region": "aws-us-east-1",
     "deployment_model": "GLOBAL",
     "security": {
         "allowed_request_origins": [

--- a/internal/local/testdata/20200603/remote/config.json
+++ b/internal/local/testdata/20200603/remote/config.json
@@ -3,6 +3,7 @@
     "app_id": "20200603-remote-abcde",
     "name": "20200603-remote",
     "location": "US-VA",
+    "provider_region": "aws-us-east-1",
     "deployment_model": "GLOBAL",
     "security": {
         "allowed_request_origins": [

--- a/internal/local/testdata/20210101/app_meta/realm_config.json
+++ b/internal/local/testdata/20210101/app_meta/realm_config.json
@@ -2,6 +2,7 @@
     "config_version": 20210101,
     "name": "20210101-local",
     "location": "US-VA",
+    "provider_region": "aws-us-east-1",
     "deployment_model": "GLOBAL",
     "allowed_request_origins": [
         "http://localhost:8080"

--- a/internal/local/testdata/20210101/local/realm_config.json
+++ b/internal/local/testdata/20210101/local/realm_config.json
@@ -2,6 +2,7 @@
     "config_version": 20210101,
     "name": "20210101-local",
     "location": "US-VA",
+    "provider_region": "aws-us-east-1",
     "deployment_model": "GLOBAL",
     "allowed_request_origins": [
         "http://localhost:8080"

--- a/internal/local/testdata/20210101/nested/realm_config.json
+++ b/internal/local/testdata/20210101/nested/realm_config.json
@@ -2,6 +2,7 @@
     "config_version": 20210101,
     "name": "20210101-nested",
     "location": "US-VA",
+    "provider_region": "aws-us-east-1",
     "deployment_model": "GLOBAL",
     "allowed_request_origins": [
         "http://localhost:8080"

--- a/internal/local/testdata/20210101/remote/realm_config.json
+++ b/internal/local/testdata/20210101/remote/realm_config.json
@@ -3,6 +3,7 @@
     "app_id": "20210101-remote-abcde",
     "name": "20210101-remote",
     "location": "US-VA",
+    "provider_region": "aws-us-east-1",
     "deployment_model": "GLOBAL",
     "allowed_request_origins": [
         "http://localhost:8080"

--- a/internal/local/testdata/full_project/config.json
+++ b/internal/local/testdata/full_project/config.json
@@ -3,6 +3,7 @@
     "app_id": "full-abcde",
     "name": "full",
     "location": "US-VA",
+    "provider_region": "aws-us-east-1",
     "deployment_model": "GLOBAL",
     "security": {
         "allowed_request_origins": [


### PR DESCRIPTION
This PR adds the provider_region field to the app create and push flows. Commands that are changed:

App Create changes: 

- app create supports the provider-region flag. Location is automatically determined if provider-region is passed in but location is not
- 
- we support passing in a location flag without provider region to support users using the command as is. Stopping support might warrant a major version bump

App init changes:

- The provider-region flag is part of the output if the provider region is not the default value of `aws-us-east-1`

App Push Changes:

- App Location is replaced with Cloud Provider and App Region selects. The App Region will filter results based on the selected cloud provider

- Deployment model is moved to above where App Location was. If a user selects GLOBAL as their deployment model, we will not show azure regions because azure is not supported for global apps. This also means that we skip the Cloud Provider select if deployment model is GLOBAL (not sure if it is considered a breaking change if we change the order of the selects)