### PR TITLE
BAAS-23774: Add device-sync product type to realm-cli

### DIFF
--- a/internal/cloud/realm/app.go
+++ b/internal/cloud/realm/app.go
@@ -116,13 +116,14 @@ type AppFilter struct {
 }
 
 const (
-	productStandard = "standard"
-	productAtlas    = "atlas"
-	productDataAPI  = "data-api"
+	productStandard   = "standard"
+	productAtlas      = "atlas"
+	productDataAPI    = "data-api"
+	productDeviceSync = "device-sync"
 )
 
 var (
-	defaultProducts = []string{productStandard, productAtlas, productDataAPI}
+	defaultProducts = []string{productStandard, productAtlas, productDataAPI, productDeviceSync}
 )
 
 func (c *client) FindApps(filter AppFilter) ([]App, error) {


### PR DESCRIPTION
This PR adds `device-sync` to the list of default product types for push/pull support